### PR TITLE
New option `auto_sort_hub` to sort Recommendation Hubs by sort title

### DIFF
--- a/config/config.yml.template
+++ b/config/config.yml.template
@@ -76,6 +76,7 @@ settings:
   default_collection_order: release
   delete_below_minimum: true
   delete_not_scheduled: false
+  auto_sort_hubs: false
   run_again_delay: 2
   missing_only_released: false
   only_filter_missing: false

--- a/docs/config/settings.md
+++ b/docs/config/settings.md
@@ -136,6 +136,26 @@ The available setting attributes which can be set at each level are outlined bel
           asset_folders: true
         ```
 
+??? blank "`auto_sort_hubs` - Used to automatically sort Plex Recommendation Hubs by sort title order.<a class="headerlink" href="#auto-sort-hubs" title="Permanent link">¶</a>"
+
+    <div id="auto-sort-hubs" />When enabled, Kometa will automatically sort Plex Recommendation Hubs based on the sort titles of the collections within each library.
+
+    This will mirror the order of how collections are displayed within the Plex library view. Only collections that are marked as visible in Plex will be sorted.
+
+    **Attribute:** `auto_sort_hubs`
+
+    **Levels with this Attribute:** Global/Library
+
+    **Accepted Values:** `true` or `false`.
+
+    **Default Value:** `false`
+
+    ???+ example "Example"
+
+        ```yaml
+        settings:
+          auto_sort_hubs: true
+        ```
 
 ??? blank "`cache` - Used to control Kometa's cache database.<a class="headerlink" href="#cache" title="Permanent link">¶</a>"
 

--- a/docs/kometa/install/walkthroughs/kubernetes.md
+++ b/docs/kometa/install/walkthroughs/kubernetes.md
@@ -146,6 +146,7 @@ data:
       default_collection_order:
       delete_below_minimum: true
       delete_not_scheduled: false
+      auto_sort_hubs: false
       run_again_delay: 2
       missing_only_released: false
       only_filter_missing: false

--- a/json-schema/config-schema.json
+++ b/json-schema/config-schema.json
@@ -775,6 +775,10 @@
                     "description": "Used to delete collections not scheduled.\nIf a collection is skipped due to it not being scheduled, delete the collection.",
                     "type": "boolean"
                 },
+                "auto_sort_hubs": {
+                    "description": "Used to automatically sort Plex recommendation hubs after collections are updated, mirroring the sort title order.",
+                    "type": "boolean"
+                },
                 "run_again_delay": {
                     "description": "Used to control the number of minutes to delay running run_again collections.\nSet the number of minutes to delay running run_again collections after daily run is finished. For example, if a collection adds items to Sonarr/Radarr, the library can automatically re-run 'X' amount of time later so that any downloaded items are processed.",
                     "type": "integer",

--- a/json-schema/kitchen_sink_config.yml
+++ b/json-schema/kitchen_sink_config.yml
@@ -819,6 +819,7 @@ settings:                                           # Can be individually specif
   minimum_items: 1
   delete_below_minimum: true
   delete_not_scheduled: false
+  auto_sort_hubs: false
   run_again_delay: 1
   missing_only_released: true
   show_unconfigured: true

--- a/json-schema/prototype_config.yml
+++ b/json-schema/prototype_config.yml
@@ -426,6 +426,7 @@ settings:
   default_collection_order: release
   delete_below_minimum: true
   delete_not_scheduled: false
+  auto_sort_hubs: false
   run_again_delay: 2
   missing_only_released: false
   only_filter_missing: false

--- a/kometa.py
+++ b/kometa.py
@@ -651,6 +651,7 @@ def run_libraries(config):
             logger.debug(f"Delete Below Minimum: {library.delete_below_minimum}")
             logger.debug(f"Delete Not Scheduled: {library.delete_not_scheduled}")
             logger.debug(f"Default Collection Order: {library.default_collection_order}")
+            logger.debug(f"Auto-Sort Hubs: {library.auto_sort_hubs}")
             logger.debug(f"Missing Only Released: {library.missing_only_released}")
             logger.debug(f"Only Filter Missing: {library.only_filter_missing}")
             logger.debug(f"Show Unmanaged: {library.show_unmanaged}")
@@ -977,6 +978,10 @@ def run_collection(config, library, metadata, requested_collections):
         logger.info("")
         logger.separator(f"Finished {mapping_name} Collection\nCollection Run Time: {collection_run_time}")
         #logger.remove_collection_handler(library.mapping_name, collection_log_name)
+
+    # Once all collections have been modified as needed, sort all the visible collection hubs if needed
+    if library.auto_sort_hubs:
+        library.sort_collection_hubs_by_sort_title()
 
 def run_playlists(config):
     stats = {"created": 0, "modified": 0, "deleted": 0, "added": 0, "unchanged": 0, "removed": 0, "radarr": 0, "sonarr": 0, "names": []}

--- a/modules/config.py
+++ b/modules/config.py
@@ -492,6 +492,7 @@ class ConfigFile:
             "item_refresh_delay": check_for_attribute(self.data, "item_refresh_delay", parent="settings", var_type="int", default=0),
             "delete_below_minimum": check_for_attribute(self.data, "delete_below_minimum", parent="settings", var_type="bool", default=False),
             "delete_not_scheduled": check_for_attribute(self.data, "delete_not_scheduled", parent="settings", var_type="bool", default=False),
+            "auto_sort_hubs": check_for_attribute(self.data, "auto_sort_hubs", parent="settings", var_type="bool", default=False),
             "run_again_delay": check_for_attribute(self.data, "run_again_delay", parent="settings", var_type="int", default=0),
             "missing_only_released": check_for_attribute(self.data, "missing_only_released", parent="settings", var_type="bool", default=False),
             "only_filter_missing": check_for_attribute(self.data, "only_filter_missing", parent="settings", var_type="bool", default=False),
@@ -912,6 +913,7 @@ class ConfigFile:
                 params["item_refresh_delay"] = check_for_attribute(lib, "item_refresh_delay", parent="settings", var_type="int", default=self.general["item_refresh_delay"], do_print=False, save=False)
                 params["delete_below_minimum"] = check_for_attribute(lib, "delete_below_minimum", parent="settings", var_type="bool", default=self.general["delete_below_minimum"], do_print=False, save=False)
                 params["delete_not_scheduled"] = check_for_attribute(lib, "delete_not_scheduled", parent="settings", var_type="bool", default=self.general["delete_not_scheduled"], do_print=False, save=False)
+                params["auto_sort_hubs"] = check_for_attribute(lib, "auto_sort_hubs", parent="settings", var_type="bool", default=self.general["auto_sort_hubs"], do_print=False, save=False)
                 params["ignore_ids"] = check_for_attribute(lib, "ignore_ids", parent="settings", var_type="int_list", default_is_none=True, do_print=False, save=False)
                 params["ignore_ids"].extend([i for i in self.general["ignore_ids"] if i not in params["ignore_ids"]])
                 params["ignore_imdb_ids"] = check_for_attribute(lib, "ignore_imdb_ids", parent="settings", var_type="lower_list", default_is_none=True, do_print=False, save=False)

--- a/modules/library.py
+++ b/modules/library.py
@@ -91,6 +91,7 @@ class Library(ABC):
         self.assets_for_all = params["assets_for_all"]
         self.assets_for_all_collections = params["assets_for_all_collections"]
         self.delete_collections = params["delete_collections"]
+        self.auto_sort_hubs = params["auto_sort_hubs"]
         self.mass_studio_update = params["mass_studio_update"]
         self.mass_genre_update = params["mass_genre_update"]
         self.mass_audience_rating_update = params["mass_audience_rating_update"]


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

I rely on sort titles prefixed with special characters (e.g. `_`, `+` and `-`) to arrange the order of collections on the Collections tab in each library opaquely (independent of the visible collection name). For example, I put "trending" collections above "genre" collections above "studio" collections, etc.

It annoys me, however, that the Recommendation Hubs (the rows on the home screen and Recommendation tabs in each library) don't automatically respect the sort titles. Instead, if a new collection is generated, it's automatically placed at the bottom of the list, and I have to manually go in and drag the listing to its proper location.

For me, I generally want the Recommendation Hubs to mirror the order of the collections via sort titles. Therefore, I've introduced a new optional setting that will do just that: automatically rearrange all (visible) collections in the Recommendation Hubs listing so that it matches the sort title order.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, GitHub will automatically close the issue.
-->
N/A

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [x] Yes
- [ ] No

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [x] No
