### PR TITLE
let conditional .not work on default vars

### DIFF
--- a/modules/meta.py
+++ b/modules/meta.py
@@ -400,16 +400,8 @@ class DataFile:
                                     con_var_value = var_key[:-7]
                                 elif var_key.endswith(".not"):
                                     var_name = var_key[:-4]
-                                    if var_name in variables:
-                                        con_var_value = variables[var_name]
-                                        if isinstance(var_value, list):
-                                            if con_var_value in var_value:
-                                                error_text = f'in {var_value}'
-                                        elif str(con_var_value) == str(var_value):
-                                            error_text = f'is "{var_value}"'
-                                    elif var_name in default:
-                                        # TODO: consolidate
-                                        con_var_value = default[var_name]
+                                    if var_name in variables or var_name in default:
+                                        con_var_value = variables[var_name] if var_name in variables else default[var_name]
                                         if isinstance(var_value, list):
                                             if con_var_value in var_value:
                                                 error_text = f'in {var_value}'

--- a/modules/meta.py
+++ b/modules/meta.py
@@ -399,8 +399,17 @@ class DataFile:
                                         error_text = "- exists"
                                     con_var_value = var_key[:-7]
                                 elif var_key.endswith(".not"):
-                                    if var_key[:-4] in variables:
-                                        con_var_value = variables[var_key[:-4]]
+                                    var_name = var_key[:-4]
+                                    if var_name in variables:
+                                        con_var_value = variables[var_name]
+                                        if isinstance(var_value, list):
+                                            if con_var_value in var_value:
+                                                error_text = f'in {var_value}'
+                                        elif str(con_var_value) == str(var_value):
+                                            error_text = f'is "{var_value}"'
+                                    elif var_name in default:
+                                        # TODO: consolidate
+                                        con_var_value = default[var_name]
                                         if isinstance(var_value, list):
                                             if con_var_value in var_value:
                                                 error_text = f'in {var_value}'


### PR DESCRIPTION
## Description

Instead of needing the variable value to be directly declared, it could be one of the default values.

My use-case is turning my `poster_url` from a default to a conditional, to cut down on lots of warnings like `no poster found at https://raw.githubusercontent.com/meisnate12/Plex-Meta-Manager-Images/master/<<poster_type>>/Love%20Hurts.jpg`

This lets me have a diff like this in my common template definition, that all my other templates build from:

```diff
  common: &common
     default: &defaults
       poster_name: <<mapping_name>>
-      poster_url: https://raw.githubusercontent.com/meisnate12/Plex-Meta-Manager-Images/master/<<poster_type>>/<<poster_name_encoded>>.jpg
+      poster_type: skip
     conditionals: &conditionals
+      poster_url:
+        conditions:
+          - poster_type.not: skip
+            value: https://raw.githubusercontent.com/meisnate12/Plex-Meta-Manager-Images/master/<<poster_type>>/<<poster_name_encoded>>.jpg
     url_poster: <<poster_url>>
```

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
