### PR TITLE
Fixed missing seasonal anime for MyAnimeList

### DIFF
--- a/modules/mal.py
+++ b/modules/mal.py
@@ -229,7 +229,7 @@ class MyAnimeList:
         return self._parse_request(url)
 
     def _season(self, data):
-        url = f"{urls['season']}/{data['year']}/{data['season']}?sort={data['sort_by']}&limit=500"
+        url = f"{urls['season']}/{data['year']}/{data['season']}?sort={data['sort_by']}&limit=500&nsfw=true"
         if data["starting_only"]:
             url += "&fields=start_season"
         results = []


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

Add `nsfw=true` to MyAnimeList API call to fix missing anime issue.

See [this comment](https://myanimelist.net/forum/?goto=post&topicid=2247862&id=73685128). I already tried this and it seems to work for Dusk Beyond the End of the World (Towa no Yuugure) which is missing without this change.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [x] No

## Have you updated the CHANGELOG?

- [ ] Yes
- [x] No
