### PR TITLE
Correct case of Crunchyroll streaming overlay key

### DIFF
--- a/docs/defaults/overlays/streaming.md
+++ b/docs/defaults/overlays/streaming.md
@@ -15,7 +15,7 @@ hide:
 | Prime Video     | `amazon`      | `150` |
 | Disney+         | `disney`      | `140` |
 | HBO Max         | `hbomax`      | `130` |
-| Crunchyroll     | `Crunchyroll` | `120` |
+| Crunchyroll     | `crunchyroll` | `120` |
 | Movistar Plus+  | `movistar`    | `115` |
 | Atres Player    | `atresplayer` | `113` |
 | YouTube         | `youtube`     | `110` |


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [X] Documentation Update
- [ ] Other 

## Description

The correct key for the Crunchyroll streaming overlay should be `crunchyroll` (lowercase "c"): [streaming.yml](https://github.com/Kometa-Team/Kometa/blob/nightly/defaults/overlays/streaming.yml#L143)


## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [X] No