### PR TITLE
Consistent arr vars

### DIFF
--- a/docs/files/arr.md
+++ b/docs/files/arr.md
@@ -9,9 +9,11 @@ tags:
   - radarr_monitor_existing
   - radarr_ignore_cache
   - radarr_folder
+  - radarr_root_folder_path
   - radarr_monitor
   - radarr_availability
   - radarr_quality
+  - radarr_quality_profile
   - radarr_tag
   - radarr_search
   - item_radarr_tag
@@ -23,10 +25,14 @@ tags:
   - sonarr_monitor_existing
   - sonarr_ignore_cache
   - sonarr_folder
+  - sonarr_root_folder_path
   - sonarr_monitor
   - sonarr_quality
+  - sonarr_quality_profile
   - sonarr_language
+  - sonarr_language_profile
   - sonarr_series
+  - sonarr_series_type
   - sonarr_season
   - sonarr_tag
   - sonarr_search
@@ -48,10 +54,10 @@ All the following attributes can override the global/library [Radarr](../config/
 | `radarr_upgrade_existing` | **Description:** Override Radarr `upgrade_existing` attribute<br>**Values:** `true` or `false`                                                                                  |
 | `radarr_monitor_existing` | **Description:** Override Radarr `monitor_existing` attribute<br>**Values:** `true` or `false`                                                                                  |
 | `radarr_ignore_cache`     | **Description:** Override Radarr `ignore_cache` attribute<br>**Values:** `true` or `false`                                                                                      |
-| `radarr_folder`           | **Description:** Override Radarr `root_folder_path` attribute<br>**Values:** Folder Path                                                                                        |
+| `radarr_root_folder_path` | **Description:** Override Radarr `root_folder_path` attribute<br>**Values:** Folder Path                                                                                        |
 | `radarr_monitor`          | **Description:** Override Radarr `monitor` attribute<br>**Values:** `movie`, `collection`, or `none`                                                                            |
 | `radarr_availability`     | **Description:** Override Radarr `availability` attribute<br>**Values:** `announced`, `cinemas`, `released`, `db`                                                               |
-| `radarr_quality`          | **Description:** Override Radarr `quality_profile` attribute<br>**Values:** Radarr Quality Profile                                                                              |
+| `radarr_quality_profile`  | **Description:** Override Radarr `quality_profile` attribute<br>**Values:** Radarr Quality Profile                                                                              |
 | `radarr_tag`              | **Description:** Override Radarr `tag` attribute<br>**Values:** List :material-information-outline:{ data-tooltip data-tooltip-id="tippy-yaml-lists" } or comma-separated string of tags                                                                          |
 | `radarr_search`           | **Description:** Override Radarr `search` attribute<br>**Values:** `true` or `false`                                                                                            |
 | `item_radarr_tag`         | **Description:** Used to append a tag in Radarr for every movie found by the builders that's in Radarr<br>**Values:** List :material-information-outline:{ data-tooltip data-tooltip-id="tippy-yaml-lists" } or comma-separated string of tags                    |
@@ -69,12 +75,12 @@ All the following attributes can override the global/library [Sonarr](../config/
 | `sonarr_upgrade_existing` | **Description:** Override Sonarr `upgrade_existing` attribute<br>**Values:** `true` or `false`                                                                                   |
 | `sonarr_monitor_existing` | **Description:** Override Sonarr `monitor_existing` attribute<br>**Values:** `true` or `false`                                                                                   |
 | `sonarr_ignore_cache`     | **Description:** Override Sonarr `ignore_cache` attribute<br>**Values:** `true` or `false`                                                                                       |
-| `sonarr_folder`           | **Description:** Override Sonarr `root_folder_path` attribute<br>**Values:** Folder Path                                                                                         |
+| `sonarr_root_folder_path` | **Description:** Override Sonarr `root_folder_path` attribute<br>**Values:** Folder Path                                                                                         |
 | `sonarr_monitor`          | **Description:** Override Sonarr `monitor` attribute<br>**Values:** `all`, `future`, `missing`, `existing`, `pilot`, `first`, `latest`, `none`                                   |
-| `sonarr_quality`          | **Description:** Override Sonarr `quality_profile` attribute<br>**Values:** Sonarr Quality Profile                                                                               |
-| `sonarr_language`         | **Description:** Override Sonarr `language_profile` attribute<br>**Values:** Sonarr Language Profile                                                                             |
-| `sonarr_series`           | **Description:** Override Sonarr `series_type` attribute<br>**Values:** `standard`, `daily`, `anime`                                                                             |
-| `sonarr_season`           | **Description:** Override Sonarr `season_folder` attribute<br>**Values:** `true` or `false`                                                                                      |
+| `sonarr_quality_profile`  | **Description:** Override Sonarr `quality_profile` attribute<br>**Values:** Sonarr Quality Profile                                                                               |
+| `sonarr_language_profile` | **Description:** Override Sonarr `language_profile` attribute<br>**Values:** Sonarr Language Profile                                                                             |
+| `sonarr_series_type`      | **Description:** Override Sonarr `series_type` attribute<br>**Values:** `standard`, `daily`, `anime`                                                                             |
+| `sonarr_season_folder`    | **Description:** Override Sonarr `season_folder` attribute<br>**Values:** `true` or `false`                                                                                      |
 | `sonarr_tag`              | **Description:** Override Sonarr `tag` attribute<br>**Values:** List :material-information-outline:{ data-tooltip data-tooltip-id="tippy-yaml-lists" } or comma-separated string of tags                                                                           |
 | `sonarr_search`           | **Description:** Override Sonarr `search` attribute<br>**Values:** `true` or `false`                                                                                             |
 | `sonarr_cutoff_search`    | **Description:** Override Sonarr `cutoff_search` attribute<br>**Values:** `true` or `false`                                                                                      |
@@ -93,9 +99,9 @@ When `radarr_add_missing`/`sonarr_add_missing` are true the items missing from t
 
 ### Arr Add Existing
 
-When `radarr_add_existing`/`sonarr_add_existing` are true the items that exist in the collection/playlist will be added to Radarr/Sonarr. 
+When `radarr_add_existing`/`sonarr_add_existing` are true the items that exist in the collection/playlist will be added to Radarr/Sonarr.
 
-If your Radarr/Sonarr has different file system mappings from your Plex use `radarr_path`/`sonarr_path` along with `plex_path` from your 
+If your Radarr/Sonarr has different file system mappings from your Plex use `radarr_path`/`sonarr_path` along with `plex_path` from your
 [Radarr](../config/radarr.md)/[Sonarr](../config/sonarr.md) global config settings.
 
 ### Radarr Add Settings
@@ -106,7 +112,7 @@ When adding a movie in Radarr you get the screen below to set these options use 
 
 ### Sonarr Add Settings
 
-When adding a show in Sonarr you get the screen below to set these options use `sonarr_folder`, `sonarr_monitor`, `sonarr_quality`, `sonarr_language`, `sonarr_series`, 
+When adding a show in Sonarr you get the screen below to set these options use `sonarr_folder`, `sonarr_monitor`, `sonarr_quality`, `sonarr_language`, `sonarr_series`,
 `sonarr_season`, `sonarr_tag`, `sonarr_search`, and `sonarr_cutoff_search`.
 
 ![Sonarr Details](../assets/images/files/sonarr-settings.png)

--- a/modules/anilist.py
+++ b/modules/anilist.py
@@ -308,9 +308,9 @@ class AniList:
                 data = {"limit": data, "score.gt": 3, "sort_by": "score"}
             elif method not in builders:
                 raise Failed(f"AniList Error: Method {method} not supported")
-            message = f"Processing {method.replace('_', ' ').title().replace('Anilist', 'AniList')}:\n\tSort By {pretty_names[data['sort_by']]}"
+            message = f"Processing {method.replace('_', ' ').title().replace('Anilist', 'AniList')}:\n    Sort By {pretty_names[data['sort_by']]}"
             if data['limit'] > 0:
-                message += f"\n\tLimit to {data['limit']} Anime"
+                message += f"\n    Limit to {data['limit']} Anime"
             for key, value in data.items():
                 if key not in ["limit", "sort_by"]:
                     if "." in key:
@@ -319,7 +319,7 @@ class AniList:
                     else:
                         attr = key
                         mod = ""
-                    message += f"\n\t{attr.replace('_', ' ').title()} {util.mod_displays[mod]} {value}"
+                    message += f"\n    {attr.replace('_', ' ').title()} {util.mod_displays[mod]} {value}"
             logger.info(message)
             anilist_ids = self._search(**data)
         logger.debug("")

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -978,7 +978,7 @@ class Operations:
                                 f"{total_update_items} {item_type_name}{'' if out_type or tag_type else f' updated to {display_value}'}")
                     for batch_num, batch_items in enumerate(_item_batches(update_items, batch_size), 1):
                         if num_batches > 1:
-                            logger.info(f"\tProcessing Batch {batch_num}/{num_batches} {len(batch_items)} {item_type_name}")
+                            logger.info(f"    Processing Batch {batch_num}/{num_batches} {len(batch_items)} {item_type_name}")
                         self.library.Plex.batchMultiEdits(batch_items)
                         if display_attr == "addedAt":
                             update_date = datetime.strptime(update_value, "%Y-%m-%d")

--- a/modules/util.py
+++ b/modules/util.py
@@ -441,7 +441,7 @@ def check_collection_mode(collection_mode):
     if collection_mode and str(collection_mode).lower() in collection_mode_options:
         return collection_mode_options[str(collection_mode).lower()]
     else:
-        raise Failed(f"Config Error: {collection_mode} collection_mode invalid\n\tdefault (Library default)\n\thide (Hide Collection)\n\thide_items (Hide Items in this Collection)\n\tshow_items (Show this Collection and its Items)")
+        raise Failed(f"Config Error: {collection_mode} collection_mode invalid\n    default (Library default)\n    hide (Hide Collection)\n    hide_items (Hide Items in this Collection)\n    show_items (Show this Collection and its Items)")
 
 def glob_filter(filter_in):
     filter_in = filter_in.translate({ord("["): "[[]", ord("]"): "[]]"}) if "[" in filter_in else filter_in
@@ -531,7 +531,7 @@ def schedule_check(attribute, data, current_time, run_hour, is_all=False):
                 logger.error(f"Schedule Error: failed to parse {attribute}: {schedule}")
                 continue
             try:
-                schedule_str += f"\nScheduled to meet all of these:\n\t"
+                schedule_str += f"\nScheduled to meet all of these:\n    "
                 schedule_str += schedule_check(attribute, match.group(1), current_time, run_hour, is_all=True)
                 all_check += 1
             except NotScheduled as e:
@@ -655,7 +655,7 @@ def schedule_check(attribute, data, current_time, run_hour, is_all=False):
         else:
             logger.error(f"Schedule Error: {display}")
     if is_all:
-        schedule_str.replace("\n", "\n\t")
+        schedule_str.replace("\n", "\n    ")
     if (all_check == 0 and not is_all) or (is_all and schedules_run != all_check):
         if non_existing:
             raise NonExisting(schedule_str)


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

This augments the Radarr/Sonarr collection-level variables so they are named the same as the global versions for clarity.

TODO: the default templates; I am unfamiliar with how those work and whether both old and new variables can be active.

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes [except default template variable stuff]
- [ ] No

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Ye
-->
- [ ] Yes
- [X] No[t yet]
