### PR TITLE
Collection batching

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ Reciperr site hasn't responded for a while, so the builder has been removed.
 Added spellcheck to precommit configuration
 Added `language` parameter to `mass_poster_update` and `mass_background_update` operations to override TMDb language for image fetching (e.g. `xx` for textless posters)
 Report deactivated Trakt accounts [Trakt returns a 410]
+Process collection alterations [add/remove] in batches of 100 to avoid "400 Bad Request" on mile-long URLs.
 
 # Docs
 Updates to Quickstart docs about limitations

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1249,9 +1249,13 @@ class Plex(Library):
         else:
             locked_items = items
 
+        batch_size = 100
+        total_sent = 0
         for _items, locked in [(locked_items, True), (unlocked_items, False)]:
-            if _items:
-                self.Plex.batchMultiEdits(_items)
+            for i in range(0, len(_items), batch_size) if _items else []:
+                chunk = _items[i : i + batch_size]
+                logger.ghost(f"{'Adding' if add else 'Removing'} {len(chunk)} items [{total_sent} so far] to{' smart label' if smart_label_collection else ''} collection: {collection.title()} (Locked: {locked})")
+                self.Plex.batchMultiEdits(chunk)
                 if smart_label_collection:
                     self.query_data(self.Plex.addLabel if add else self.Plex.removeLabel, collection)
                 elif add:
@@ -1259,6 +1263,8 @@ class Plex(Library):
                 else:
                     self.Plex.removeCollection(collection, locked=locked)
                 self.Plex.saveMultiEdits()
+                total_sent += len(chunk)
+            logger.exorcise()
 
     def move_item(self, collection, item, after=None):
         key = f"{collection.key}/items/{item}/move"


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

Items were added to collection with a single call, which in the case of large collections, would result in a 400 error because of the mile-long URL.

Now those high-item-count operations are batched like the operations.

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [X] No need

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
