### PR TITLE
Restore lb details url

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -90,3 +90,4 @@ Fix an issue where tvdb_to_imdb writes wrong IMDb ID when TVDb movie ID collides
 Hide some traceback errors for "known good" errors that don't really need a trace
 Fix `imdb_awards` failing when any one of the `award_filters` or `category_filters` do not exist, this will now produce a warning and the builder will only fail if all of the `award_filters` or all of the `category_filters` does not exist.
 Fix imdb_watchlist rejecting new IMDb user ID format (p.xxxxxxx). Now accepts both ur######## (legacy) and p.xxxxxxx formats, as a bare ID or full watchlist URL.
+Restore and/or verify support for Letterboxd /detail/ list views and /USERNAME/films/reviews/ URLs.

--- a/modules/letterboxd.py
+++ b/modules/letterboxd.py
@@ -245,6 +245,16 @@ class Letterboxd:
         return None
 
     @staticmethod
+    def _extract_rating_from_stars(star_values):
+        for star_value in star_values:
+            if not star_value or "★" not in star_value:
+                continue
+            full_stars = star_value.count("★")
+            half_star = 1 if "½" in star_value else 0
+            return full_stars * 2 + half_star
+        return None
+
+    @staticmethod
     def _extract_like_from_classes(class_values):
         return any("like" in class_name for class_value in class_values for class_name in class_value.split())
 
@@ -300,6 +310,24 @@ class Letterboxd:
             item = self._extract_fallback_react_component(element)
             if item:
                 items.append(item)
+        next_url = response.xpath("//a[contains(@class, 'next')]/@href")
+        return items, next_url[0] if next_url else None
+
+    def _extract_fallback_list_detail_page(self, page_url, language):
+        response = self._request_html(page_url, language)
+        items = []
+        for article in response.xpath("//article[contains(@class,'list-detailed-entry')]"):
+            react = self._first_xpath_value(article, ".//div[contains(@class,'react-component')]")
+            if react is None:
+                continue
+            film_id = self._extract_film_id(react)
+            slug = self._extract_slug(react)
+            if not film_id or not slug:
+                continue
+            star_values = article.xpath(".//span[contains(@class,'inline-rating')]//title/text()")
+            rating = self._extract_rating_from_stars(star_values)
+            note = self._extract_review_text(article)
+            items.append((str(film_id), slug, self._extract_year(react), note, rating))
         next_url = response.xpath("//a[contains(@class, 'next')]/@href")
         return items, next_url[0] if next_url else None
 
@@ -543,7 +571,9 @@ class Letterboxd:
         else:
             # letterboxdpy doesn't support parameters in urls (for shuffling the list before fetching it) or unlisted lists.
             parsed_path = urlparse(list_url).path
-            if "/share/" in parsed_path or "/by/" in parsed_path or "/detail/" in parsed_path:
+            if "/detail/" in parsed_path:
+                items = self._get_list_items_fallback(list_url, limit, language, extractor=self._extract_fallback_list_detail_page)
+            elif "/share/" in parsed_path or "/by/" in parsed_path:
                 items = self._get_list_items_fallback(list_url, limit, language)
             else:
                 list_obj = self._get_list_object(list_url)
@@ -778,8 +808,8 @@ class Letterboxd:
 
             ids = []
             filtered_ids = []
-            supports_note = self._url_type(data["url"]) == "films"
-            supports_rating = self._url_type(data["url"]) == "films"
+            supports_note = self._url_type(data["url"]) == "films" or "/detail/" in urlparse(data["url"]).path
+            supports_rating = self._url_type(data["url"]) == "films" or "/detail/" in urlparse(data["url"]).path
             if data["note"] and not supports_note:
                 self._warn_once(("list_note", data["url"]), "Letterboxd Warning: letterboxdpy does not expose per-item list notes for standard Letterboxd lists; ignoring note filter.")
             if data["rating"] and not supports_rating:

--- a/modules/letterboxd.py
+++ b/modules/letterboxd.py
@@ -54,12 +54,7 @@ builders = ["letterboxd_list", "letterboxd_list_details", "letterboxd_user_films
 base_url = "https://letterboxd.com"
 boxd_short_url = "https://boxd.it"
 
-list_url_pattern = re.compile(
-    r"^https://letterboxd\.com/(?P<username>[^/]+)/list/(?P<slug>[^/]+)"
-    r"(?:/share/(?P<share>[^/]+))?"
-    r"(?:/by/(?P<sort>[^/]+))?"
-    r"/?$"
-)
+list_url_pattern = re.compile(r"^https://letterboxd\.com/(?P<username>[^/]+)/list/(?P<slug>[^/]+)" r"(?:/share/(?P<share>[^/]+))?" r"(?:/detail)?" r"(?:/by/(?P<sort>[^/]+))?" r"/?$")
 watchlist_url_pattern = re.compile(r"^https://letterboxd\.com/(?P<username>[^/]+)/watchlist/?$")
 film_path_pattern = re.compile(r"^/film/(?P<slug>[^/]+)/?$")
 film_identifier_pattern = re.compile(r"film:(?P<id>\d+)")
@@ -548,7 +543,7 @@ class Letterboxd:
         else:
             # letterboxdpy doesn't support parameters in urls (for shuffling the list before fetching it) or unlisted lists.
             parsed_path = urlparse(list_url).path
-            if "/share/" in parsed_path or "/by/" in parsed_path:
+            if "/share/" in parsed_path or "/by/" in parsed_path or "/detail/" in parsed_path:
                 items = self._get_list_items_fallback(list_url, limit, language)
             else:
                 list_obj = self._get_list_object(list_url)

--- a/tests/test_letterboxd.py
+++ b/tests/test_letterboxd.py
@@ -241,6 +241,37 @@ def test_list_url_is_normalized_before_fallback(monkeypatch):
     assert items == [("111", "/film/first-film/", 2001, None, None)]
 
 
+def test_detail_list_url_extracts_rating_from_star_glyphs():
+    requests = FakeRequests(
+        {
+            "https://letterboxd.com/demo/list/staff-picks/detail/": """
+                <html><body>
+                    <article class="list-detailed-entry">
+                        <div class="react-component" data-item-link="/film/first-film/" data-item-name="First Film (2001)" data-postered-identifier="{&quot;uid&quot;:&quot;film:111&quot;}"></div>
+                        <div class="content-reactions-strip">
+                            <span class="inline-symbol inline-rating">
+                                <svg><title>&#9733;&#9733;&#9733;&#9733;&#189;</title></svg>
+                            </span>
+                        </div>
+                    </article>
+                </body></html>
+            """
+        }
+    )
+    adapter = Letterboxd(requests, FakeCache())
+
+    items = adapter._get_list_items("https://letterboxd.com/demo/list/staff-picks/detail/", 0, "en")
+
+    assert items == [("111", "/film/first-film/", 2001, None, 9)]
+
+
+def test_parse_list_url_accepts_detail_segment():
+    adapter = Letterboxd(None, None)
+
+    assert adapter._parse_list_url("https://letterboxd.com/demo/list/staff-picks/detail/") == ("demo", "staff-picks")
+    assert adapter._parse_list_url("https://letterboxd.com/demo/list/staff-picks/detail/by/rating/") == ("demo", "staff-picks")
+
+
 def test_request_html_retries_with_scraper_on_cloudflare_challenge(monkeypatch, patch_logger):
     monkeypatch.setattr(letterboxd_module, "Films", FakeFilms)
     monkeypatch.setattr(letterboxd_module, "LetterboxdList", FakeList)


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

Support for two types of Letterboxd URLs was inadvertently dropped; this PR restores that support.

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [X] No need; this code restores functionality already described

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
