### PR TITLE
Update mediastinger.md

### DIFF
--- a/docs/defaults/overlays/mediastinger.md
+++ b/docs/defaults/overlays/mediastinger.md
@@ -46,5 +46,5 @@ libraries:
     overlay_path:
       - pmm: mediastinger
         template_variables:
-          font_color: "#FFFFFF99"
+          back_color: "#FFFFFF99"
 ```


### PR DESCRIPTION
font_color is not possible with mediastinger overlay

## Description

font_color is not possible with mediastinger overlay so made it back_color

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Documentation change (non-code changes affecting only the wiki)
- [ ] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

- [ x] My code was submitted to the nightly branch of the repository.
