### PR TITLE
Golden Globe category name updates for award and ribbon Defaults

### DIFF
--- a/defaults/award/golden.yml
+++ b/defaults/award/golden.yml
@@ -28,6 +28,11 @@ collections:
       event_id: ev0000292
       event_year: all
       category_filter:
+        - best animated feature film
+        - best animated film
+        - best foreign film
+        - best foreign language film
+        - best foreign-language foreign film
         - best motion picture - animated
         - best motion picture - comedy
         - best motion picture - comedy or musical
@@ -37,6 +42,7 @@ collections:
         - best motion picture - musical or comedy
         - best motion picture - non-english language
         - best motion picture, musical or comedy
+        - best picture
       winning: true
 
   Golden Globes Best Director Winners:

--- a/defaults/overlays/ribbon.yml
+++ b/defaults/overlays/ribbon.yml
@@ -78,6 +78,11 @@ overlays:
       event_id: ev0000292
       event_year: all
       category_filter:
+        - best animated feature film
+        - best animated film
+        - best foreign film
+        - best foreign language film
+        - best foreign-language foreign film
         - best motion picture - animated
         - best motion picture - comedy
         - best motion picture - comedy or musical
@@ -86,10 +91,8 @@ overlays:
         - best motion picture - musical
         - best motion picture - musical or comedy
         - best motion picture - non-english language
-        - best motion picture, animated
-        - best motion picture, drama
         - best motion picture, musical or comedy
-        - best motion picture, non-english language
+        - best picture
       winning: true
 
   Golden Globe Best Director:
@@ -101,7 +104,6 @@ overlays:
       category_filter:
         - best director
         - best director - motion picture
-        - best director, motion picture
       winning: true
 
   BAFTA Winners:


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

Updated the category filters for:
Award Default: Golden Globe Winner
Ribbon Default: Golden Globe Winner
Ribbon Default: Golden Globe Director

I used [this summary](https://en.wikipedia.org/wiki/Golden_Globe_Awards#Motion_picture_awards) from Wikipedia as a baseline of the categories and years, then tried to map it to the [event validation file](https://github.com/Kometa-Team/IMDb-Awards/blob/master/event_validation.yml#L3193) in the IMDb-Awards repo. Sorry for the wall of text that follows, but just wanted to show my work in case someone has a different take on this.

**Golden Globe Winner:**

Best Motion Picture – Drama: since 1943 (separated genre in 1951)
  - best motion picture - drama # 75 Events: 1951-2025
  - best picture # 7 Events: 1944-1950

Best Motion Picture – Musical or Comedy: since 1951
  - best motion picture - comedy # 5 Events: 1959-1963
  - best motion picture - comedy or musical # 59 Events: 1952-1953, 1955-1958, 1964-2016
  - best motion picture - musical # 5 Events: 1959-1963
  - best motion picture - musical or comedy # 8 Events: 2017-2023, 2025
  - best motion picture, musical or comedy # 1 Event: 2024

Best Motion Picture – Animated: since 2006
  - best animated feature film # 5 Events: 2010, 2012-2015
  - best animated film # 4 Events: 2007-2009, 2011
  - best motion picture - animated # 10 Events: 2016-2025

Best Motion Picture – Foreign Language: since 1948
  - best foreign film # 20 Events: 1949-1950, 1955-1956, 1960, 1963-1964, 1974-1986
  - best foreign language film # 29 Events: 1987-2015
  - best foreign-language foreign film # 14 Events: 1957-1959, 1961-1962, 1965-1973
  - best motion picture - foreign language # 6 Events: 2016-2021
  - best motion picture - non-english language # 4 Events: 2022-2025

**Golden Globe Director:**

Best Director – Motion Picture: since 1943
  - best director - motion picture # 54 Events: 1972-2025
  - best director # 28 Events: 1944-1971


## Related Issues

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, GitHub will automatically close the issue.
-->
- Closes #2860 

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [X] No

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [X] No
