### PR TITLE
fix: correct monthly(N) last-day fallback; add monthly(last)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@ Bump requests to 2.34.2
 Bump setuptools to 82.0.1
 
 # New Features
+Add `monthly(last)` schedule option: fires on the last day of every month regardless of its length (Feb 28/29, Apr/Jun/Sep/Nov 30, or the 31st in 31-day months).
 Add comprehensive config validation with `--validate`, `--validate-level`, `--validate-schema`, and `--schema-path` CLI flags. Supports syntax, structure, full, and schema-level validation with a gap report showing missing/extra fields.
 Add `--validate-file` and `--validate-dir` CLI flags for standalone and batch YAML validation against auto-detected schema types (config, collection, metadata, overlay, playlist). Output written to `validate.log`.
 Add `modules/validator.py` with `ConfigValidator` (multi-level config validation) and `FileSetValidator` (standalone/batch YAML validation with schema type detection).
@@ -96,4 +97,5 @@ Fix `title_format` fallback value in `award/sag.yml` to match its translation na
 Fix an issue where Plex would fail to update collections if the casing of the collection name did not match the YAML (such as "Dogs And Cats" vs "Dogs and Cats")
 Fix shared `ignore_ids` and `ignore_imdb_ids` template variables for builders that resolve Plex `ratingKey`s first.
 Fix an issue where collections would not be recognized as configured if they were not scheduled to run
+Fix `monthly(N)` schedule: values greater than the current month's last day (e.g. `monthly(31)` in November) no longer fire on the last day of the month as a fallback. `monthly(N)` now only triggers when today is exactly day N. A warning is logged when a configured day does not exist in the current month, directing users to the new `monthly(last)` option. Fixes #2884
 

--- a/docs/config/schedule.md
+++ b/docs/config/schedule.md
@@ -24,7 +24,7 @@ The scheduling options are:
 | Hourly       | Update only when the script is run in that hour or hour range.                                                       | hourly(Hour of Day)<br>hourly(Start Hour-End Hour) | `hourly(17)`<br>`hourly(17-04)`                                      |
 | Daily        | Update once a day.                                                                                                   | daily                                              | `daily`                                                              |
 | Weekly       | Update once a week on the specified days. (For multiple days, use a bar-separated (<code>&#124;</code>) list)        | weekly(Days of Week)                               | `weekly(sunday)`<br><code>weekly(sunday&#124;tuesday)</code>         |
-| Monthly      | Update once a month on the specified day. (multiple days not supported as a parameter) (For multiple days, use a list: `[monthly(1), monthly(15)]`) | monthly(Day of Month)                              | `monthly(1)`                                                         |
+| Monthly      | Update once a month on the specified day. Use `monthly(last)` to run on the last day of every month regardless of its length. (multiple days not supported as a parameter) (For multiple days, use a list: `[monthly(1), monthly(15)]`) | monthly(Day of Month)<br>monthly(last) | `monthly(1)`<br>`monthly(last)`                                      |
 | Yearly       | Update once a year on the specified day. (multiple days not supported as a parameter)                                | yearly(MM/DD)                                      | `yearly(01/30)`                                                      |
 | Date         | Update on a specific date.                                                                                           | date(MM/DD/YYYY)                                   |                                                                      |
 | Range        | Updates whenever the date is within the range. A range can be a single day (`range(06/01-06/01)`) (For multiple ranges, use a bar-separated (<code>&#124;</code>) list) | range(MM/DD-MM/DD)                                 | `range(12/01-12/31)`<br><code>range(8/01-8/15&#124;9/01-9/15)</code> |
@@ -36,6 +36,18 @@ The scheduling options are:
 * You can run Kometa multiple times per day but using the `--time` command line argument detailed on the [Run Commands & Environmental Variables Page](../kometa/environmental.md).
 * You can have multiple scheduling options as a list.
 * You can use the `delete_not_scheduled` setting to delete Collections that are skipped due to not being scheduled.
+
+???+ warning "monthly(N) behaviour change"
+    In previous versions, `monthly(N)` would fall back to the last day of the month if day N didn't exist in that month — for example, `monthly(31)` would fire on 30 November. This created a conflict where `monthly(30)` and `monthly(31)` would both trigger on the same day in 30-day months.
+
+    This fallback has been removed. `monthly(N)` now only fires when today is exactly day N. If you want to schedule something for the last day of every month, use **`monthly(last)`** instead.
+
+    If your config uses `monthly(29)`, `monthly(30)`, or `monthly(31)` and relies on the fallback behaviour, Kometa will log a warning on months where that day doesn't exist:
+
+    ```
+    Schedule Warning: monthly(31) will not run this month; November does not have a 31st day.
+    Use monthly(last) if you want to schedule for the last day of every month.
+    ```
 
 ## Examples
 

--- a/modules/util.py
+++ b/modules/util.py
@@ -717,15 +717,24 @@ def schedule_check(attribute, data, current_time, run_hour, is_all=False):
                 if pass_day:
                     all_check += 1
             elif run_time.startswith("month"):
-                try:
-                    if 1 <= int(param) <= 31:
-                        schedule_str += f"\nScheduled monthly on the {num2words(param, to='ordinal_num')}"
-                        if current_time.day == int(param) or (current_time.day == last_day.day and int(param) > last_day.day):
-                            all_check += 1
-                    else:
-                        raise ValueError
-                except ValueError:
-                    logger.error(f"Schedule Error: monthly {display} must be an integer between 1 and 31")
+                if param == "last":
+                    schedule_str += "\nScheduled monthly on the last day of the month"
+                    if current_time.day == last_day.day:
+                        all_check += 1
+                else:
+                    try:
+                        if 1 <= int(param) <= 31:
+                            schedule_str += f"\nScheduled monthly on the {num2words(param, to='ordinal_num')}"
+                            if current_time.day == int(param):
+                                all_check += 1
+                            elif int(param) > last_day.day:
+                                logger.warning(f"Schedule Warning: monthly({param}) will not run this month; "
+                                               f"{current_time.strftime('%B')} does not have a {num2words(param, to='ordinal_num')} day. "
+                                               f"Use monthly(last) if you want to schedule for the last day of every month.")
+                        else:
+                            raise ValueError
+                    except ValueError:
+                        logger.error(f"Schedule Error: monthly {display} must be an integer between 1 and 31 or 'last'")
             elif run_time.startswith("year"):
                 try:
                     if "/" in param:


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [X] Documentation Update
- [ ] Other 

## Description

`monthly(31)` (and any `monthly(N)` where N exceeds the month's length) was incorrectly firing on the last day of short months - so `monthly(31)` would trigger on 30 November, the same day as `monthly(30)`. Root cause: `schedule_check()` in `modules/util.py` had a last-day fallback clause (`current_time.day == last_day.day and int(param) > last_day.day`) that collapsed distinct `monthly(N)` values onto each other on short-month last days.

**Changes:**
- Remove the fallback: `monthly(N)` now only fires when today is exactly day N
- Add `monthly(last)`: a new keyword that explicitly fires on the last day of every month, regardless of its length (Feb 28/29, 30-day months, and 31-day months)
- Add a `logger.warning` when `monthly(N)` is configured with N greater than the current month's length, directing users to `monthly(last)`
- Update `docs/config/schedule.md` with the new keyword and a migration warning admonition for users who relied on the old fallback behaviour

Tested with a standalone proof script (`test_2884.py`) covering 44 cases: SANITY (4), CORRECT (13), BUG (9), LAST (13), WARNING (5). All pass on the fix branch; 25 fail on stock nightly confirming the bug.

## Related Issues

- Closes #2884

## Have you updated the Documentation to reflect changes (if necessary)?

- [X] Yes
- [ ] No

## Have you updated the CHANGELOG?

- [X] Yes
- [ ] No