### PR TITLE
fix: imdb_watchlist now accepts new p.xxxxxxx user ID format

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -470,6 +470,7 @@ wolof
 www
 xmark
 xmen
+xxxxxxx
 xyz
 yaml
 yml

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -88,3 +88,4 @@ Update Letterbox URL parsing to handle unlisted lists and shuffle argument in th
 Fix an issue where tvdb_to_imdb writes wrong IMDb ID when TVDb movie ID collides with a TVDb series ID
 Hide some traceback errors for "known good" errors that don't really need a trace
 Fix `imdb_awards` failing when any one of the `award_filters` or `category_filters` do not exist, this will now produce a warning and the builder will only fail if all of the `award_filters` or all of the `category_filters` does not exist.
+Fix imdb_watchlist rejecting new IMDb user ID format (p.xxxxxxx). Now accepts both ur######## (legacy) and p.xxxxxxx formats, as a bare ID or full watchlist URL.

--- a/docs/files/builders/imdb/watchlist.md
+++ b/docs/files/builders/imdb/watchlist.md
@@ -8,7 +8,7 @@ Finds every item in an IMDb User's Watchlist.
 
 | List Parameter | Description                                                                                                                                                                                                                                                                                                                                   |
 |:---------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `user_id`      | Specify the User ID for the IMDb Watchlist. **This attribute is required.**<br>**Options:** The ID that starts with `ur` found in the URL of the watchlist. (ex. `ur12345678`)                                                                                                                                                                |
+| `user_id`      | Specify the User ID for the IMDb Watchlist. **This attribute is required.**<br>**Options:** The `ur########` ID (legacy format) or the `p.xxxxxxx` ID (new format) found in the URL of the watchlist, or a full watchlist URL. (ex. `ur12345678`, `p.fl6ssgsolkgcctcuxapgh6chsa`, or `https://www.imdb.com/user/p.fl6ssgsolkgcctcuxapgh6chsa/watchlist`) |
 | `limit`        | Specify how items you want returned by the query.<br>**Options:** Any Integer `0` or greater where `0` get all items.<br>**Default:** `0`                                                                                                                                                                                                     |
 | `sort_by`      | Choose from one of the many available sort options.<br>**Options:** `custom.asc`, `custom.desc`, `title.asc`, `title.desc`, `rating.asc`, `rating.desc`, `popularity.asc`, `popularity.desc`, `votes.asc`, `votes.desc`, `release.asc`, `release.desc`, `runtime.asc`, `runtime.desc`, `added.asc`, `added.desc`<br>**Default:** `custom.asc` |
 
@@ -35,7 +35,7 @@ collections:
       - user_id: ur64054558
         sort_by: rating.asc
         limit: 100
-      - user_id: ur12345678
+      - user_id: p.fl6ssgsolkgcctcuxapgh6chsa
         sort_by: rating.asc
         limit: 100
     sync_mode: sync

--- a/modules/imdb.py
+++ b/modules/imdb.py
@@ -462,14 +462,20 @@ class IMDb:
                         raise Failed(f"IMDb Error: {method} {main} must begin with ls (ex. ls005526372)")
                     new_dict = {main: search.group(1)}
                 else:
+                    # Extract user ID from a full watchlist URL (handles both ur### and p. formats)
+                    url_match = re.search(r"imdb\.com/user/([^/?#]+)", main_data)
+                    if url_match:
+                        main_data = url_match.group(1)
                     user_id = None
                     if main_data.startswith("ur"):
                         try:
                             user_id = int(main_data[2:])
                         except ValueError:
                             pass
+                    elif re.match(r"^p\.[A-Za-z0-9_-]+$", main_data):
+                        user_id = main_data  # p. format: pass through as-is to the GraphQL API
                     if not user_id:
-                        raise Failed(f"{err_type} Error: {method} {main}: {main_data} not in the format of 'ur########'")
+                        raise Failed(f"{err_type} Error: {method} {main}: {main_data} must be in the format 'ur########' or 'p.xxxxxxx' (or a full watchlist URL)")
                     new_dict = {main: main_data}
 
             if "limit" in dict_methods:
@@ -618,7 +624,21 @@ class IMDb:
         op, sha = self._json_operation(list_type)
         return {"operationName": op, "variables": out, "extensions": {"persistedQuery": {"version": 1, "sha256Hash": sha}}}
 
+    def _resolve_profile_id(self, profile_id):
+        """Resolve an IMDb p.xxxxxxx profileId to its internal ur### userId via the GraphQL userProfile query."""
+        logger.debug(f"IMDb: Resolving p. profileId '{profile_id}' to ur userId")
+        response = self._graph_request({"query": f'{{ userProfile(input: {{profileId: "{profile_id}"}}) {{ userId }} }}'})
+        if "errors" in response:
+            raise Failed(f"IMDb Error: Could not resolve watchlist profileId '{profile_id}': {response['errors'][0]['message']}")
+        user_id = response.get("data", {}).get("userProfile", {}).get("userId")
+        if not user_id:
+            raise Failed(f"IMDb Error: No IMDb account found for profileId '{profile_id}'")
+        logger.debug(f"IMDb: Resolved profileId '{profile_id}' -> userId '{user_id}'")
+        return user_id
+
     def _pagination(self, data, list_type):
+        if list_type == "watchlist" and re.match(r"^p\.", data["user_id"]):
+            data = {**data, "user_id": self._resolve_profile_id(data["user_id"])}
         is_list = list_type != "search"
         json_obj = self._graphql_json(data, list_type)
         item_count = 100 if is_list else 250
@@ -640,6 +660,13 @@ class IMDb:
                 logger.trace(response_json["errors"])
                 raise Failed(f"IMDb Error: {response_json['errors'][0]['message']}")
         step = "list" if list_type == "list" else "predefinedList"
+        if list_type == "watchlist" and response_json["data"].get("predefinedList") is None:
+            user_id = data["user_id"]
+            raise Failed(
+                f"IMDb Error: No public watchlist found for user '{user_id}'. "
+                f"Ensure the watchlist exists and is set to public. "
+                f"If your config uses a ur### ID, update it to the p.xxxxxxx format shown in your watchlist URL at imdb.com."
+            )
         search_data = response_json["data"][step]["titleListItemSearch"] if is_list else response_json["data"]["advancedTitleSearch"]
         total = search_data["total"]
         limit = data["limit"]

--- a/tests/test_imdb.py
+++ b/tests/test_imdb.py
@@ -148,3 +148,62 @@ def test_parental_guide_empty_categories_raises_failed():
     imdb = make_imdb(graph_response=graph_response)
     with pytest.raises(Failed, match="No Parental Guide Found"):
         imdb.parental_guide("tt0000000")
+
+
+# ---------------------------------------------------------------------------
+# validate_imdb: imdb_watchlist user ID format support (#3091)
+#
+# IMDb stopped showing ur######## IDs in their UI. Users now see p.xxxxxxx
+# in watchlist URLs. These tests cover both formats as bare IDs and full URLs.
+# ---------------------------------------------------------------------------
+
+class TestValidateImdbWatchlist:
+
+    def _imdb(self):
+        return make_imdb(graph_response={})
+
+    # --- ur######## (classic numeric format) ---
+
+    def test_ur_bare_id_accepted(self):
+        """Classic ur######## bare ID is still valid."""
+        result = self._imdb().validate_imdb("Test", "imdb_watchlist", "ur64054558")
+        assert result[0]["user_id"] == "ur64054558"
+
+    def test_ur_full_url_extracted(self):
+        """Full watchlist URL containing a ur######## ID is parsed correctly."""
+        result = self._imdb().validate_imdb("Test", "imdb_watchlist", "https://www.imdb.com/user/ur64054558/watchlist")
+        assert result[0]["user_id"] == "ur64054558"
+
+    # --- p.xxxxxxx (new format) ---
+
+    def test_p_hashed_bare_id_accepted(self):
+        """Hashed p.xxxxxxx ID (most accounts) is accepted."""
+        result = self._imdb().validate_imdb("Test", "imdb_watchlist", "p.fl6ssgsolkgcctcuxapgh6chsa")
+        assert result[0]["user_id"] == "p.fl6ssgsolkgcctcuxapgh6chsa"
+
+    def test_p_readable_bare_id_accepted(self):
+        """Human-readable p.<name> ID (older accounts) is accepted."""
+        result = self._imdb().validate_imdb("Test", "imdb_watchlist", "p.colneedham")
+        assert result[0]["user_id"] == "p.colneedham"
+
+    def test_p_hashed_full_url_extracted(self):
+        """Full watchlist URL with hashed p.xxxxxxx ID is parsed correctly."""
+        result = self._imdb().validate_imdb("Test", "imdb_watchlist", "https://www.imdb.com/user/p.fl6ssgsolkgcctcuxapgh6chsa/watchlist")
+        assert result[0]["user_id"] == "p.fl6ssgsolkgcctcuxapgh6chsa"
+
+    def test_p_readable_full_url_extracted(self):
+        """Full watchlist URL with readable p.<name> ID is parsed correctly."""
+        result = self._imdb().validate_imdb("Test", "imdb_watchlist", "https://www.imdb.com/user/p.colneedham/watchlist")
+        assert result[0]["user_id"] == "p.colneedham"
+
+    # --- invalid input ---
+
+    def test_invalid_format_raises_failed(self):
+        """Unrecognised format raises Failed mentioning both valid formats."""
+        with pytest.raises(Failed, match="ur########"):
+            self._imdb().validate_imdb("Test", "imdb_watchlist", "abc12345")
+
+    def test_ur_non_numeric_suffix_raises_failed(self):
+        """ur prefix without a numeric suffix is rejected."""
+        with pytest.raises(Failed, match="ur########"):
+            self._imdb().validate_imdb("Test", "imdb_watchlist", "urnothex")


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)

## Description

IMDb no longer displays `ur########` user IDs in their UI. Users now see a `p.xxxxxxx` identifier in their watchlist URLs (e.g. `https://www.imdb.com/user/p.fl6ssgsolkgcctcuxapgh6chsa/watchlist`), which `validate_imdb` previously rejected outright, and which the GraphQL `WatchListPageRefiner` query rejects with `BAD_USER_INPUT` even if passed through.

This PR fixes both layers:

**Validation (`validate_imdb`)** now accepts:
- The new `p.xxxxxxx` format as a bare ID
- A full watchlist URL in either format, extracting the ID automatically
- Retains full backwards compatibility with the existing `ur########` format

**Runtime (`imdb.py`)** - `p.xxxxxxx` IDs are resolved to their internal `ur###` userId before the existing `WatchListPageRefiner` query runs. The resolution uses IMDb's GraphQL API (`api.graphql.imdb.com`), which is not affected by the AWS WAF that blocks all HTML requests to `www.imdb.com`:

```graphql
{ userProfile(input: {profileId: "p.xxxxxxx"}) { userId } }
```

`ur########` IDs in existing configs continue to work where the watchlist is public. Where no public watchlist is found, Kometa now fails gracefully with a message directing the user to update to `p.xxxxxxx` format, rather than crashing with `NoneType`.

Tested locally against the unpatched image (bug reproduced) and the patched repo, covering all four cases: legacy `ur########`, bare `p.xxxxxxx`, empty watchlist, and full watchlist URL.

## Related Issues
- Closes #3091

## Have you updated the Documentation to reflect changes (if necessary)?
- [X] Yes

## Have you updated the CHANGELOG?
- [X] Yes