### PR TITLE
Fix Letterboxd list/watchlist parser for LazyPoster markup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,7 +28,7 @@ Updates to Trakt and MAL flow pages
 # Defaults
 
 # Bug Fixes
-Update Letterboxd list/watchlist parser for the React-based `LazyPoster` markup that replaced `data-film-id`/`data-target-link` nodes, restoring collections built from `letterboxd_list` and `letterboxd_user_films`/`letterboxd_user_reviews` on watchlists and user lists.
+Update Letterboxd list/watchlist parser for the React-based `LazyPoster` markup, which replaced the `data-film-id` nodes the `letterboxd_list`, `letterboxd_user_films`, and `letterboxd_user_reviews` builders relied on.
 Catch KeyError on Plex NFO build.
 Fixing "list index out of range" error when processing imdb charts #3006
 TMDB language now reflected in mass_poster_update; cache extension

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,7 @@ Updates to Trakt and MAL flow pages
 # Defaults
 
 # Bug Fixes
+Update Letterboxd list/watchlist parser for the React-based `LazyPoster` markup that replaced `data-film-id`/`data-target-link` nodes, restoring collections built from `letterboxd_list` and `letterboxd_user_films`/`letterboxd_user_reviews` on watchlists and user lists.
 Catch KeyError on Plex NFO build.
 Fixing "list index out of range" error when processing imdb charts #3006
 TMDB language now reflected in mass_poster_update; cache extension

--- a/modules/letterboxd.py
+++ b/modules/letterboxd.py
@@ -33,6 +33,45 @@ user_sort_options = {
 builders = ["letterboxd_list", "letterboxd_list_details", "letterboxd_user_films", "letterboxd_user_films_details", "letterboxd_user_reviews", "letterboxd_user_reviews_details"]
 base_url = "https://letterboxd.com"
 
+# Letterboxd migrated list/watchlist pages to a React-based "LazyPoster"
+# component in April 2026. Films are now nodes like:
+#   <div class="react-component" data-component-class="LazyPoster"
+#        data-item-slug="interstellar" data-item-link="/film/interstellar/"
+#        data-item-name="Interstellar (2014)"
+#        data-postered-identifier='{"lid":"4VZ8","uid":"film:117621","type":"film",...}' ...>
+# The numeric film id is embedded in the data-postered-identifier JSON as
+# uid="film:<ID>"; extracting it here keeps existing letterboxd_map cache
+# rows (keyed by the same numeric id) compatible.
+_item_id_re = re.compile(r'"uid"\s*:\s*"film:(\d+)"')
+_item_year_re = re.compile(r"\((\d{4})\)\s*$")
+
+
+def _item_from_element(element):
+    """Extract (letterboxd_id, slug, year) from a new-style LazyPoster div.
+    Returns (None, None, None) if required fields are missing; callers skip those."""
+    slug = element.get("data-item-link")
+    if not slug:
+        # Fallback: some older pages use data-target-link on the same element.
+        target = element.xpath("@data-target-link")
+        slug = target[0] if target else None
+    if not slug:
+        return None, None, None
+    letterboxd_id = None
+    pid = element.get("data-postered-identifier") or ""
+    if pid:
+        m = _item_id_re.search(pid)
+        if m:
+            letterboxd_id = m.group(1)
+    if not letterboxd_id:
+        return None, None, None
+    year = None
+    name = element.get("data-item-name") or ""
+    if name:
+        m = _item_year_re.search(name)
+        if m:
+            year = int(m.group(1))
+    return letterboxd_id, slug, year
+
 class Letterboxd:
     def __init__(self, requests, cache=None):
         self.requests = requests
@@ -47,22 +86,16 @@ class Letterboxd:
         if "ajax" not in list_url:
             list_url = list_url.replace("https://letterboxd.com/films", "https://letterboxd.com/films/ajax")
         response = self._request(list_url, language)
-        letterboxd_elements = response.xpath("//div[@data-film-id]")
+        # New LazyPoster markup (post-April-2026 migration) — see module-level
+        # notes above. Ratings/notes are no longer nearby siblings on list and
+        # watchlist pages, so those fields are left as None.
+        letterboxd_elements = response.xpath("//div[@data-item-slug]")
         items = []
         for letterboxd_element in letterboxd_elements:
-            slug = letterboxd_element.xpath("@data-target-link")[0]
-            letterboxd_id = letterboxd_element.xpath("@data-film-id")[0]
-            comments = letterboxd_element.xpath("parent::article/div[@class='body']/div/p/text()")
-            ratings = letterboxd_element.xpath("parent::article/div[@class='body']/div/span/@class")
-            if not ratings:
-                ratings = letterboxd_element.xpath("parent::li/p/span[contains(@class, 'rating')]/@class")
-            years = letterboxd_element.xpath("parent::article/div[@class='body']/div/header/span/span/a/text()")
-            rating = None
-            if ratings:
-                match = re.search("rated-(\\d+)", ratings[0])
-                if match:
-                    rating = int(match.group(1))
-            items.append((letterboxd_id, slug, int(years[0]) if years else None, comments[0] if comments else None, rating))
+            letterboxd_id, slug, year = _item_from_element(letterboxd_element)
+            if not letterboxd_id or not slug:
+                continue
+            items.append((letterboxd_id, slug, year, None, None))
         next_url = response.xpath("//a[@class='next']/@href")
         return items, next_url
 
@@ -79,36 +112,24 @@ class Letterboxd:
     def _parse_user_page(self, page_url, language):
         # User pages don't use /ajax/ endpoints, use regular URL
         response = self._request(page_url, language)
-        letterboxd_elements = response.xpath("//div[@data-film-id]")
+        # New LazyPoster markup — see module-level notes. Rating/note data is
+        # no longer carried on a sibling/parent of the item on list/watchlist
+        # pages; when_added is best-effort from a nearby <time datetime=...>.
+        letterboxd_elements = response.xpath("//div[@data-item-slug]")
         items = []
         for letterboxd_element in letterboxd_elements:
-            slug_list = letterboxd_element.xpath("@data-target-link")
-            letterboxd_id_list = letterboxd_element.xpath("@data-film-id")
-            if not slug_list or not letterboxd_id_list:
+            letterboxd_id, slug, year = _item_from_element(letterboxd_element)
+            if not letterboxd_id or not slug:
                 continue
-            slug = slug_list[0]
-            letterboxd_id = letterboxd_id_list[0]
-            comments = letterboxd_element.xpath(f"parent::article/div[@class='body']/div/p/text()")
-            ratings = letterboxd_element.xpath("parent::article/div[@class='body']/div/span/@class")
-            if not ratings:
-                ratings = letterboxd_element.xpath("parent::li/p/span[contains(@class, 'rating')]/@class")
-            years = letterboxd_element.xpath(f"parent::article/div[@class='body']/div/header/span/span/a/text()")
-            # Try to extract when_added date from data attributes or text
             when_added = None
             date_attrs = letterboxd_element.xpath("@data-added-date")
-            if not date_attrs:
-                # Try to find date in nearby elements
-                date_text = letterboxd_element.xpath("parent::article//time/@datetime")
+            if date_attrs:
+                when_added = date_attrs[0]
+            else:
+                date_text = letterboxd_element.xpath("ancestor::*[self::li or self::article][1]//time/@datetime")
                 if date_text:
                     when_added = date_text[0]
-            else:
-                when_added = date_attrs[0]
-            rating = None
-            if ratings:
-                match = re.search("rated-(\\d+)", ratings[0])
-                if match:
-                    rating = int(match.group(1))
-            items.append((letterboxd_id, slug, int(years[0]) if years else None, comments[0] if comments else None, rating, when_added))
+            items.append((letterboxd_id, slug, year, None, None, when_added))
         next_url = response.xpath("//a[@class='next']/@href")
         return items, next_url
 


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)

## Description

Letterboxd migrated list and watchlist pages to a React-based `LazyPoster` component in April 2026. The `<div data-film-id="...">` nodes `modules/letterboxd.py` matches no longer exist; film data is now on:

```html
<div class="react-component"
     data-component-class="LazyPoster"
     data-item-slug="interstellar"
     data-item-link="/film/interstellar/"
     data-item-name="Interstellar (2014)"
     data-postered-identifier='{"lid":"4VZ8","uid":"film:117621","type":"film","typeName":"film"}'
     ...>
```

As a result every `letterboxd_list` / `letterboxd_user_films` / `letterboxd_user_reviews` / watchlist builder fails with `Letterboxd Error: No List Items found in {...}` during `get_tmdb_ids`, and emits `returned no items during validation` in `validate_letterboxd_lists`.

This PR updates `_parse_page` and `_parse_user_page` to match the new element via `//div[@data-item-slug]` and extract:

- **slug** from `data-item-link` (falls back to the legacy `data-target-link`, which still appears on the same element)
- **numeric film id** from the `data-postered-identifier` JSON (`uid: "film:<id>"`). The id format is identical to the old `data-film-id` value, so existing `letterboxd_map` cache rows keep matching — no forced re-scrape of TMDb IDs on upgrade
- **year** via regex from `data-item-name` (e.g. `"Interstellar (2014)"`)

Rating / note are left as `None` on list and watchlist items — the new poster markup has no `<article>` ancestor (watchlist items sit inside `<li class="griditem">`, list items inside `<li class="posteritem numbered-list-item">`), so the legacy sibling xpaths for those fields match nothing. Restoring them depends on the diary / `/<user>/films/` pages, which are currently returning `403 Forbidden` even through `cloudscraper` (the underlying problem behind #3054). That is a transport-level issue and warrants a separate pass.

`_tmdb()` is unchanged — `/film/<slug>/` pages still expose `data-track-action="TMDb"` when fetched via `cloudscraper`, and the existing xpath resolves correctly.

### Testing

Exercised `_parse_list` against six real URLs inside a running Kometa 2.3.1.4 (Docker master) container after swapping in the patched `modules/letterboxd.py`. Before the fix, all six return 0 items with `No List Items found`. After:

| URL shape | Items before | Items after | First item |
|---|---:|---:|---|
| `/<user>/watchlist/` | 0 | 159 | `id=41361 year=1979 /film/all-that-jazz/` |
| `/ellefnning/list/for-when-you-want-to-feel-something/` | 0 | 186 | `id=730798 year=2022 /film/cha-cha-real-smooth/` |
| `/cinemaparadisa/list/comfort-movies/` | 0 | 183 | `id=95113 year=2014 /film/the-grand-budapest-hotel/` |
| `/official/list/top-250-films-with-the-most-fans/` | 0 | 250 | `id=117621 year=2014 /film/interstellar/` |
| `/dave/list/imdb-top-250/` | 0 | 250 | `id=51778 year=1994 /film/the-shawshank-redemption/` |
| `/alexanderh/list/letterboxd-one-million-watched-club/` | 0 | 748 | `id=636761 year=2023 /film/evil-dead-rise/` |

Cache-compat spot check: `id=51778` for Shawshank matches the value historically stored under `data-film-id` in the old markup, so existing `letterboxd_map` rows keyed on that id remain valid.

## Related Issues [optional]

- Related Issue #3054 — same family of breakage. This PR fixes the parser-level manifestation affecting `/<user>/list/` and `/<user>/watchlist/`. The original `/films/popular/this/week/` scenario in #3054 is still `403 Forbidden` through `cloudscraper`, so this PR is **not** a full close of that issue.

## Have you updated the Documentation to reflect changes (if necessary)?

- [x] No (internal parser change; user-facing docs remain accurate)

## Have you updated the CHANGELOG?

- [x] Yes
