### PR TITLE
Handle operations in batches

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ Updated requests requirement to 2.32.5
 
 # New Features
 Adds `|` as a preferred delimiter for run times.
+Library operations now happen in batches of items (size=100) instead of over the entire library all at one.
 
 # Docs
 Fixed an issue where the home page logo and shield images appeared as raw text

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ Updated requests requirement to 2.32.5
 
 # New Features
 Adds `|` as a preferred delimiter for run times.
-Library operations now happen in batches of items (size=100) instead of over the entire library all at one.
+Adds an optional setting `plex_bulk_edit_batch_size` in operations to control how many items are processed in a single batch.
 
 # Docs
 Fixed an issue where the home page logo and shield images appeared as raw text

--- a/docs/config/operations.md
+++ b/docs/config/operations.md
@@ -946,3 +946,30 @@ Several of these operations perform **mass** updates; these are just that, **mas
             metadata_files:
               file: config/Movie_Backup.yml  # apply this Metadata File to the library
         ```
+
+###### Plex Bulk Edits Batch Size
+
+??? blank "`plex_bulk_edit_batch_size` - Breaks up processing of operations into chunks of this many items.<a class="headerlink" href="#plex-bulk-edit-batch-size" title="Permanent link">¶</a>"
+
+    <div id="plex-bulk-edit-batch-size" />Setting this file tells Kometa to break up operations that require inspecting/modifying the entire library into chunks. Setting this can be particularly helpful for large libraries.
+
+    If no value is set, the entire library is processed in one batch.
+
+    For example, if your Movies library has 1000 items, by default all of them will be processed at once.
+    If `plex_bulk_edit_batch_size=100`, then 100 items will be processed at once.
+
+    <hr style="margin: 0px;">
+
+    **Attribute:** `plex_bulk_edit_batch_size`
+
+    **Accepted Values:** None, or any number.
+
+    ???+ example "Example"
+
+        ```yaml
+        libraries:
+          Movies:
+            operations:
+                plex_bulk_edit_batch_size: 1000
+                mass_audience_rating_update: imdb
+        ```

--- a/modules/config.py
+++ b/modules/config.py
@@ -149,6 +149,7 @@ library_operations = {
     "mass_originally_available_update": mass_available_options, "mass_added_at_update": mass_available_options,
     "mass_collection_mode": "mass_collection_mode", "mass_poster_update": "dict", "mass_background_update": "dict",
     "metadata_backup": "dict", "delete_collections": "dict", "genre_mapper": "dict", "content_rating_mapper": "dict",
+    "plex_bulk_edit_batch_size": "int",
 }
 
 class ConfigFile:

--- a/modules/library.py
+++ b/modules/library.py
@@ -126,6 +126,7 @@ class Library(ABC):
         self.optimize = params["plex"]["optimize"] # TODO: Here or just in Plex?
         self.stats = {"created": 0, "modified": 0, "deleted": 0, "added": 0, "unchanged": 0, "removed": 0, "radarr": 0, "sonarr": 0, "names": []}
         self.status = {}
+        self.plex_bulk_edit_batch_size = params["plex_bulk_edit_batch_size"]
 
         self.items_library_operation = True if self.assets_for_all or self.mass_genre_update or self.remove_title_parentheses \
                                                or self.mass_audience_rating_update or self.mass_critic_rating_update or self.mass_user_rating_update \

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -120,15 +120,13 @@ class Operations:
             logger.info(f"{len(tracks)} Tracks Processed; {num_edited} Blank Track Titles Updated")
 
         if self.library.items_library_operation:
-            items = self.library.get_all()
-            total_items = len(items)
-            
             if self.library.assets_for_all and not self.library.asset_directory:
                 logger.error("Asset Error: No Asset Directory for Assets For All")
 
             # Get an iterable of all items and create the batch generator
-            all_items_iterable = self.library.get_all()
-            batch_generator = self._get_items_in_batches(all_items_iterable, batch_size)
+            all_items = self.library.get_all()
+            total_items = len(all_items)
+            batch_generator = self._get_items_in_batches(all_items, batch_size)
             
             num_batches = (total_items + batch_size - 1) // batch_size if isinstance(total_items, int) else "Unknown"
             processed_items = 0
@@ -155,7 +153,7 @@ class Operations:
                 ep_lock_edits = {}
                 ep_unlock_edits = {}
 
-                for i, item in enumerate(items, 1):
+                for item in items:
                     processed_items += 1
                     logger.info("")
                     logger.info(f"({processed_items}/{total_items}) {item.title}")

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -22,10 +22,24 @@ name_display = {
     "contentRating": "Content Rating"
 }
 
+# How many library items to process at a time.
+batch_size = 100
+
 class Operations:
     def __init__(self, config, library):
         self.config = config
         self.library = library
+
+    def _get_items_in_batches(self, items_iterable, batch_size=1000):
+        """Yield successive n-sized chunks from an iterable."""
+        batch = []
+        for item in items_iterable:
+            batch.append(item)
+            if len(batch) == batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch
 
     def run_operations(self):
         operation_start = datetime.now()
@@ -107,995 +121,1011 @@ class Operations:
 
         if self.library.items_library_operation:
             items = self.library.get_all()
-            radarr_adds = []
-            sonarr_adds = []
-            label_edits = {"add": {}, "remove": {}}
-            rating_edits = {"audienceRating": {}, "rating": {}, "userRating": {}}
-            genre_edits = {"add": {}, "remove": {}}
-            content_edits = {}
-            studio_edits = {}
-            date_edits = {"originallyAvailableAt": {}, "addedAt": {}}
-            remove_edits = {}
-            reset_edits = {}
-            lock_edits = {}
-            unlock_edits = {}
-            ep_rating_edits = {"audienceRating": {}, "rating": {}, "userRating": {}}
-            ep_remove_edits = {}
-            ep_reset_edits = {}
-            ep_lock_edits = {}
-            ep_unlock_edits = {}
-
+            total_items = len(items)
+            
             if self.library.assets_for_all and not self.library.asset_directory:
                 logger.error("Asset Error: No Asset Directory for Assets For All")
 
-            total_items = len(items)
-            for i, item in enumerate(items, 1):
-                logger.info("")
-                logger.info(f"({i}/{total_items}) {item.title}")
-                try:
-                    item = self.library.reload(item)
-                except Failed as e:
-                    logger.error(e)
-                    continue
-                current_labels = [la.tag for la in self.library.item_labels(item)] if self.library.label_operations else []
+            # Get an iterable of all items and create the batch generator
+            all_items_iterable = self.library.get_all()
+            batch_generator = self._get_items_in_batches(all_items_iterable, batch_size)
+            
+            num_batches = (total_items + batch_size - 1) // batch_size if isinstance(total_items, int) else "Unknown"
+            processed_items = 0
 
-                if self.library.assets_for_all and self.library.asset_directory:
-                    self.library.find_and_upload_assets(item, current_labels)
+            # New batch processing loop using the generator
+            for batch_num, items in enumerate(batch_generator, 1):
+                logger.separator(f"Processing Batch {batch_num}/{num_batches}")
 
-                locked_fields = [f.name for f in item.fields if f.locked]
+                radarr_adds = []
+                sonarr_adds = []
+                label_edits = {"add": {}, "remove": {}}
+                rating_edits = {"audienceRating": {}, "rating": {}, "userRating": {}}
+                genre_edits = {"add": {}, "remove": {}}
+                content_edits = {}
+                studio_edits = {}
+                date_edits = {"originallyAvailableAt": {}, "addedAt": {}}
+                remove_edits = {}
+                reset_edits = {}
+                lock_edits = {}
+                unlock_edits = {}
+                ep_rating_edits = {"audienceRating": {}, "rating": {}, "userRating": {}}
+                ep_remove_edits = {}
+                ep_reset_edits = {}
+                ep_lock_edits = {}
+                ep_unlock_edits = {}
 
-                tmdb_id, tvdb_id, imdb_id = self.library.get_ids(item)
-
-                item_edits = ""
-
-                if self.library.remove_title_parentheses:
-                    if not any([f.name == "title" and f.locked for f in item.fields]) and item.title.endswith(")"):
-                        new_title = re.sub(" \\(\\w+\\)$", "", item.title)
-                        item.editTitle(new_title)
-                        item_edits += f"Updated Title: {item.title[:25]:<25} | {new_title}"
-
-                if self.library.mass_imdb_parental_labels:
+                for i, item in enumerate(items, 1):
+                    processed_items += 1
+                    logger.info("")
+                    logger.info(f"({processed_items}/{total_items}) {item.title}")
                     try:
-                        if self.library.mass_imdb_parental_labels == "remove":
-                            parental_labels = []
-                        else:
-                            parental_guide = self.config.IMDb.parental_guide(imdb_id)
-                            parental_labels = [f"{k}:{v}" for k, v in parental_guide.items() if v and v not in util.parental_levels[self.library.mass_imdb_parental_labels]]
-                        add_labels = [la for la in parental_labels if la not in current_labels]
-                        remove_labels = [la for la in current_labels if la in util.parental_labels and la not in parental_labels]
-                        for label_list, edit_type in [(add_labels, "add"), (remove_labels, "remove")]:
-                            if label_list:
-                                for label in label_list:
-                                    if label not in label_edits[edit_type]:
-                                        label_edits[edit_type][label] = []
-                                    label_edits[edit_type][label].append(item.ratingKey)
-                                item_edits += f"{edit_type.capitalize()} IMDb Parental Labels (Batched) | {', '.join(label_list)}"
-                    except Failed:
-                        pass
-                if item.locations:
-                    path = os.path.dirname(str(item.locations[0])) if self.library.is_movie else str(item.locations[0])
-                    if self.library.Radarr and self.library.radarr_add_all_existing and tmdb_id:
-                        path = path.replace(self.library.Radarr.plex_path, self.library.Radarr.radarr_path)
-                        path = path[:-1] if path.endswith(('/', '\\')) else path
-                        radarr_adds.append((tmdb_id, path))
-                    if self.library.Sonarr and self.library.sonarr_add_all_existing and tvdb_id:
-                        path = path.replace(self.library.Sonarr.plex_path, self.library.Sonarr.sonarr_path)
-                        path = path[:-1] if path.endswith(("/", "\\")) else path
-                        sonarr_adds.append((tvdb_id, path))
+                        item = self.library.reload(item)
+                    except Failed as e:
+                        logger.error(e)
+                        continue
+                    current_labels = [la.tag for la in self.library.item_labels(item)] if self.library.label_operations else []
 
-                _trakt_ratings = None
-                def trakt_ratings():
-                    nonlocal _trakt_ratings
-                    if _trakt_ratings is None:
-                        _trakt_ratings = self.config.Trakt.user_ratings(self.library.is_movie)
-                    if not _trakt_ratings:
-                        raise Failed
-                    return _trakt_ratings
+                    if self.library.assets_for_all and self.library.asset_directory:
+                        self.library.find_and_upload_assets(item, current_labels)
 
-                _tmdb_obj = None
-                def tmdb_obj():
-                    nonlocal _tmdb_obj
-                    if _tmdb_obj is None:
-                        _tmdb_obj = False
+                    locked_fields = [f.name for f in item.fields if f.locked]
+
+                    tmdb_id, tvdb_id, imdb_id = self.library.get_ids(item)
+
+                    item_edits = ""
+
+                    if self.library.remove_title_parentheses:
+                        if not any([f.name == "title" and f.locked for f in item.fields]) and item.title.endswith(")"):
+                            new_title = re.sub(" \\(\\w+\\)$", "", item.title)
+                            item.editTitle(new_title)
+                            item_edits += f"Updated Title: {item.title[:25]:<25} | {new_title}"
+
+                    if self.library.mass_imdb_parental_labels:
                         try:
-                            _item = self.config.TMDb.get_item(item, tmdb_id, tvdb_id, imdb_id, is_movie=self.library.is_movie)
-                            if _item:
-                                _tmdb_obj = _item
-                        except Failed as err:
-                            logger.error(str(err))
-                    if not _tmdb_obj:
-                        raise Failed
-                    return _tmdb_obj
-
-                _omdb_obj = None
-                def omdb_obj():
-                    nonlocal _omdb_obj
-                    if _omdb_obj is None:
-                        _omdb_obj = False
-                        if self.config.OMDb.limit is not False:
-                            logger.error("Daily OMDb Limit Reached")
-                        elif not imdb_id:
-                            logger.info(f"No IMDb ID for Guid: {item.guid}")
-                        else:
-                            try:
-                                _omdb_obj = self.config.OMDb.get_omdb(imdb_id)
-                            except Failed as err:
-                                logger.error(str(err))
-                            except Exception:
-                                logger.error(f"IMDb ID: {imdb_id}")
-                                raise
-                    if not _omdb_obj:
-                        raise Failed
-                    return _omdb_obj
-
-                _tvdb_obj = None
-                def tvdb_obj():
-                    nonlocal _tvdb_obj
-                    if _tvdb_obj is None:
-                        _tvdb_obj = False
-                        if tvdb_id:
-                            try:
-                                _tvdb_obj = self.config.TVDb.get_tvdb_obj(tvdb_id, is_movie=self.library.is_movie)
-                            except Failed as err:
-                                logger.error(str(err))
-                        else:
-                            logger.info(f"No TVDb ID for Guid: {item.guid}")
-                    if not _tvdb_obj:
-                        raise Failed
-                    return _tvdb_obj
-
-                _mdb_obj = None
-                def mdb_obj():
-                    nonlocal _mdb_obj
-                    if _mdb_obj is None:
-                        _mdb_obj = False
-                        if self.config.MDBList.limit is False:
-                            if self.library.is_show and tvdb_id:
-                                try:
-                                    _mdb_obj = self.config.MDBList.get_series(tvdb_id)
-                                except LimitReached as err:
-                                    logger.debug(err)
-                                except Failed as err:
-                                    logger.error(str(err))
-                                except Exception:
-                                    logger.trace(f"TVDb ID: {tvdb_id}")
-                                    raise
-                            if self.library.is_movie and tmdb_id:
-                                try:
-                                    _mdb_obj = self.config.MDBList.get_movie(tmdb_id)
-                                except LimitReached as err:
-                                    logger.debug(err)
-                                except Failed as err:
-                                    logger.error(str(err))
-                                except Exception:
-                                    logger.trace(f"TMDb ID: {tmdb_id}")
-                                    raise
-                            if imdb_id and not _mdb_obj:
-                                try:
-                                    _mdb_obj = self.config.MDBList.get_imdb(imdb_id)
-                                except LimitReached as err:
-                                    logger.debug(err)
-                                except Failed as err:
-                                    logger.error(str(err))
-                                except Exception:
-                                    logger.trace(f"IMDb ID: {imdb_id}")
-                                    raise
-                            if not _mdb_obj:
-                                logger.warning(f"No MdbItem for {item.title} (Guid: {item.guid})")
-                    if not _mdb_obj:
-                        raise Failed
-                    return _mdb_obj
-
-                anidb_id = None
-                def get_anidb_id():
-                    temp_id = self.config.Convert.ids_to_anidb(self.library, item.ratingKey, tvdb_id, imdb_id, tmdb_id)
-                    return temp_id if temp_id else False
-
-                _anidb_obj = None
-                def anidb_obj():
-                    nonlocal anidb_id, _anidb_obj
-                    if _anidb_obj is None:
-                        _anidb_obj = False
-                        if anidb_id is None:
-                            anidb_id = get_anidb_id()
-                        if anidb_id:
-                            try:
-                                _anidb_obj = self.config.AniDB.get_anime(anidb_id)
-                            except Failed as err:
-                                logger.error(str(err))
-                        else:
-                            logger.warning(f"No AniDB ID for Guid: {item.guid}")
-                    if not _anidb_obj:
-                        raise Failed
-                    return _anidb_obj
-
-                _mal_obj = None
-                def mal_obj():
-                    nonlocal anidb_id, _mal_obj
-                    if _mal_obj is None:
-                        _mal_obj = False
-                        if anidb_id is None:
-                            anidb_id = get_anidb_id()
-                        mal_id = None
-                        if item.ratingKey in self.library.reverse_mal:
-                            mal_id = self.library.reverse_mal[item.ratingKey]
-                        elif not anidb_id:
-                            logger.warning(f"Convert Warning: No AniDB ID to Convert to MyAnimeList ID for Guid: {item.guid}")
-                        else:
-                            try:
-                                mal_id = self.config.Convert.anidb_to_mal(anidb_id)
-                            except Failed as err:
-                                logger.warning(f"{err} of Guid: {item.guid}")
-                        if mal_id:
-                            try:
-                                _mal_obj = self.config.MyAnimeList.get_anime(mal_id)
-                            except Failed as err:
-                                logger.error(str(err))
-                    if not _mal_obj:
-                        raise Failed
-                    return _mal_obj
-
-                for attribute, item_attr in [
-                    (self.library.mass_audience_rating_update, "audienceRating"),
-                    (self.library.mass_critic_rating_update, "rating"),
-                    (self.library.mass_user_rating_update, "userRating")
-                ]:
-                    if attribute:
-                        current = getattr(item, item_attr)
-                        for option in attribute:
-                            if option in ["lock", "remove"]:
-                                if option == "remove" and current:
-                                    if item_attr not in remove_edits:
-                                        remove_edits[item_attr] = []
-                                    remove_edits[item_attr].append(item.ratingKey)
-                                    item_edits += f"Remove {name_display[item_attr]} (Batched)"
-                                elif item_attr not in locked_fields:
-                                    if item_attr not in lock_edits:
-                                        lock_edits[item_attr] = []
-                                    lock_edits[item_attr].append(item.ratingKey)
-                                    item_edits += f"Lock {name_display[item_attr]} (Batched)"
-                                break
-                            elif option in ["unlock", "reset"]:
-                                if option == "reset" and current:
-                                    if item_attr not in reset_edits:
-                                        reset_edits[item_attr] = []
-                                    reset_edits[item_attr].append(item.ratingKey)
-                                    item_edits += f"Reset {name_display[item_attr]} (Batched)"
-                                elif item_attr in locked_fields:
-                                    if item_attr not in unlock_edits:
-                                        unlock_edits[item_attr] = []
-                                    unlock_edits[item_attr].append(item.ratingKey)
-                                    item_edits += f"Unlock {name_display[item_attr]} (Batched)"
-                                break
+                            if self.library.mass_imdb_parental_labels == "remove":
+                                parental_labels = []
                             else:
-                                try:
-                                    if option == "tmdb":
-                                        found_rating = tmdb_obj().vote_average # noqa
-                                    elif option == "imdb":
-                                        found_rating = self.config.IMDb.get_rating(imdb_id)
-                                    elif option == "trakt":
-                                        found_rating = self.config.Trakt.get_rating(imdb_id, self.library.is_movie)
-                                    elif option == "trakt_user":
-                                        _ratings = trakt_ratings()
-                                        _id = tmdb_id if self.library.is_movie else tvdb_id
-                                        if _id in _ratings:
-                                            found_rating = _ratings[_id]
-                                        else:
-                                            raise Failed
-                                    elif str(option).startswith("plex"):
-                                        ratings = self.library.get_ratings(item)
-                                        try:
-                                            found_rating = ratings[option] # noqa
-                                        except KeyError:
-                                            found_rating = None
-                                    elif str(option).startswith("omdb"):
-                                        omdb_item = omdb_obj()
-                                        if option == "omdb_metascore":
-                                            found_rating = omdb_item.metacritic_rating / 10 if omdb_item.metacritic_rating else None # noqa
-                                        elif option == "omdb_tomatoes":
-                                            found_rating = omdb_item.rotten_tomatoes / 10 if omdb_item.rotten_tomatoes else None # noqa
-                                        else:
-                                            found_rating = omdb_item.imdb_rating # noqa
-                                    elif str(option).startswith("mdb"):
-                                        mdb_item = mdb_obj()
-                                        if option == "mdb_average":
-                                            found_rating = mdb_item.average / 10 if mdb_item.average else None # noqa
-                                        elif option == "mdb_imdb":
-                                            found_rating = mdb_item.imdb_rating if mdb_item.imdb_rating else None # noqa
-                                        elif option == "mdb_metacritic":
-                                            found_rating = mdb_item.metacritic_rating / 10 if mdb_item.metacritic_rating else None # noqa
-                                        elif option == "mdb_metacriticuser":
-                                            found_rating = mdb_item.metacriticuser_rating if mdb_item.metacriticuser_rating else None # noqa
-                                        elif option == "mdb_trakt":
-                                            found_rating = mdb_item.trakt_rating / 10 if mdb_item.trakt_rating else None # noqa
-                                        elif option == "mdb_tomatoes":
-                                            found_rating = mdb_item.tomatoes_rating / 10 if mdb_item.tomatoes_rating else None # noqa
-                                        elif option == "mdb_tomatoesaudience":
-                                            found_rating = mdb_item.tomatoesaudience_rating / 10 if mdb_item.tomatoesaudience_rating else None # noqa
-                                        elif option == "mdb_tmdb":
-                                            found_rating = mdb_item.tmdb_rating / 10 if mdb_item.tmdb_rating else None # noqa
-                                        elif option == "mdb_letterboxd":
-                                            found_rating = mdb_item.letterboxd_rating * 2 if mdb_item.letterboxd_rating else None # noqa
-                                        elif option == "mdb_myanimelist":
-                                            found_rating = mdb_item.myanimelist_rating if mdb_item.myanimelist_rating else None # noqa
-                                        else:
-                                            found_rating = mdb_item.score / 10 if mdb_item.score else None # noqa
-                                    elif option == "anidb_rating":
-                                        found_rating = anidb_obj().rating # noqa
-                                    elif option == "anidb_average":
-                                        found_rating = anidb_obj().average # noqa
-                                    elif option == "anidb_score":
-                                        found_rating = anidb_obj().score # noqa
-                                    elif option == "mal":
-                                        found_rating = mal_obj().score # noqa
-                                    else:
-                                        found_rating = option
-                                    if not found_rating:
-                                        logger.info(f"No {option} {name_display[item_attr]} Found")
-                                        raise Failed
-                                    found_rating = f"{float(found_rating):.1f}"
-                                    if str(current) != found_rating:
-                                        if found_rating not in rating_edits[item_attr]:
-                                            rating_edits[item_attr][found_rating] = []
-                                        rating_edits[item_attr][found_rating].append(item.ratingKey)
-                                        item_edits += f"Update {name_display[item_attr]} (Batched) | {found_rating}"
-                                    break
-                                except Failed:
-                                    continue
-
-                if self.library.mass_genre_update or self.library.genre_mapper:
-                    new_genres = []
-                    extra_option = None
-                    if self.library.mass_genre_update:
-                        for option in self.library.mass_genre_update:
-                            if option in ["lock", "unlock", "remove", "reset"]:
-                                extra_option = option
-                                break
-                            try:
-                                if option == "tmdb":
-                                    new_genres = tmdb_obj().genres # noqa
-                                elif option == "imdb":
-                                    new_genres = self.config.IMDb.get_genres(imdb_id)
-                                elif option == "omdb":
-                                    new_genres = omdb_obj().genres # noqa
-                                elif option == "tvdb":
-                                    new_genres = tvdb_obj().genres # noqa
-                                elif str(option) in anidb.weights:
-                                    new_genres = [str(t).title() for t, w in anidb_obj().tags.items() if w >= anidb.weights[str(option)]] # noqa
-                                elif option == "mal":
-                                    new_genres = mal_obj().genres # noqa
-                                else:
-                                    new_genres = option
-                                if not new_genres:
-                                    logger.info(f"No {option} Genres Found")
-                                    raise Failed
-                                break
-                            except Failed:
-                                continue
-
-                    item_genres = [g.tag for g in item.genres]
-                    if not new_genres and extra_option not in ["remove", "reset"]:
-                        new_genres = item_genres
-                    if self.library.genre_mapper:
-                        mapped_genres = []
-                        for genre in new_genres:
-                            if genre in self.library.genre_mapper:
-                                if self.library.genre_mapper[genre]:
-                                    mapped_genres.append(self.library.genre_mapper[genre])
-                            else:
-                                mapped_genres.append(genre)
-                        new_genres = mapped_genres
-                    _add = list(set(new_genres) - set(item_genres))
-                    _remove = list(set(item_genres) - set(new_genres))
-                    for genre_list, edit_type in [(_add, "add"), (_remove, "remove")]:
-                        if genre_list:
-                            for g in genre_list:
-                                if g not in genre_edits[edit_type]:
-                                    genre_edits[edit_type][g] = []
-                                genre_edits[edit_type][g].append(item.ratingKey)
-                            item_edits += f"{edit_type.capitalize()} Genres (Batched) | {', '.join(genre_list)}"
-                    if extra_option in ["unlock", "reset"] and ("genre" in locked_fields or _add or _remove):
-                        if "genre" not in unlock_edits:
-                            unlock_edits["genre"] = []
-                        unlock_edits["genre"].append(item.ratingKey)
-                        item_edits += "\nUnlock Genre (Batched)"
-                    elif extra_option in ["lock", "remove"] and "genre" not in locked_fields and not _add and not _remove:
-                        if "genre" not in lock_edits:
-                            lock_edits["genre"] = []
-                        lock_edits["genre"].append(item.ratingKey)
-                        item_edits += "\nLock Genre (Batched)"
-
-                if self.library.mass_content_rating_update or self.library.content_rating_mapper:
-                    new_rating = None
-                    extra_option = None
-                    if self.library.mass_content_rating_update:
-                        for option in self.library.mass_content_rating_update:
-                            if option in ["lock", "unlock", "remove", "reset"]:
-                                extra_option = option
-                                break
-                            try:
-                                if option == "omdb":
-                                    new_rating = omdb_obj().content_rating # noqa
-                                elif option == "mdb":
-                                    _rating = mdb_obj().content_rating # noqa
-                                    new_rating = _rating if _rating else None
-                                elif str(option).startswith("mdb_commonsense"):
-                                    _rating = mdb_obj().commonsense # noqa
-                                    if not _rating:
-                                        new_rating = None
-                                    elif option == "mdb_commonsense0":
-                                        new_rating = str(_rating).rjust(2, "0")
-                                    else:
-                                        new_rating = _rating
-                                elif str(option).startswith("mdb_age_rating"):
-                                    _rating = mdb_obj().age_rating # noqa
-                                    if not _rating:
-                                        new_rating = None
-                                    elif option == "mdb_age_rating0":
-                                        new_rating = str(_rating).rjust(2, "0")
-                                    else:
-                                        new_rating = _rating
-                                elif option == "mal":
-                                    new_rating = mal_obj().rating # noqa
-                                else:
-                                    new_rating = option
-                                if new_rating is None:
-                                    logger.info(f"No {option} Content Rating Found")
-                                    raise Failed
-                                else:
-                                    new_rating = str(new_rating)
-                                    break
-                            except Failed:
-                                continue
-
-                    is_none = False
-                    do_lock = False
-                    do_unlock = False
-                    current_rating = item.contentRating
-                    if not new_rating:
-                        new_rating = current_rating
-                    if self.library.content_rating_mapper:
-                        if new_rating in self.library.content_rating_mapper:
-                            new_rating = self.library.content_rating_mapper[new_rating]
-                            if not new_rating:
-                                is_none = True
-                    if extra_option == "reset":
-                        if current_rating:
-                            if "contentRating" not in reset_edits:
-                                reset_edits["contentRating"] = []
-                            reset_edits["contentRating"].append(item.ratingKey)
-                            item_edits += "\nReset Content Rating (Batched)"
-                        elif "contentRating" in locked_fields:
-                            do_unlock = True
-                    elif extra_option == "remove" or is_none:
-                        if current_rating:
-                            if "contentRating" not in remove_edits:
-                                remove_edits["contentRating"] = []
-                            remove_edits["contentRating"].append(item.ratingKey)
-                            item_edits += "\nRemove Content Rating (Batched)"
-                        elif "contentRating" not in locked_fields:
-                            do_lock = True
-                    elif new_rating and new_rating != current_rating:
-                        if new_rating not in content_edits:
-                            content_edits[new_rating] = []
-                        content_edits[new_rating].append(item.ratingKey)
-                        item_edits += f"Update Content Rating (Batched) | {new_rating}"
-                        do_lock = False
-
-                    if extra_option == "lock" or do_lock:
-                        if "contentRating" not in lock_edits:
-                            lock_edits["contentRating"] = []
-                        lock_edits["contentRating"].append(item.ratingKey)
-                        item_edits += "\nLock Content Rating (Batched)"
-                    elif extra_option == "unlock" or do_unlock:
-                        if "contentRating" not in unlock_edits:
-                            unlock_edits["contentRating"] = []
-                        unlock_edits["contentRating"].append(item.ratingKey)
-                        item_edits += "\nUnlock Content Rating (Batched)"
-
-                if self.library.mass_original_title_update:
-                    current_original = item.originalTitle
-                    for option in self.library.mass_original_title_update:
-                        if option in ["lock", "remove"]:
-                            if option == "remove" and current_original:
-                                if "originalTitle" not in remove_edits:
-                                    remove_edits["originalTitle"] = []
-                                remove_edits["originalTitle"].append(item.ratingKey)
-                                item_edits += "\nRemove Original Title (Batched)"
-                            elif "originalTitle" not in locked_fields:
-                                if "originalTitle" not in lock_edits:
-                                    lock_edits["originalTitle"] = []
-                                lock_edits["originalTitle"].append(item.ratingKey)
-                                item_edits += "\nLock Original Title (Batched)"
-                            break
-                        elif option in ["unlock", "reset"]:
-                            if option == "reset" and current_original:
-                                if "originalTitle" not in reset_edits:
-                                    reset_edits["originalTitle"] = []
-                                reset_edits["originalTitle"].append(item.ratingKey)
-                                item_edits += "\nReset Original Title (Batched)"
-                            elif "originalTitle" in locked_fields:
-                                if "originalTitle" not in unlock_edits:
-                                    unlock_edits["originalTitle"] = []
-                                unlock_edits["originalTitle"].append(item.ratingKey)
-                                item_edits += "\nUnlock Original Title (Batched)"
-                            break
-                        else:
-                            try:
-                                if option == "anidb":
-                                    new_original_title = anidb_obj().main_title # noqa
-                                elif option == "anidb_official":
-                                    new_original_title = anidb_obj().official_title # noqa
-                                elif option == "mal":
-                                    new_original_title = mal_obj().title # noqa
-                                elif option == "mal_english":
-                                    new_original_title = mal_obj().title_english # noqa
-                                elif option == "mal_japanese":
-                                    new_original_title = mal_obj().title_japanese # noqa
-                                else:
-                                    new_original_title = option
-                                if not new_original_title:
-                                    logger.info(f"No {option} Original Title Found")
-                                    raise Failed
-                                if str(current_original) != str(new_original_title):
-                                    item.editOriginalTitle(new_original_title)
-                                    item_edits += f"Updated Original Title | {new_original_title}"
-                                break
-                            except Failed:
-                                continue
-
-                if self.library.mass_studio_update:
-                    current_studio = item.studio
-                    for option in self.library.mass_studio_update:
-                        if option in ["lock", "remove"]:
-                            if option == "remove" and current_studio:
-                                if "studio" not in remove_edits:
-                                    remove_edits["studio"] = []
-                                remove_edits["studio"].append(item.ratingKey)
-                                item_edits += "\nRemove Studio (Batched)"
-                            elif "studio" not in locked_fields:
-                                if "studio" not in lock_edits:
-                                    lock_edits["studio"] = []
-                                lock_edits["studio"].append(item.ratingKey)
-                                item_edits += "\nLock Studio (Batched)"
-                            break
-                        elif option in ["unlock", "reset"]:
-                            if option == "reset" and current_studio:
-                                if "studio" not in reset_edits:
-                                    reset_edits["studio"] = []
-                                reset_edits["studio"].append(item.ratingKey)
-                                item_edits += "\nReset Studio (Batched)"
-                            elif "studio" in locked_fields:
-                                if "studio" not in unlock_edits:
-                                    unlock_edits["studio"] = []
-                                unlock_edits["studio"].append(item.ratingKey)
-                                item_edits += "\nUnlock Studio (Batched)"
-                            break
-                        else:
-                            try:
-                                if option == "tmdb":
-                                    new_studio = tmdb_obj().studio # noqa
-                                elif option == "anidb":
-                                    new_studio = anidb_obj().studio # noqa
-                                elif option == "mal":
-                                    new_studio = mal_obj().studio # noqa
-                                else:
-                                    new_studio = option
-                                if not new_studio:
-                                    logger.info(f"No {option} Studio Found")
-                                    raise Failed
-                                if str(current_studio) != str(new_studio):
-                                    if new_studio not in studio_edits:
-                                        studio_edits[new_studio] = []
-                                    studio_edits[new_studio].append(item.ratingKey)
-                                    item_edits += f"Update Studio (Batched) | {new_studio}"
-                                break
-                            except Failed:
-                                continue
-
-                for attribute, item_attr in [
-                    (self.library.mass_originally_available_update, "originallyAvailableAt"),
-                    (self.library.mass_added_at_update, "addedAt")
-                ]:
-                    if attribute:
-                        current = getattr(item, item_attr)
-                        if current:
-                            current = current.strftime("%Y-%m-%d")
-                        for option in attribute:
-                            if option in ["lock", "remove"]:
-                                if option == "remove" and current:
-                                    if item_attr not in remove_edits:
-                                        remove_edits[item_attr] = []
-                                    remove_edits[item_attr].append(item.ratingKey)
-                                    item_edits += f"Remove {name_display[item_attr]} (Batched)"
-                                elif item_attr not in locked_fields:
-                                    if item_attr not in lock_edits:
-                                        lock_edits[item_attr] = []
-                                    lock_edits[item_attr].append(item.ratingKey)
-                                    item_edits += f"Lock {name_display[item_attr]} (Batched)"
-                                break
-                            elif option in ["unlock", "reset"]:
-                                if option == "reset" and current:
-                                    if item_attr not in reset_edits:
-                                        reset_edits[item_attr] = []
-                                    reset_edits[item_attr].append(item.ratingKey)
-                                    item_edits += f"Reset {name_display[item_attr]} (Batched)"
-                                elif item_attr in locked_fields:
-                                    if item_attr not in unlock_edits:
-                                        unlock_edits[item_attr] = []
-                                    unlock_edits[item_attr].append(item.ratingKey)
-                                    item_edits += f"Unlock {name_display[item_attr]} (Batched)"
-                                break
-                            else:
-                                try:
-                                    if option == "tmdb":
-                                        new_date = tmdb_obj().release_date if self.library.is_movie else tmdb_obj().first_air_date  # noqa
-                                    elif option == "omdb":
-                                        new_date = omdb_obj().released  # noqa
-                                    elif option == "tvdb":
-                                        new_date = tvdb_obj().release_date  # noqa
-                                    elif option == "mdb":
-                                        new_date = mdb_obj().released  # noqa
-                                    elif option == "mdb_digital":
-                                        new_date = mdb_obj().released_digital  # noqa
-                                    elif option == "anidb":
-                                        new_date = anidb_obj().released  # noqa
-                                    elif option == "mal":
-                                        new_date = mal_obj().aired  # noqa
-                                    else:
-                                        new_date = option
-                                    if not new_date:
-                                        logger.info(f"No {option} {name_display[item_attr]} Found")
-                                        raise Failed
-                                    new_date = new_date.strftime("%Y-%m-%d")
-                                    if current != new_date:
-                                        if new_date not in date_edits[item_attr]:
-                                            date_edits[item_attr][new_date] = []
-                                        date_edits[item_attr][new_date].append(item.ratingKey)
-                                        item_edits += f"Update {name_display[item_attr]} (Batched) | {new_date}"
-                                    break
-                                except Failed:
-                                    continue
-
-                if len(item_edits) > 0:
-                    logger.info(f"{item_edits}")
-                else:
-                    logger.info("No Item Edits")
-
-                if self.library.mass_poster_update or self.library.mass_background_update:
-                    try:
-                        new_poster, new_background, logo, item_dir, name = self.library.find_item_assets(item)
-                    except Failed:
-                        new_poster, new_background, logo, item_dir, name = None, None, None, None, None
-                    try:
-                        tmdb_item = tmdb_obj()
-                    except Failed:
-                        tmdb_item = None
-
-                    if self.library.mass_poster_update:
-                        source = self.library.mass_poster_update["source"]
-                        ignore_locked = self.library.mass_poster_update["ignore_locked"]
-                        ignore_overlays = self.library.mass_poster_update.get("ignore_overlays")
-                        thumb_locked = any(f.name == "thumb" and f.locked for f in item.fields)
-                        labels = [la.tag for la in self.library.item_labels(item)]
-                        has_overlay_label = "Overlay" in labels
-                        
-                        # Bypass ignore_locked and ignore_overlays checks if the source is "unlock" or "lock"
-                        if source in ["unlock", "lock"]:
-                            self.library.poster_update(item, new_poster, tmdb=tmdb_item.poster_url if tmdb_item else None, title=item.title)  # noqa
-                        elif ignore_locked and thumb_locked:
-                            # Skip processing if ignore_locked is True and thumb is locked
+                                parental_guide = self.config.IMDb.parental_guide(imdb_id)
+                                parental_labels = [f"{k}:{v}" for k, v in parental_guide.items() if v and v not in util.parental_levels[self.library.mass_imdb_parental_labels]]
+                            add_labels = [la for la in parental_labels if la not in current_labels]
+                            remove_labels = [la for la in current_labels if la in util.parental_labels and la not in parental_labels]
+                            for label_list, edit_type in [(add_labels, "add"), (remove_labels, "remove")]:
+                                if label_list:
+                                    for label in label_list:
+                                        if label not in label_edits[edit_type]:
+                                            label_edits[edit_type][label] = []
+                                        label_edits[edit_type][label].append(item.ratingKey)
+                                    item_edits += f"{edit_type.capitalize()} IMDb Parental Labels (Batched) | {', '.join(label_list)}"
+                        except Failed:
                             pass
-                        elif ignore_overlays and has_overlay_label:
-                            # Skip processing if ignore_overlays is True and Overlay label is found
-                            pass
-                        else:
-                            self.library.poster_update(item, new_poster, tmdb=tmdb_item.poster_url if tmdb_item else None, title=item.title)  # noqa
+                    if item.locations:
+                        path = os.path.dirname(str(item.locations[0])) if self.library.is_movie else str(item.locations[0])
+                        if self.library.Radarr and self.library.radarr_add_all_existing and tmdb_id:
+                            path = path.replace(self.library.Radarr.plex_path, self.library.Radarr.radarr_path)
+                            path = path[:-1] if path.endswith(('/', '\\')) else path
+                            radarr_adds.append((tmdb_id, path))
+                        if self.library.Sonarr and self.library.sonarr_add_all_existing and tvdb_id:
+                            path = path.replace(self.library.Sonarr.plex_path, self.library.Sonarr.sonarr_path)
+                            path = path[:-1] if path.endswith(("/", "\\")) else path
+                            sonarr_adds.append((tvdb_id, path))
 
-                    if self.library.mass_background_update:
-                        source = self.library.mass_background_update["source"]
-                        ignore_locked = self.library.mass_background_update["ignore_locked"]
-                        ignore_overlays = self.library.mass_background_update["ignore_overlays"]
-                        art_locked = any(f.name == "art" and f.locked for f in item.fields)
+                    _trakt_ratings = None
+                    def trakt_ratings():
+                        nonlocal _trakt_ratings
+                        if _trakt_ratings is None:
+                            _trakt_ratings = self.config.Trakt.user_ratings(self.library.is_movie)
+                        if not _trakt_ratings:
+                            raise Failed
+                        return _trakt_ratings
 
-                        if source in ["unlock", "lock"]:
-                            self.library.background_update(item, new_background, tmdb=tmdb_item.backdrop_url if tmdb_item else None, title=item.title) # noqa
+                    _tmdb_obj = None
+                    def tmdb_obj():
+                        nonlocal _tmdb_obj
+                        if _tmdb_obj is None:
+                            _tmdb_obj = False
+                            try:
+                                _item = self.config.TMDb.get_item(item, tmdb_id, tvdb_id, imdb_id, is_movie=self.library.is_movie)
+                                if _item:
+                                    _tmdb_obj = _item
+                            except Failed as err:
+                                logger.error(str(err))
+                        if not _tmdb_obj:
+                            raise Failed
+                        return _tmdb_obj
 
-                        elif not (ignore_locked and art_locked):
-                            self.library.background_update(item, new_background, tmdb=tmdb_item.backdrop_url if tmdb_item else None, title=item.title) # noqa
-
-
-                    if self.library.is_show and (
-                            (self.library.mass_poster_update and
-                                (self.library.mass_poster_update["seasons"] or self.library.mass_poster_update["episodes"])) or
-                            (self.library.mass_background_update and
-                                (self.library.mass_background_update["seasons"] or self.library.mass_background_update["episodes"]))
-                    ):
-                        real_show = None
-                        try:
-                            real_show = tmdb_item.load_show() if tmdb_item else None # noqa
-                        except Failed as e:
-                            logger.error(e)
-                        tmdb_seasons = {s.season_number: s for s in real_show.seasons} if real_show else {}
-                        for season in self.library.query(item.seasons):
-                            if (self.library.mass_poster_update and self.library.mass_poster_update["seasons"]) or \
-                                    (self.library.mass_background_update and self.library.mass_background_update["seasons"]):
+                    _omdb_obj = None
+                    def omdb_obj():
+                        nonlocal _omdb_obj
+                        if _omdb_obj is None:
+                            _omdb_obj = False
+                            if self.config.OMDb.limit is not False:
+                                logger.error("Daily OMDb Limit Reached")
+                            elif not imdb_id:
+                                logger.info(f"No IMDb ID for Guid: {item.guid}")
+                            else:
                                 try:
-                                    season_poster, season_background, _, _, _ = self.library.find_item_assets(season, item_asset_directory=item_dir, folder_name=name)
-                                except Failed:
-                                    season_poster = None
-                                    season_background = None
-                                season_title = f"S{season.seasonNumber} {season.title}"
-                                tmdb_poster = tmdb_seasons[season.seasonNumber].poster_url if season.seasonNumber in tmdb_seasons else None
-                                if self.library.mass_poster_update and self.library.mass_poster_update["seasons"]:
-                                    self.library.poster_update(season, season_poster, tmdb=tmdb_poster, title=season_title if season else None)
-                                if self.library.mass_background_update and self.library.mass_background_update["seasons"]:
-                                    self.library.background_update(season, season_background, title=season_title if season else None)
+                                    _omdb_obj = self.config.OMDb.get_omdb(imdb_id)
+                                except Failed as err:
+                                    logger.error(str(err))
+                                except Exception:
+                                    logger.error(f"IMDb ID: {imdb_id}")
+                                    raise
+                        if not _omdb_obj:
+                            raise Failed
+                        return _omdb_obj
 
-                            if (self.library.mass_poster_update and self.library.mass_poster_update["episodes"]) or \
-                                    (self.library.mass_background_update and self.library.mass_background_update["episodes"]):
-                                tmdb_episodes = {}
-                                if season.seasonNumber in tmdb_seasons:
-                                    for episode in tmdb_seasons[season.seasonNumber].episodes:
-                                        episode._partial = False
-                                        try:
-                                            tmdb_episodes[episode.episode_number] = episode
-                                        except NotFound:
-                                            logger.error(f"TMDb Error: An Episode of Season {season.seasonNumber} was Not Found")
+                    _tvdb_obj = None
+                    def tvdb_obj():
+                        nonlocal _tvdb_obj
+                        if _tvdb_obj is None:
+                            _tvdb_obj = False
+                            if tvdb_id:
+                                try:
+                                    _tvdb_obj = self.config.TVDb.get_tvdb_obj(tvdb_id, is_movie=self.library.is_movie)
+                                except Failed as err:
+                                    logger.error(str(err))
+                            else:
+                                logger.info(f"No TVDb ID for Guid: {item.guid}")
+                        if not _tvdb_obj:
+                            raise Failed
+                        return _tvdb_obj
 
-                                for episode in self.library.query(season.episodes):
+                    _mdb_obj = None
+                    def mdb_obj():
+                        nonlocal _mdb_obj
+                        if _mdb_obj is None:
+                            _mdb_obj = False
+                            if self.config.MDBList.limit is False:
+                                if self.library.is_show and tvdb_id:
                                     try:
-                                        episode = self.library.reload(episode)
-                                    except Failed:
-                                        logger.error(f"S{season.seasonNumber}E{episode.episodeNumber} {episode.title} Failed to Reload from Plex")
-                                        continue
+                                        _mdb_obj = self.config.MDBList.get_series(tvdb_id)
+                                    except LimitReached as err:
+                                        logger.debug(err)
+                                    except Failed as err:
+                                        logger.error(str(err))
+                                    except Exception:
+                                        logger.trace(f"TVDb ID: {tvdb_id}")
+                                        raise
+                                if self.library.is_movie and tmdb_id:
                                     try:
-                                        episode_poster, episode_background, _, _, _ = self.library.find_item_assets(episode, item_asset_directory=item_dir, folder_name=name)
-                                    except Failed:
-                                        episode_poster = None
-                                        episode_background = None
-                                    episode_title = f"S{season.seasonNumber}E{episode.episodeNumber} {episode.title}"
-                                    tmdb_poster = tmdb_episodes[episode.episodeNumber].still_url if episode.episodeNumber in tmdb_episodes else None
-                                    if self.library.mass_poster_update and self.library.mass_poster_update["episodes"]:
-                                        self.library.poster_update(episode, episode_poster, tmdb=tmdb_poster, title=episode_title if episode else None)
-                                    if self.library.mass_background_update and self.library.mass_background_update["episodes"]:
-                                        self.library.background_update(episode, episode_background, title=episode_title if episode else None)
+                                        _mdb_obj = self.config.MDBList.get_movie(tmdb_id)
+                                    except LimitReached as err:
+                                        logger.debug(err)
+                                    except Failed as err:
+                                        logger.error(str(err))
+                                    except Exception:
+                                        logger.trace(f"TMDb ID: {tmdb_id}")
+                                        raise
+                                if imdb_id and not _mdb_obj:
+                                    try:
+                                        _mdb_obj = self.config.MDBList.get_imdb(imdb_id)
+                                    except LimitReached as err:
+                                        logger.debug(err)
+                                    except Failed as err:
+                                        logger.error(str(err))
+                                    except Exception:
+                                        logger.trace(f"IMDb ID: {imdb_id}")
+                                        raise
+                                if not _mdb_obj:
+                                    logger.warning(f"No MdbItem for {item.title} (Guid: {item.guid})")
+                        if not _mdb_obj:
+                            raise Failed
+                        return _mdb_obj
 
-                episode_ops = [
-                    (self.library.mass_episode_audience_rating_update, "audienceRating"),
-                    (self.library.mass_episode_critic_rating_update, "rating"),
-                    (self.library.mass_episode_user_rating_update, "userRating")
-                ]
+                    anidb_id = None
+                    def get_anidb_id():
+                        temp_id = self.config.Convert.ids_to_anidb(self.library, item.ratingKey, tvdb_id, imdb_id, tmdb_id)
+                        return temp_id if temp_id else False
 
-                if any([x is not None for x, _ in episode_ops]):
+                    _anidb_obj = None
+                    def anidb_obj():
+                        nonlocal anidb_id, _anidb_obj
+                        if _anidb_obj is None:
+                            _anidb_obj = False
+                            if anidb_id is None:
+                                anidb_id = get_anidb_id()
+                            if anidb_id:
+                                try:
+                                    _anidb_obj = self.config.AniDB.get_anime(anidb_id)
+                                except Failed as err:
+                                    logger.error(str(err))
+                            else:
+                                logger.warning(f"No AniDB ID for Guid: {item.guid}")
+                        if not _anidb_obj:
+                            raise Failed
+                        return _anidb_obj
 
-                    if any(["imdb" in x for x, _ in episode_ops if x]) and not imdb_id:
-                        logger.info(f"No IMDb ID for Guid: {item.guid}")
+                    _mal_obj = None
+                    def mal_obj():
+                        nonlocal anidb_id, _mal_obj
+                        if _mal_obj is None:
+                            _mal_obj = False
+                            if anidb_id is None:
+                                anidb_id = get_anidb_id()
+                            mal_id = None
+                            if item.ratingKey in self.library.reverse_mal:
+                                mal_id = self.library.reverse_mal[item.ratingKey]
+                            elif not anidb_id:
+                                logger.warning(f"Convert Warning: No AniDB ID to Convert to MyAnimeList ID for Guid: {item.guid}")
+                            else:
+                                try:
+                                    mal_id = self.config.Convert.anidb_to_mal(anidb_id)
+                                except Failed as err:
+                                    logger.warning(f"{err} of Guid: {item.guid}")
+                            if mal_id:
+                                try:
+                                    _mal_obj = self.config.MyAnimeList.get_anime(mal_id)
+                                except Failed as err:
+                                    logger.error(str(err))
+                        if not _mal_obj:
+                            raise Failed
+                        return _mal_obj
 
-                    for ep in item.episodes():
-                        ep = self.library.reload(ep)
-                        item_title = self.library.get_item_display_title(ep)
-                        logger.info("")
-                        logger.info(f"{item_title}")
-                        item_edits = ""
-
-                        for attribute, item_attr in episode_ops:
-                            if attribute:
-                                current = getattr(ep, item_attr)
-                                for option in attribute:
-                                    if option in ["lock", "remove"]:
-                                        if option == "remove" and current:
-                                            if item_attr not in ep_remove_edits:
-                                                ep_remove_edits[item_attr] = []
-                                            ep_remove_edits[item_attr].append(ep)
-                                            item_edits += f"Remove {name_display[item_attr]} (Batched)"
-                                        elif item_attr not in locked_fields:
-                                            if item_attr not in ep_lock_edits:
-                                                ep_lock_edits[item_attr] = []
-                                            ep_lock_edits[item_attr].append(ep)
-                                            item_edits += f"Lock {name_display[item_attr]} (Batched)"
-                                        break
-                                    elif option in ["unlock", "reset"]:
-                                        if option == "reset" and current:
-                                            if item_attr not in ep_reset_edits:
-                                                ep_reset_edits[item_attr] = []
-                                            ep_reset_edits[item_attr].append(ep)
-                                            item_edits += f"Reset {name_display[item_attr]} (Batched)"
-                                        elif item_attr in locked_fields:
-                                            if item_attr not in ep_unlock_edits:
-                                                ep_unlock_edits[item_attr] = []
-                                            ep_unlock_edits[item_attr].append(ep)
-                                            item_edits += f"Unlock {name_display[item_attr]} (Batched)"
-                                        break
-                                    else:
-                                        try:
-                                            try:
-                                                tmdb_item = tmdb_obj()
-                                            except Failed:
-                                                tmdb_item = None
-                                            found_rating = None
-                                            if str(option).startswith("plex"):
-                                                ratings = self.library.get_ratings(ep)
-                                                try:
-                                                    found_rating = ratings[option]  # noqa
-                                                except KeyError:
-                                                    found_rating = None
-                                            if tmdb_item and option == "tmdb":
-                                                try:
-                                                    found_rating = self.config.TMDb.get_episode(tmdb_item.tmdb_id, ep.seasonNumber, ep.episodeNumber).vote_average  # noqa
-                                                except Failed as er:
-                                                    logger.error(er)
-                                            elif imdb_id and option == "imdb":
-                                                found_rating = self.config.IMDb.get_episode_rating(imdb_id, ep.seasonNumber, ep.episodeNumber)
-                                            elif imdb_id and option == "trakt":
-                                                found_rating = self.config.Trakt.get_episode_rating(imdb_id, ep.seasonNumber, ep.episodeNumber)
+                    for attribute, item_attr in [
+                        (self.library.mass_audience_rating_update, "audienceRating"),
+                        (self.library.mass_critic_rating_update, "rating"),
+                        (self.library.mass_user_rating_update, "userRating")
+                    ]:
+                        if attribute:
+                            current = getattr(item, item_attr)
+                            for option in attribute:
+                                if option in ["lock", "remove"]:
+                                    if option == "remove" and current:
+                                        if item_attr not in remove_edits:
+                                            remove_edits[item_attr] = []
+                                        remove_edits[item_attr].append(item.ratingKey)
+                                        item_edits += f"Remove {name_display[item_attr]} (Batched)"
+                                    elif item_attr not in locked_fields:
+                                        if item_attr not in lock_edits:
+                                            lock_edits[item_attr] = []
+                                        lock_edits[item_attr].append(item.ratingKey)
+                                        item_edits += f"Lock {name_display[item_attr]} (Batched)"
+                                    break
+                                elif option in ["unlock", "reset"]:
+                                    if option == "reset" and current:
+                                        if item_attr not in reset_edits:
+                                            reset_edits[item_attr] = []
+                                        reset_edits[item_attr].append(item.ratingKey)
+                                        item_edits += f"Reset {name_display[item_attr]} (Batched)"
+                                    elif item_attr in locked_fields:
+                                        if item_attr not in unlock_edits:
+                                            unlock_edits[item_attr] = []
+                                        unlock_edits[item_attr].append(item.ratingKey)
+                                        item_edits += f"Unlock {name_display[item_attr]} (Batched)"
+                                    break
+                                else:
+                                    try:
+                                        if option == "tmdb":
+                                            found_rating = tmdb_obj().vote_average # noqa
+                                        elif option == "imdb":
+                                            found_rating = self.config.IMDb.get_rating(imdb_id)
+                                        elif option == "trakt":
+                                            found_rating = self.config.Trakt.get_rating(imdb_id, self.library.is_movie)
+                                        elif option == "trakt_user":
+                                            _ratings = trakt_ratings()
+                                            _id = tmdb_id if self.library.is_movie else tvdb_id
+                                            if _id in _ratings:
+                                                found_rating = _ratings[_id]
                                             else:
-                                                try:
-                                                    found_rating = float(option)
-                                                except ValueError:
-                                                    pass
-                                            if not found_rating:
-                                                logger.info(f"  No {option} {name_display[item_attr]} Found")
                                                 raise Failed
-                                            found_rating = f"{float(found_rating):.1f}"
-                                            if str(current) != found_rating:
-                                                if found_rating not in ep_rating_edits[item_attr]:
-                                                    ep_rating_edits[item_attr][found_rating] = []
-                                                ep_rating_edits[item_attr][found_rating].append(ep)
-                                                item_edits += f"Update {name_display[item_attr]} (Batched) | {found_rating}"
-                                            break
+                                        elif str(option).startswith("plex"):
+                                            ratings = self.library.get_ratings(item)
+                                            try:
+                                                found_rating = ratings[option] # noqa
+                                            except KeyError:
+                                                found_rating = None
+                                        elif str(option).startswith("omdb"):
+                                            omdb_item = omdb_obj()
+                                            if option == "omdb_metascore":
+                                                found_rating = omdb_item.metacritic_rating / 10 if omdb_item.metacritic_rating else None # noqa
+                                            elif option == "omdb_tomatoes":
+                                                found_rating = omdb_item.rotten_tomatoes / 10 if omdb_item.rotten_tomatoes else None # noqa
+                                            else:
+                                                found_rating = omdb_item.imdb_rating # noqa
+                                        elif str(option).startswith("mdb"):
+                                            mdb_item = mdb_obj()
+                                            if option == "mdb_average":
+                                                found_rating = mdb_item.average / 10 if mdb_item.average else None # noqa
+                                            elif option == "mdb_imdb":
+                                                found_rating = mdb_item.imdb_rating if mdb_item.imdb_rating else None # noqa
+                                            elif option == "mdb_metacritic":
+                                                found_rating = mdb_item.metacritic_rating / 10 if mdb_item.metacritic_rating else None # noqa
+                                            elif option == "mdb_metacriticuser":
+                                                found_rating = mdb_item.metacriticuser_rating if mdb_item.metacriticuser_rating else None # noqa
+                                            elif option == "mdb_trakt":
+                                                found_rating = mdb_item.trakt_rating / 10 if mdb_item.trakt_rating else None # noqa
+                                            elif option == "mdb_tomatoes":
+                                                found_rating = mdb_item.tomatoes_rating / 10 if mdb_item.tomatoes_rating else None # noqa
+                                            elif option == "mdb_tomatoesaudience":
+                                                found_rating = mdb_item.tomatoesaudience_rating / 10 if mdb_item.tomatoesaudience_rating else None # noqa
+                                            elif option == "mdb_tmdb":
+                                                found_rating = mdb_item.tmdb_rating / 10 if mdb_item.tmdb_rating else None # noqa
+                                            elif option == "mdb_letterboxd":
+                                                found_rating = mdb_item.letterboxd_rating * 2 if mdb_item.letterboxd_rating else None # noqa
+                                            elif option == "mdb_myanimelist":
+                                                found_rating = mdb_item.myanimelist_rating if mdb_item.myanimelist_rating else None # noqa
+                                            else:
+                                                found_rating = mdb_item.score / 10 if mdb_item.score else None # noqa
+                                        elif option == "anidb_rating":
+                                            found_rating = anidb_obj().rating # noqa
+                                        elif option == "anidb_average":
+                                            found_rating = anidb_obj().average # noqa
+                                        elif option == "anidb_score":
+                                            found_rating = anidb_obj().score # noqa
+                                        elif option == "mal":
+                                            found_rating = mal_obj().score # noqa
+                                        else:
+                                            found_rating = option
+                                        if not found_rating:
+                                            logger.info(f"No {option} {name_display[item_attr]} Found")
+                                            raise Failed
+                                        found_rating = f"{float(found_rating):.1f}"
+                                        if str(current) != found_rating:
+                                            if found_rating not in rating_edits[item_attr]:
+                                                rating_edits[item_attr][found_rating] = []
+                                            rating_edits[item_attr][found_rating].append(item.ratingKey)
+                                            item_edits += f"Update {name_display[item_attr]} (Batched) | {found_rating}"
+                                        break
+                                    except Failed:
+                                        continue
+
+                    if self.library.mass_genre_update or self.library.genre_mapper:
+                        new_genres = []
+                        extra_option = None
+                        if self.library.mass_genre_update:
+                            for option in self.library.mass_genre_update:
+                                if option in ["lock", "unlock", "remove", "reset"]:
+                                    extra_option = option
+                                    break
+                                try:
+                                    if option == "tmdb":
+                                        new_genres = tmdb_obj().genres # noqa
+                                    elif option == "imdb":
+                                        new_genres = self.config.IMDb.get_genres(imdb_id)
+                                    elif option == "omdb":
+                                        new_genres = omdb_obj().genres # noqa
+                                    elif option == "tvdb":
+                                        new_genres = tvdb_obj().genres # noqa
+                                    elif str(option) in anidb.weights:
+                                        new_genres = [str(t).title() for t, w in anidb_obj().tags.items() if w >= anidb.weights[str(option)]] # noqa
+                                    elif option == "mal":
+                                        new_genres = mal_obj().genres # noqa
+                                    else:
+                                        new_genres = option
+                                    if not new_genres:
+                                        logger.info(f"No {option} Genres Found")
+                                        raise Failed
+                                    break
+                                except Failed:
+                                    continue
+
+                        item_genres = [g.tag for g in item.genres]
+                        if not new_genres and extra_option not in ["remove", "reset"]:
+                            new_genres = item_genres
+                        if self.library.genre_mapper:
+                            mapped_genres = []
+                            for genre in new_genres:
+                                if genre in self.library.genre_mapper:
+                                    if self.library.genre_mapper[genre]:
+                                        mapped_genres.append(self.library.genre_mapper[genre])
+                                else:
+                                    mapped_genres.append(genre)
+                            new_genres = mapped_genres
+                        _add = list(set(new_genres) - set(item_genres))
+                        _remove = list(set(item_genres) - set(new_genres))
+                        for genre_list, edit_type in [(_add, "add"), (_remove, "remove")]:
+                            if genre_list:
+                                for g in genre_list:
+                                    if g not in genre_edits[edit_type]:
+                                        genre_edits[edit_type][g] = []
+                                    genre_edits[edit_type][g].append(item.ratingKey)
+                                item_edits += f"{edit_type.capitalize()} Genres (Batched) | {', '.join(genre_list)}"
+                        if extra_option in ["unlock", "reset"] and ("genre" in locked_fields or _add or _remove):
+                            if "genre" not in unlock_edits:
+                                unlock_edits["genre"] = []
+                            unlock_edits["genre"].append(item.ratingKey)
+                            item_edits += "\nUnlock Genre (Batched)"
+                        elif extra_option in ["lock", "remove"] and "genre" not in locked_fields and not _add and not _remove:
+                            if "genre" not in lock_edits:
+                                lock_edits["genre"] = []
+                            lock_edits["genre"].append(item.ratingKey)
+                            item_edits += "\nLock Genre (Batched)"
+
+                    if self.library.mass_content_rating_update or self.library.content_rating_mapper:
+                        new_rating = None
+                        extra_option = None
+                        if self.library.mass_content_rating_update:
+                            for option in self.library.mass_content_rating_update:
+                                if option in ["lock", "unlock", "remove", "reset"]:
+                                    extra_option = option
+                                    break
+                                try:
+                                    if option == "omdb":
+                                        new_rating = omdb_obj().content_rating # noqa
+                                    elif option == "mdb":
+                                        _rating = mdb_obj().content_rating # noqa
+                                        new_rating = _rating if _rating else None
+                                    elif str(option).startswith("mdb_commonsense"):
+                                        _rating = mdb_obj().commonsense # noqa
+                                        if not _rating:
+                                            new_rating = None
+                                        elif option == "mdb_commonsense0":
+                                            new_rating = str(_rating).rjust(2, "0")
+                                        else:
+                                            new_rating = _rating
+                                    elif str(option).startswith("mdb_age_rating"):
+                                        _rating = mdb_obj().age_rating # noqa
+                                        if not _rating:
+                                            new_rating = None
+                                        elif option == "mdb_age_rating0":
+                                            new_rating = str(_rating).rjust(2, "0")
+                                        else:
+                                            new_rating = _rating
+                                    elif option == "mal":
+                                        new_rating = mal_obj().rating # noqa
+                                    else:
+                                        new_rating = option
+                                    if new_rating is None:
+                                        logger.info(f"No {option} Content Rating Found")
+                                        raise Failed
+                                    else:
+                                        new_rating = str(new_rating)
+                                        break
+                                except Failed:
+                                    continue
+
+                        is_none = False
+                        do_lock = False
+                        do_unlock = False
+                        current_rating = item.contentRating
+                        if not new_rating:
+                            new_rating = current_rating
+                        if self.library.content_rating_mapper:
+                            if new_rating in self.library.content_rating_mapper:
+                                new_rating = self.library.content_rating_mapper[new_rating]
+                                if not new_rating:
+                                    is_none = True
+                        if extra_option == "reset":
+                            if current_rating:
+                                if "contentRating" not in reset_edits:
+                                    reset_edits["contentRating"] = []
+                                reset_edits["contentRating"].append(item.ratingKey)
+                                item_edits += "\nReset Content Rating (Batched)"
+                            elif "contentRating" in locked_fields:
+                                do_unlock = True
+                        elif extra_option == "remove" or is_none:
+                            if current_rating:
+                                if "contentRating" not in remove_edits:
+                                    remove_edits["contentRating"] = []
+                                remove_edits["contentRating"].append(item.ratingKey)
+                                item_edits += "\nRemove Content Rating (Batched)"
+                            elif "contentRating" not in locked_fields:
+                                do_lock = True
+                        elif new_rating and new_rating != current_rating:
+                            if new_rating not in content_edits:
+                                content_edits[new_rating] = []
+                            content_edits[new_rating].append(item.ratingKey)
+                            item_edits += f"Update Content Rating (Batched) | {new_rating}"
+                            do_lock = False
+
+                        if extra_option == "lock" or do_lock:
+                            if "contentRating" not in lock_edits:
+                                lock_edits["contentRating"] = []
+                            lock_edits["contentRating"].append(item.ratingKey)
+                            item_edits += "\nLock Content Rating (Batched)"
+                        elif extra_option == "unlock" or do_unlock:
+                            if "contentRating" not in unlock_edits:
+                                unlock_edits["contentRating"] = []
+                            unlock_edits["contentRating"].append(item.ratingKey)
+                            item_edits += "\nUnlock Content Rating (Batched)"
+
+                    if self.library.mass_original_title_update:
+                        current_original = item.originalTitle
+                        for option in self.library.mass_original_title_update:
+                            if option in ["lock", "remove"]:
+                                if option == "remove" and current_original:
+                                    if "originalTitle" not in remove_edits:
+                                        remove_edits["originalTitle"] = []
+                                    remove_edits["originalTitle"].append(item.ratingKey)
+                                    item_edits += "\nRemove Original Title (Batched)"
+                                elif "originalTitle" not in locked_fields:
+                                    if "originalTitle" not in lock_edits:
+                                        lock_edits["originalTitle"] = []
+                                    lock_edits["originalTitle"].append(item.ratingKey)
+                                    item_edits += "\nLock Original Title (Batched)"
+                                break
+                            elif option in ["unlock", "reset"]:
+                                if option == "reset" and current_original:
+                                    if "originalTitle" not in reset_edits:
+                                        reset_edits["originalTitle"] = []
+                                    reset_edits["originalTitle"].append(item.ratingKey)
+                                    item_edits += "\nReset Original Title (Batched)"
+                                elif "originalTitle" in locked_fields:
+                                    if "originalTitle" not in unlock_edits:
+                                        unlock_edits["originalTitle"] = []
+                                    unlock_edits["originalTitle"].append(item.ratingKey)
+                                    item_edits += "\nUnlock Original Title (Batched)"
+                                break
+                            else:
+                                try:
+                                    if option == "anidb":
+                                        new_original_title = anidb_obj().main_title # noqa
+                                    elif option == "anidb_official":
+                                        new_original_title = anidb_obj().official_title # noqa
+                                    elif option == "mal":
+                                        new_original_title = mal_obj().title # noqa
+                                    elif option == "mal_english":
+                                        new_original_title = mal_obj().title_english # noqa
+                                    elif option == "mal_japanese":
+                                        new_original_title = mal_obj().title_japanese # noqa
+                                    else:
+                                        new_original_title = option
+                                    if not new_original_title:
+                                        logger.info(f"No {option} Original Title Found")
+                                        raise Failed
+                                    if str(current_original) != str(new_original_title):
+                                        item.editOriginalTitle(new_original_title)
+                                        item_edits += f"Updated Original Title | {new_original_title}"
+                                    break
+                                except Failed:
+                                    continue
+
+                    if self.library.mass_studio_update:
+                        current_studio = item.studio
+                        for option in self.library.mass_studio_update:
+                            if option in ["lock", "remove"]:
+                                if option == "remove" and current_studio:
+                                    if "studio" not in remove_edits:
+                                        remove_edits["studio"] = []
+                                    remove_edits["studio"].append(item.ratingKey)
+                                    item_edits += "\nRemove Studio (Batched)"
+                                elif "studio" not in locked_fields:
+                                    if "studio" not in lock_edits:
+                                        lock_edits["studio"] = []
+                                    lock_edits["studio"].append(item.ratingKey)
+                                    item_edits += "\nLock Studio (Batched)"
+                                break
+                            elif option in ["unlock", "reset"]:
+                                if option == "reset" and current_studio:
+                                    if "studio" not in reset_edits:
+                                        reset_edits["studio"] = []
+                                    reset_edits["studio"].append(item.ratingKey)
+                                    item_edits += "\nReset Studio (Batched)"
+                                elif "studio" in locked_fields:
+                                    if "studio" not in unlock_edits:
+                                        unlock_edits["studio"] = []
+                                    unlock_edits["studio"].append(item.ratingKey)
+                                    item_edits += "\nUnlock Studio (Batched)"
+                                break
+                            else:
+                                try:
+                                    if option == "tmdb":
+                                        new_studio = tmdb_obj().studio # noqa
+                                    elif option == "anidb":
+                                        new_studio = anidb_obj().studio # noqa
+                                    elif option == "mal":
+                                        new_studio = mal_obj().studio # noqa
+                                    else:
+                                        new_studio = option
+                                    if not new_studio:
+                                        logger.info(f"No {option} Studio Found")
+                                        raise Failed
+                                    if str(current_studio) != str(new_studio):
+                                        if new_studio not in studio_edits:
+                                            studio_edits[new_studio] = []
+                                        studio_edits[new_studio].append(item.ratingKey)
+                                        item_edits += f"Update Studio (Batched) | {new_studio}"
+                                    break
+                                except Failed:
+                                    continue
+
+                    for attribute, item_attr in [
+                        (self.library.mass_originally_available_update, "originallyAvailableAt"),
+                        (self.library.mass_added_at_update, "addedAt")
+                    ]:
+                        if attribute:
+                            current = getattr(item, item_attr)
+                            if current:
+                                current = current.strftime("%Y-%m-%d")
+                            for option in attribute:
+                                if option in ["lock", "remove"]:
+                                    if option == "remove" and current:
+                                        if item_attr not in remove_edits:
+                                            remove_edits[item_attr] = []
+                                        remove_edits[item_attr].append(item.ratingKey)
+                                        item_edits += f"Remove {name_display[item_attr]} (Batched)"
+                                    elif item_attr not in locked_fields:
+                                        if item_attr not in lock_edits:
+                                            lock_edits[item_attr] = []
+                                        lock_edits[item_attr].append(item.ratingKey)
+                                        item_edits += f"Lock {name_display[item_attr]} (Batched)"
+                                    break
+                                elif option in ["unlock", "reset"]:
+                                    if option == "reset" and current:
+                                        if item_attr not in reset_edits:
+                                            reset_edits[item_attr] = []
+                                        reset_edits[item_attr].append(item.ratingKey)
+                                        item_edits += f"Reset {name_display[item_attr]} (Batched)"
+                                    elif item_attr in locked_fields:
+                                        if item_attr not in unlock_edits:
+                                            unlock_edits[item_attr] = []
+                                        unlock_edits[item_attr].append(item.ratingKey)
+                                        item_edits += f"Unlock {name_display[item_attr]} (Batched)"
+                                    break
+                                else:
+                                    try:
+                                        if option == "tmdb":
+                                            new_date = tmdb_obj().release_date if self.library.is_movie else tmdb_obj().first_air_date  # noqa
+                                        elif option == "omdb":
+                                            new_date = omdb_obj().released  # noqa
+                                        elif option == "tvdb":
+                                            new_date = tvdb_obj().release_date  # noqa
+                                        elif option == "mdb":
+                                            new_date = mdb_obj().released  # noqa
+                                        elif option == "mdb_digital":
+                                            new_date = mdb_obj().released_digital  # noqa
+                                        elif option == "anidb":
+                                            new_date = anidb_obj().released  # noqa
+                                        elif option == "mal":
+                                            new_date = mal_obj().aired  # noqa
+                                        else:
+                                            new_date = option
+                                        if not new_date:
+                                            logger.info(f"No {option} {name_display[item_attr]} Found")
+                                            raise Failed
+                                        new_date = new_date.strftime("%Y-%m-%d")
+                                        if current != new_date:
+                                            if new_date not in date_edits[item_attr]:
+                                                date_edits[item_attr][new_date] = []
+                                            date_edits[item_attr][new_date].append(item.ratingKey)
+                                            item_edits += f"Update {name_display[item_attr]} (Batched) | {new_date}"
+                                        break
+                                    except Failed:
+                                        continue
+
+                    if len(item_edits) > 0:
+                        logger.info(f"{item_edits}")
+                    else:
+                        logger.info("No Item Edits")
+
+                    if self.library.mass_poster_update or self.library.mass_background_update:
+                        try:
+                            new_poster, new_background, logo, item_dir, name = self.library.find_item_assets(item)
+                        except Failed:
+                            new_poster, new_background, logo, item_dir, name = None, None, None, None, None
+                        try:
+                            tmdb_item = tmdb_obj()
+                        except Failed:
+                            tmdb_item = None
+
+                        if self.library.mass_poster_update:
+                            source = self.library.mass_poster_update["source"]
+                            ignore_locked = self.library.mass_poster_update["ignore_locked"]
+                            ignore_overlays = self.library.mass_poster_update.get("ignore_overlays")
+                            thumb_locked = any(f.name == "thumb" and f.locked for f in item.fields)
+                            labels = [la.tag for la in self.library.item_labels(item)]
+                            has_overlay_label = "Overlay" in labels
+                            
+                            # Bypass ignore_locked and ignore_overlays checks if the source is "unlock" or "lock"
+                            if source in ["unlock", "lock"]:
+                                self.library.poster_update(item, new_poster, tmdb=tmdb_item.poster_url if tmdb_item else None, title=item.title)  # noqa
+                            elif ignore_locked and thumb_locked:
+                                # Skip processing if ignore_locked is True and thumb is locked
+                                pass
+                            elif ignore_overlays and has_overlay_label:
+                                # Skip processing if ignore_overlays is True and Overlay label is found
+                                pass
+                            else:
+                                self.library.poster_update(item, new_poster, tmdb=tmdb_item.poster_url if tmdb_item else None, title=item.title)  # noqa
+
+                        if self.library.mass_background_update:
+                            source = self.library.mass_background_update["source"]
+                            ignore_locked = self.library.mass_background_update["ignore_locked"]
+                            ignore_overlays = self.library.mass_background_update["ignore_overlays"]
+                            art_locked = any(f.name == "art" and f.locked for f in item.fields)
+
+                            if source in ["unlock", "lock"]:
+                                self.library.background_update(item, new_background, tmdb=tmdb_item.backdrop_url if tmdb_item else None, title=item.title) # noqa
+
+                            elif not (ignore_locked and art_locked):
+                                self.library.background_update(item, new_background, tmdb=tmdb_item.backdrop_url if tmdb_item else None, title=item.title) # noqa
+
+
+                        if self.library.is_show and (
+                                (self.library.mass_poster_update and
+                                    (self.library.mass_poster_update["seasons"] or self.library.mass_poster_update["episodes"])) or
+                                (self.library.mass_background_update and
+                                    (self.library.mass_background_update["seasons"] or self.library.mass_background_update["episodes"]))
+                        ):
+                            real_show = None
+                            try:
+                                real_show = tmdb_item.load_show() if tmdb_item else None # noqa
+                            except Failed as e:
+                                logger.error(e)
+                            tmdb_seasons = {s.season_number: s for s in real_show.seasons} if real_show else {}
+                            for season in self.library.query(item.seasons):
+                                if (self.library.mass_poster_update and self.library.mass_poster_update["seasons"]) or \
+                                        (self.library.mass_background_update and self.library.mass_background_update["seasons"]):
+                                    try:
+                                        season_poster, season_background, _, _, _ = self.library.find_item_assets(season, item_asset_directory=item_dir, folder_name=name)
+                                    except Failed:
+                                        season_poster = None
+                                        season_background = None
+                                    season_title = f"S{season.seasonNumber} {season.title}"
+                                    tmdb_poster = tmdb_seasons[season.seasonNumber].poster_url if season.seasonNumber in tmdb_seasons else None
+                                    if self.library.mass_poster_update and self.library.mass_poster_update["seasons"]:
+                                        self.library.poster_update(season, season_poster, tmdb=tmdb_poster, title=season_title if season else None)
+                                    if self.library.mass_background_update and self.library.mass_background_update["seasons"]:
+                                        self.library.background_update(season, season_background, title=season_title if season else None)
+
+                                if (self.library.mass_poster_update and self.library.mass_poster_update["episodes"]) or \
+                                        (self.library.mass_background_update and self.library.mass_background_update["episodes"]):
+                                    tmdb_episodes = {}
+                                    if season.seasonNumber in tmdb_seasons:
+                                        for episode in tmdb_seasons[season.seasonNumber].episodes:
+                                            episode._partial = False
+                                            try:
+                                                tmdb_episodes[episode.episode_number] = episode
+                                            except NotFound:
+                                                logger.error(f"TMDb Error: An Episode of Season {season.seasonNumber} was Not Found")
+
+                                    for episode in self.library.query(season.episodes):
+                                        try:
+                                            episode = self.library.reload(episode)
                                         except Failed:
+                                            logger.error(f"S{season.seasonNumber}E{episode.episodeNumber} {episode.title} Failed to Reload from Plex")
                                             continue
+                                        try:
+                                            episode_poster, episode_background, _, _, _ = self.library.find_item_assets(episode, item_asset_directory=item_dir, folder_name=name)
+                                        except Failed:
+                                            episode_poster = None
+                                            episode_background = None
+                                        episode_title = f"S{season.seasonNumber}E{episode.episodeNumber} {episode.title}"
+                                        tmdb_poster = tmdb_episodes[episode.episodeNumber].still_url if episode.episodeNumber in tmdb_episodes else None
+                                        if self.library.mass_poster_update and self.library.mass_poster_update["episodes"]:
+                                            self.library.poster_update(episode, episode_poster, tmdb=tmdb_poster, title=episode_title if episode else None)
+                                        if self.library.mass_background_update and self.library.mass_background_update["episodes"]:
+                                            self.library.background_update(episode, episode_background, title=episode_title if episode else None)
 
-                        if len(item_edits) > 0:
-                            logger.info(f"{item_edits}")
+                    episode_ops = [
+                        (self.library.mass_episode_audience_rating_update, "audienceRating"),
+                        (self.library.mass_episode_critic_rating_update, "rating"),
+                        (self.library.mass_episode_user_rating_update, "userRating")
+                    ]
 
-            logger.info("")
-            logger.separator("Batch Updates", space=False, border=False)
-            logger.info("")
+                    if any([x is not None for x, _ in episode_ops]):
 
-            def get_batch_info(placement, total, display_attr, total_count, display_value=None, is_episode=False, out_type=None, tag_type=None):
-                return f"Batch {name_display[display_attr] if display_attr in name_display else display_attr.capitalize()} Update ({placement}/{total}): " \
-                       f"{f'{out_type.capitalize()} ' if out_type else ''}" \
-                       f"{f'Adding {display_value} to ' if tag_type == 'add' else f'Removing {display_value} from ' if tag_type == 'remove' else ''}" \
-                       f"{total_count} {'Episode' if is_episode else 'Movie' if self.library.is_movie else 'Show'}" \
-                       f"{'s' if total_count > 1 else ''}{'' if out_type or tag_type else f' updated to {display_value}'}"
+                        if any(["imdb" in x for x, _ in episode_ops if x]) and not imdb_id:
+                            logger.info(f"No IMDb ID for Guid: {item.guid}")
 
-            for tag_attribute, edit_dict in [("Label", label_edits), ("Genre", genre_edits)]:
-                for edit_type, batch_edits in edit_dict.items():
-                    _size = len(batch_edits.items())
-                    for i, (tag_name, rating_keys) in enumerate(sorted(batch_edits.items()), 1):
-                        logger.info(get_batch_info(i, _size, tag_attribute, len(rating_keys), display_value=tag_name, tag_type=edit_type))
+                        for ep in item.episodes():
+                            ep = self.library.reload(ep)
+                            item_title = self.library.get_item_display_title(ep)
+                            logger.info("")
+                            logger.info(f"{item_title}")
+                            item_edits = ""
+
+                            for attribute, item_attr in episode_ops:
+                                if attribute:
+                                    current = getattr(ep, item_attr)
+                                    for option in attribute:
+                                        if option in ["lock", "remove"]:
+                                            if option == "remove" and current:
+                                                if item_attr not in ep_remove_edits:
+                                                    ep_remove_edits[item_attr] = []
+                                                ep_remove_edits[item_attr].append(ep)
+                                                item_edits += f"Remove {name_display[item_attr]} (Batched)"
+                                            elif item_attr not in locked_fields:
+                                                if item_attr not in ep_lock_edits:
+                                                    ep_lock_edits[item_attr] = []
+                                                ep_lock_edits[item_attr].append(ep)
+                                                item_edits += f"Lock {name_display[item_attr]} (Batched)"
+                                            break
+                                        elif option in ["unlock", "reset"]:
+                                            if option == "reset" and current:
+                                                if item_attr not in ep_reset_edits:
+                                                    ep_reset_edits[item_attr] = []
+                                                ep_reset_edits[item_attr].append(ep)
+                                                item_edits += f"Reset {name_display[item_attr]} (Batched)"
+                                            elif item_attr in locked_fields:
+                                                if item_attr not in ep_unlock_edits:
+                                                    ep_unlock_edits[item_attr] = []
+                                                ep_unlock_edits[item_attr].append(ep)
+                                                item_edits += f"Unlock {name_display[item_attr]} (Batched)"
+                                            break
+                                        else:
+                                            try:
+                                                try:
+                                                    tmdb_item = tmdb_obj()
+                                                except Failed:
+                                                    tmdb_item = None
+                                                found_rating = None
+                                                if str(option).startswith("plex"):
+                                                    ratings = self.library.get_ratings(ep)
+                                                    try:
+                                                        found_rating = ratings[option]  # noqa
+                                                    except KeyError:
+                                                        found_rating = None
+                                                if tmdb_item and option == "tmdb":
+                                                    try:
+                                                        found_rating = self.config.TMDb.get_episode(tmdb_item.tmdb_id, ep.seasonNumber, ep.episodeNumber).vote_average  # noqa
+                                                    except Failed as er:
+                                                        logger.error(er)
+                                                elif imdb_id and option == "imdb":
+                                                    found_rating = self.config.IMDb.get_episode_rating(imdb_id, ep.seasonNumber, ep.episodeNumber)
+                                                elif imdb_id and option == "trakt":
+                                                    found_rating = self.config.Trakt.get_episode_rating(imdb_id, ep.seasonNumber, ep.episodeNumber)
+                                                else:
+                                                    try:
+                                                        found_rating = float(option)
+                                                    except ValueError:
+                                                        pass
+                                                if not found_rating:
+                                                    logger.info(f"  No {option} {name_display[item_attr]} Found")
+                                                    raise Failed
+                                                found_rating = f"{float(found_rating):.1f}"
+                                                if str(current) != found_rating:
+                                                    if found_rating not in ep_rating_edits[item_attr]:
+                                                        ep_rating_edits[item_attr][found_rating] = []
+                                                    ep_rating_edits[item_attr][found_rating].append(ep)
+                                                    item_edits += f"Update {name_display[item_attr]} (Batched) | {found_rating}"
+                                                break
+                                            except Failed:
+                                                continue
+
+                            if len(item_edits) > 0:
+                                logger.info(f"{item_edits}")
+
+                logger.info("")
+                logger.separator("Batch Updates", space=False, border=False)
+                logger.info("")
+
+                def get_batch_info(placement, total, display_attr, total_count, display_value=None, is_episode=False, out_type=None, tag_type=None):
+                    return f"Batch {name_display[display_attr] if display_attr in name_display else display_attr.capitalize()} Update ({placement}/{total}): " \
+                        f"{f'{out_type.capitalize()} ' if out_type else ''}" \
+                        f"{f'Adding {display_value} to ' if tag_type == 'add' else f'Removing {display_value} from ' if tag_type == 'remove' else ''}" \
+                        f"{total_count} {'Episode' if is_episode else 'Movie' if self.library.is_movie else 'Show'}" \
+                        f"{'s' if total_count > 1 else ''}{'' if out_type or tag_type else f' updated to {display_value}'}"
+
+                for tag_attribute, edit_dict in [("Label", label_edits), ("Genre", genre_edits)]:
+                    for edit_type, batch_edits in edit_dict.items():
+                        _size = len(batch_edits.items())
+                        for i, (tag_name, rating_keys) in enumerate(sorted(batch_edits.items()), 1):
+                            logger.info(get_batch_info(i, _size, tag_attribute, len(rating_keys), display_value=tag_name, tag_type=edit_type))
+                            self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
+                            getattr(self.library.Plex, f"{edit_type}{tag_attribute}")(tag_name)
+                            self.library.Plex.saveMultiEdits()
+
+                for item_attr, _edits in rating_edits.items():
+                    _size = len(_edits.items())
+                    for i, (new_rating, rating_keys) in enumerate(sorted(_edits.items()), 1):
+                        logger.info(get_batch_info(i, _size, item_attr, len(rating_keys), display_value=new_rating))
                         self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
-                        getattr(self.library.Plex, f"{edit_type}{tag_attribute}")(tag_name)
+                        self.library.Plex.editField(item_attr, new_rating)
                         self.library.Plex.saveMultiEdits()
 
-            for item_attr, _edits in rating_edits.items():
-                _size = len(_edits.items())
-                for i, (new_rating, rating_keys) in enumerate(sorted(_edits.items()), 1):
-                    logger.info(get_batch_info(i, _size, item_attr, len(rating_keys), display_value=new_rating))
+                _size = len(content_edits.items())
+                for i, (new_rating, rating_keys) in enumerate(sorted(content_edits.items()), 1):
+                    logger.info(get_batch_info(i, _size, "contentRating", len(rating_keys), display_value=new_rating))
                     self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
-                    self.library.Plex.editField(item_attr, new_rating)
+                    self.library.Plex.editContentRating(new_rating)
                     self.library.Plex.saveMultiEdits()
 
-            _size = len(content_edits.items())
-            for i, (new_rating, rating_keys) in enumerate(sorted(content_edits.items()), 1):
-                logger.info(get_batch_info(i, _size, "contentRating", len(rating_keys), display_value=new_rating))
-                self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
-                self.library.Plex.editContentRating(new_rating)
-                self.library.Plex.saveMultiEdits()
+                _size = len(studio_edits.items())
+                for i, (new_studio, rating_keys) in enumerate(sorted(studio_edits.items()), 1):
+                    logger.info(get_batch_info(i, _size, "studio", len(rating_keys), display_value=new_studio))
+                    self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
+                    self.library.Plex.editStudio(new_studio)
+                    self.library.Plex.saveMultiEdits()
 
-            _size = len(studio_edits.items())
-            for i, (new_studio, rating_keys) in enumerate(sorted(studio_edits.items()), 1):
-                logger.info(get_batch_info(i, _size, "studio", len(rating_keys), display_value=new_studio))
-                self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
-                self.library.Plex.editStudio(new_studio)
-                self.library.Plex.saveMultiEdits()
+                _size = len(date_edits["originallyAvailableAt"].items())
+                for i, (new_date, rating_keys) in enumerate(sorted(date_edits["originallyAvailableAt"].items()), 1):
+                    logger.info(get_batch_info(i, _size, "originallyAvailableAt", len(rating_keys), display_value=new_date))
+                    self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
+                    self.library.Plex.editOriginallyAvailable(new_date)
+                    self.library.Plex.saveMultiEdits()
 
-            _size = len(date_edits["originallyAvailableAt"].items())
-            for i, (new_date, rating_keys) in enumerate(sorted(date_edits["originallyAvailableAt"].items()), 1):
-                logger.info(get_batch_info(i, _size, "originallyAvailableAt", len(rating_keys), display_value=new_date))
-                self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
-                self.library.Plex.editOriginallyAvailable(new_date)
-                self.library.Plex.saveMultiEdits()
+                epoch = datetime(1970, 1, 1)
+                _size = len(date_edits["addedAt"].items())
+                for i, (new_date, rating_keys) in enumerate(sorted(date_edits["addedAt"].items()), 1):
+                    logger.info(get_batch_info(i, _size, "addedAt", len(rating_keys), display_value=new_date))
+                    self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
+                    new_date = datetime.strptime(new_date, "%Y-%m-%d")
+                    logger.trace(new_date)
+                    try:
+                        ts = int(round(new_date.timestamp()))
+                    except (TypeError, OSError):
+                        offset = int(datetime(2000, 1, 1, tzinfo=timezone.utc).timestamp() - datetime(2000, 1, 1).timestamp())
+                        ts = int((new_date - epoch).total_seconds()) - offset
+                    logger.trace(epoch + timedelta(seconds=ts))
+                    self.library.Plex.editAddedAt(ts)
+                    self.library.Plex.saveMultiEdits()
 
-            epoch = datetime(1970, 1, 1)
-            _size = len(date_edits["addedAt"].items())
-            for i, (new_date, rating_keys) in enumerate(sorted(date_edits["addedAt"].items()), 1):
-                logger.info(get_batch_info(i, _size, "addedAt", len(rating_keys), display_value=new_date))
-                self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
-                new_date = datetime.strptime(new_date, "%Y-%m-%d")
-                logger.trace(new_date)
-                try:
-                    ts = int(round(new_date.timestamp()))
-                except (TypeError, OSError):
-                    offset = int(datetime(2000, 1, 1, tzinfo=timezone.utc).timestamp() - datetime(2000, 1, 1).timestamp())
-                    ts = int((new_date - epoch).total_seconds()) - offset
-                logger.trace(epoch + timedelta(seconds=ts))
-                self.library.Plex.editAddedAt(ts)
-                self.library.Plex.saveMultiEdits()
+                _size = len(remove_edits.items())
+                for i, (field_attr, rating_keys) in enumerate(remove_edits.items(), 1):
+                    logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), out_type="remov"))
+                    self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
+                    self.library.Plex.editField(field_attr, None, locked=True)
+                    self.library.Plex.saveMultiEdits()
 
-            _size = len(remove_edits.items())
-            for i, (field_attr, rating_keys) in enumerate(remove_edits.items(), 1):
-                logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), out_type="remov"))
-                self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
-                self.library.Plex.editField(field_attr, None, locked=True)
-                self.library.Plex.saveMultiEdits()
+                _size = len(reset_edits.items())
+                for i, (field_attr, rating_keys) in enumerate(reset_edits.items(), 1):
+                    logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), out_type="reset"))
+                    self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
+                    self.library.Plex.editField(field_attr, None, locked=False)
+                    self.library.Plex.saveMultiEdits()
 
-            _size = len(reset_edits.items())
-            for i, (field_attr, rating_keys) in enumerate(reset_edits.items(), 1):
-                logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), out_type="reset"))
-                self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
-                self.library.Plex.editField(field_attr, None, locked=False)
-                self.library.Plex.saveMultiEdits()
+                _size = len(lock_edits.items())
+                for i, (field_attr, rating_keys) in enumerate(lock_edits.items(), 1):
+                    logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), out_type="lock"))
+                    self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
+                    self.library.Plex._edit(**{f"{field_attr}.locked": 1})
+                    self.library.Plex.saveMultiEdits()
 
-            _size = len(lock_edits.items())
-            for i, (field_attr, rating_keys) in enumerate(lock_edits.items(), 1):
-                logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), out_type="lock"))
-                self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
-                self.library.Plex._edit(**{f"{field_attr}.locked": 1})
-                self.library.Plex.saveMultiEdits()
+                _size = len(unlock_edits.items())
+                for i, (field_attr, rating_keys) in enumerate(unlock_edits.items(), 1):
+                    logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), out_type="unlock"))
+                    self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
+                    self.library.Plex._edit(**{f"{field_attr}.locked": 0})
+                    self.library.Plex.saveMultiEdits()
 
-            _size = len(unlock_edits.items())
-            for i, (field_attr, rating_keys) in enumerate(unlock_edits.items(), 1):
-                logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), out_type="unlock"))
-                self.library.Plex.batchMultiEdits(self.library.load_list_from_cache(rating_keys))
-                self.library.Plex._edit(**{f"{field_attr}.locked": 0})
-                self.library.Plex.saveMultiEdits()
+                for item_attr, _edits in ep_rating_edits.items():
+                    _size = len(_edits.items())
+                    for i, (new_rating, rating_keys) in enumerate(sorted(_edits.items()), 1):
+                        logger.info(get_batch_info(i, _size, item_attr, len(rating_keys), display_value=new_rating, is_episode=True))
+                        self.library.Plex.batchMultiEdits(rating_keys)
+                        self.library.Plex.editField(item_attr, new_rating)
+                        self.library.Plex.saveMultiEdits()
 
-            for item_attr, _edits in ep_rating_edits.items():
-                _size = len(_edits.items())
-                for i, (new_rating, rating_keys) in enumerate(sorted(_edits.items()), 1):
-                    logger.info(get_batch_info(i, _size, item_attr, len(rating_keys), display_value=new_rating, is_episode=True))
+                _size = len(ep_remove_edits.items())
+                for i, (field_attr, rating_keys) in enumerate(ep_remove_edits.items(), 1):
+                    logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), is_episode=True, out_type="remov"))
                     self.library.Plex.batchMultiEdits(rating_keys)
-                    self.library.Plex.editField(item_attr, new_rating)
+                    self.library.Plex.editField(field_attr, None, locked=True)
                     self.library.Plex.saveMultiEdits()
 
-            _size = len(ep_remove_edits.items())
-            for i, (field_attr, rating_keys) in enumerate(ep_remove_edits.items(), 1):
-                logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), is_episode=True, out_type="remov"))
-                self.library.Plex.batchMultiEdits(rating_keys)
-                self.library.Plex.editField(field_attr, None, locked=True)
-                self.library.Plex.saveMultiEdits()
+                _size = len(ep_reset_edits.items())
+                for i, (field_attr, rating_keys) in enumerate(ep_reset_edits.items(), 1):
+                    logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), is_episode=True, out_type="reset"))
+                    self.library.Plex.batchMultiEdits(rating_keys)
+                    self.library.Plex.editField(field_attr, None, locked=False)
+                    self.library.Plex.saveMultiEdits()
 
-            _size = len(ep_reset_edits.items())
-            for i, (field_attr, rating_keys) in enumerate(ep_reset_edits.items(), 1):
-                logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), is_episode=True, out_type="reset"))
-                self.library.Plex.batchMultiEdits(rating_keys)
-                self.library.Plex.editField(field_attr, None, locked=False)
-                self.library.Plex.saveMultiEdits()
+                _size = len(ep_lock_edits.items())
+                for i, (field_attr, rating_keys) in enumerate(ep_lock_edits.items(), 1):
+                    logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), is_episode=True, out_type="lock"))
+                    self.library.Plex.batchMultiEdits(rating_keys)
+                    self.library.Plex._edit(**{f"{field_attr}.locked": 1})
+                    self.library.Plex.saveMultiEdits()
 
-            _size = len(ep_lock_edits.items())
-            for i, (field_attr, rating_keys) in enumerate(ep_lock_edits.items(), 1):
-                logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), is_episode=True, out_type="lock"))
-                self.library.Plex.batchMultiEdits(rating_keys)
-                self.library.Plex._edit(**{f"{field_attr}.locked": 1})
-                self.library.Plex.saveMultiEdits()
+                _size = len(ep_unlock_edits.items())
+                for i, (field_attr, rating_keys) in enumerate(ep_unlock_edits.items(), 1):
+                    logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), is_episode=True, out_type="unlock"))
+                    self.library.Plex.batchMultiEdits(rating_keys)
+                    self.library.Plex._edit(**{f"{field_attr}.locked": 0})
+                    self.library.Plex.saveMultiEdits()
 
-            _size = len(ep_unlock_edits.items())
-            for i, (field_attr, rating_keys) in enumerate(ep_unlock_edits.items(), 1):
-                logger.info(get_batch_info(i, _size, field_attr, len(rating_keys), is_episode=True, out_type="unlock"))
-                self.library.Plex.batchMultiEdits(rating_keys)
-                self.library.Plex._edit(**{f"{field_attr}.locked": 0})
-                self.library.Plex.saveMultiEdits()
+                if self.library.Radarr and self.library.radarr_add_all_existing:
+                    logger.info("")
+                    logger.separator(f"Radarr Add All Existing: {len(radarr_adds)} Movies", space=False, border=False)
+                    logger.info("")
+                    try:
+                        self.library.Radarr.add_tmdb(radarr_adds)
+                    except Failed as e:
+                        logger.error(e)
 
-            if self.library.Radarr and self.library.radarr_add_all_existing:
+                if self.library.Sonarr and self.library.sonarr_add_all_existing:
+                    logger.info("")
+                    logger.separator(f"Sonarr Add All Existing: {len(sonarr_adds)} Shows", space=False, border=False)
+                    logger.info("")
+                    try:
+                        self.library.Sonarr.add_tvdb(sonarr_adds)
+                    except Failed as e:
+                        logger.error(e)
+                
                 logger.info("")
-                logger.separator(f"Radarr Add All Existing: {len(radarr_adds)} Movies", space=False, border=False)
-                logger.info("")
-                try:
-                    self.library.Radarr.add_tmdb(radarr_adds)
-                except Failed as e:
-                    logger.error(e)
-
-            if self.library.Sonarr and self.library.sonarr_add_all_existing:
-                logger.info("")
-                logger.separator(f"Sonarr Add All Existing: {len(sonarr_adds)} Shows", space=False, border=False)
-                logger.info("")
-                try:
-                    self.library.Sonarr.add_tvdb(sonarr_adds)
-                except Failed as e:
-                    logger.error(e)
+                logger.separator(f"Done with Batch {batch_num}/{num_batches}")
 
         if self.library.radarr_remove_by_tag:
             logger.info("")

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -22,8 +22,7 @@ name_display = {
     "contentRating": "Content Rating"
 }
 
-# How many library items to process at a time.
-batch_size = 100
+default_plex_bulk_edit_batch_size = 500
 
 class Operations:
     def __init__(self, config, library):
@@ -76,6 +75,7 @@ class Operations:
         logger.debug(f"Content Rating Mapper: {self.library.content_rating_mapper}")
         logger.debug(f"Metadata Backup: {self.library.metadata_backup}")
         logger.debug(f"Item Operation: {self.library.items_library_operation}")
+        logger.debug(f"Plex Bulk Edit Batch Size: {self.library.plex_bulk_edit_batch_size}")
         logger.debug("")
 
         def should_be_deleted(col_in, labels_in, configured_in, managed_in, less_in):
@@ -126,6 +126,7 @@ class Operations:
             # Get an iterable of all items and create the batch generator
             all_items = self.library.get_all()
             total_items = len(all_items)
+            batch_size = self.library.plex_bulk_edit_batch_size if self.library.plex_bulk_edit_batch_size else total_items
             batch_generator = self._get_items_in_batches(all_items, batch_size)
             
             num_batches = (total_items + batch_size - 1) // batch_size if isinstance(total_items, int) else "Unknown"


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

This PR breaks up operation handling into batches (not to be confused with plex update batches that are already done). This is done to increase reliability and performance of the operations (basically by breaking up a large chunk of work into smaller chunks). It also improves memory usage - by only keeping a batch's worth of updates in memory.

In addition, some reverse proxies reject large URLs, which can happen for a large enough number of edits.

For my very large library (10k+ movies) ratings updates would never finish (because something would cause kometa to break - reverse proxy, server instability, host instability, OOM etc). This change makes it way more reliable - I'm actually getting updates done now.

## Related Issues [optional]

- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [X] No

## Have you updated the CHANGELOG?

- [X] Yes
- [ ] No

## Sample logs

```
[INFO]     |====================================================================================================|
[INFO]     |                                      Processing Batch 1/1129                                       |
[INFO]     |====================================================================================================|
[INFO]     |                                                                                                    |
[INFO]     | (1/11288) #1 HAPPY FAMILY USA                                                                      |
... snip
[INFO]     | Batch Audience Rating Update (29/35): 5 Episodes updated to 8.4                                    |
[INFO]     | Batch Audience Rating Update (30/35): 3 Episodes updated to 8.5                                    |
[INFO]     | Batch Audience Rating Update (31/35): 2 Episodes updated to 8.6                                    |
[INFO]     | Batch Audience Rating Update (32/35): 3 Episodes updated to 8.7                                    |
[INFO]     | Batch Audience Rating Update (33/35): 2 Episodes updated to 8.8                                    |
[INFO]     | Batch Audience Rating Update (34/35): 3 Episodes updated to 9.0                                    |
[INFO]     | Batch Audience Rating Update (35/35): 1 Episode updated to 9.3                                     |
[INFO]     |                                                                                                    |
[INFO]     |====================================================================================================|
[INFO]     |                                       Done with Batch 1/1129                                       |
[INFO]     |====================================================================================================|
[INFO]     |====================================================================================================|
[INFO]     |                                      Processing Batch 2/1129                                       |
[INFO]     |====================================================================================================|
```

(Ran with `batch_size=10` just to test out)