### PR TITLE
Hide traceback errors for "known good" errors

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -409,6 +409,7 @@ tomatoesaudience
 tomatometer
 tooltip
 tooltips
+traceback
 trakt
 trakt's
 transcoded

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -86,3 +86,4 @@ Fix `mass_imdb_parental_labels` crash when IMDb GraphQL returns `null` for the t
 Addresses edge case where missing `settings:minimum_items` would make Kometa redact `1` in the log.
 Update Letterbox URL parsing to handle unlisted lists and shuffle argument in the url
 Fix an issue where tvdb_to_imdb writes wrong IMDb ID when TVDb movie ID collides with a TVDb series ID
+Hide some traceback errors for "known good" errors that don't really need a trace

--- a/modules/logs.py
+++ b/modules/logs.py
@@ -25,6 +25,12 @@ INFO = 20
 DEBUG = 10
 TRACE = 0
 
+SUPPRESS_STACKTRACE_PATTERNS = [
+    r"Plex Error: .* not found",
+    r"No matches found with regex pattern",
+    r"No Items found in Plex",
+]
+
 
 def fmt_filter(record):
     record.levelname = f"[{record.levelname}]"
@@ -218,7 +224,17 @@ class MyLogger:
             self._log(CRITICAL, str(msg), args, **kwargs)
 
     def stacktrace(self, trace=False):
-        self.print(traceback.format_exc(), debug=not trace, trace=trace)
+        stack = traceback.format_exc()
+
+        suppress_stacktrace_patterns = [
+            r"Plex Error: .* not found",
+            r"No matches found with regex pattern",
+        ]
+
+        if any(re.search(pattern, stack) for pattern in suppress_stacktrace_patterns):
+            return
+
+        self.print(stack, debug=not trace, trace=trace)
 
     def _space(self, display_title):
         display_title = str(display_title)

--- a/modules/logs.py
+++ b/modules/logs.py
@@ -229,6 +229,7 @@ class MyLogger:
         suppress_stacktrace_patterns = [
             r"Plex Error: .* not found",
             r"No matches found with regex pattern",
+            r"Plex Error: No Items found in Plex"
         ]
 
         if any(re.search(pattern, stack) for pattern in suppress_stacktrace_patterns):


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [X] Other 

## Description

This PR hides the stacktrace errors that accompany some "known ok" error messages that don't really warrant stacktraces such as:

```
Plex Error: genre: Documentary not found
No matches found with regex pattern
Plex Error: No Items found in Plex
```

The errors will still appear, but will not have stacktaces before them:

```
|=============================== Validating Documentaries Attributes ================================|
|                                                                                                    |
| Looking for: Documentaries                                                                         |
|                                                                                                    |
| Validating Method: plex_search                                                                     |
| Value: {'all': {'genre': 'Documentary'}}                                                           |
| Plex Error: genre: Documentary not found                                                           |
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, GitHub will automatically close the issue.
-->
- Related Issue #
- Closes #2937

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [X] No

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
