### PR TITLE
Document limitations of Quickstart in quickstart.md

### DIFF
--- a/docs/kometa/scripts/quickstart.md
+++ b/docs/kometa/scripts/quickstart.md
@@ -11,6 +11,9 @@ hide:
     
     Notably, template variables on the default collections are not available, so you cannot generally modify the behavior of the default collections within Quickstart.
 
+    Quickstart also does not provide any support for manipulating external YAML files like collection, overlay, and metadata files.
+    
+
 {%
   include-markdown "https://raw.githubusercontent.com/Kometa-Team/Quickstart/refs/heads/develop/README.md"
   comments=false

--- a/docs/kometa/scripts/quickstart.md
+++ b/docs/kometa/scripts/quickstart.md
@@ -7,6 +7,10 @@ hide:
     **Quickstart is in early development.** Please provide feedback via the 
     [quickstart-feedback Discord channel](https://discord.com/channels/822460010649878528/1335372922306695198)
 
+    Quickstart is incomplete in that it does not expose every possible setting in `config.yml`.
+    
+    Notably, template variables on the default collections are not available, so you cannot generally modify the behavior of the default collections within Quickstart.
+
 {%
   include-markdown "https://raw.githubusercontent.com/Kometa-Team/Quickstart/refs/heads/develop/README.md"
   comments=false


### PR DESCRIPTION
Added notes about Quickstart's limitations regarding config.yml settings and template variables.

<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [X] Documentation Update
- [ ] Other 

## Description

Adds more words about things QS cannot do to hopefully forestall Discord questions about "how do I do <thing-qs-cannot-do> is Quickstart"?


## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [X] No

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [X] No
