### PR TITLE
fix: sanitize PR branch names in CI workflows and fix tag-cleanup output key

### DIFF
--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -81,10 +81,11 @@ jobs:
       - name: Update VERSION File
         id: update-version
         run: |
-            branch_name=${{ github.event.pull_request.head.ref }}
+            branch_name="${{ github.event.pull_request.head.ref }}"
+            branch_name=$(echo "${branch_name}" | sed 's/[^a-zA-Z0-9._-]/-/g')
             repo_name=${{ github.event.pull_request.head.repo.full_name }}
             base_name="${repo_name%/*}"
-            if [[ "${branch_name}" =~ ^(master|develop|nightly)$ ]]; then 
+            if [[ "${branch_name}" =~ ^(master|develop|nightly)$ ]]; then
                 pr_tag="${base_name}"
             else
                 pr_tag="${branch_name}"

--- a/.github/workflows/tag-cleanup.yml
+++ b/.github/workflows/tag-cleanup.yml
@@ -14,10 +14,11 @@ jobs:
       - name: Get Tag Name
         id: get-tag-name
         run: |
-          branch_name=${{ github.event.pull_request.head.ref }}
+          branch_name="${{ github.event.pull_request.head.ref }}"
+          branch_name=$(echo "${branch_name}" | sed 's/[^a-zA-Z0-9._-]/-/g')
           repo_name=${{ github.event.pull_request.head.repo.full_name }}
           base_name="${repo_name%/*}"
-          if [[ "${branch_name}" =~ ^(master|develop|nightly)$ ]]; then 
+          if [[ "${branch_name}" =~ ^(master|develop|nightly)$ ]]; then
               tag_name="${base_name}"
           else
               tag_name="${branch_name}"
@@ -30,4 +31,4 @@ jobs:
           curl -i -X DELETE \
           -H "Accept: application/json" \
           -H "Authorization: JWT $HUB_TOKEN" \
-          https://hub.docker.com/v2/repositories/${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}/tags/${{ steps.get-tag-name.outputs.tag_name }}/
+          https://hub.docker.com/v2/repositories/${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}/tags/${{ steps.get-tag-name.outputs.tag-name }}/

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -104,10 +104,11 @@ jobs:
       - name: Update VERSION File
         id: update-version
         run: |
-            branch_name=${{ github.event.pull_request.head.ref }}
+            branch_name="${{ github.event.pull_request.head.ref }}"
+            branch_name=$(echo "${branch_name}" | sed 's/[^a-zA-Z0-9._-]/-/g')
             repo_name=${{ github.event.pull_request.head.repo.full_name }}
             base_name="${repo_name%/*}"
-            if [[ "${branch_name}" =~ ^(master|develop|nightly)$ ]]; then 
+            if [[ "${branch_name}" =~ ^(master|develop|nightly)$ ]]; then
                 tag_name="${base_name}"
             else
                 tag_name="${branch_name}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -63,6 +63,8 @@ Call out the schema file as supporting only config.yml. explicitly.
 Add E4 to network overlay and show network collection. #2975
 
 # Bug Fixes
+Sanitize PR branch names in CI workflows (`validate-pull.yml`, `increment-build.yml`, `tag-cleanup.yml`) by replacing non-Docker-safe characters with `-`; branch names containing `/` (e.g. `feature/my-fix`) previously caused Docker Hub tag pushes and deletes to fail.
+Fix `tag-cleanup.yml` output key mismatch (`tag_name` vs `tag-name`) that caused the Docker Hub tag DELETE to always target an empty tag name, leaving stale tester tags behind.
 Update Letterbox URL parsing to handle unlisted lists and shuffle argument in the url
 Update Letterboxd list/watchlist parser for the React-based `LazyPoster` markup, which replaced the `data-film-id` nodes the `letterboxd_list`, `letterboxd_user_films`, and `letterboxd_user_reviews` builders relied on.
 Catch KeyError on Plex NFO build.


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Three fixes to the GitHub Actions CI workflows:

1. **Branch name sanitisation** (`validate-pull.yml`, `increment-build.yml`, `tag-cleanup.yml`) - branch names containing `/` (e.g. `feature/my-fix`) were passed directly as Docker Hub image tags, which caused builds to fail since Docker tags do not allow `/`. Added a `sed` sanitisation step after each `branch_name` assignment to replace any non-Docker-safe characters with `-`.

2. **`tag-cleanup.yml` output key typo** - the step output was set as `tag-name` but referenced as `tag_name` (hyphen vs underscore), meaning the Docker Hub DELETE call always targeted an empty tag name and never actually cleaned up. Fixed the reference to match the output key.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [X] No

## Have you updated the CHANGELOG?

- [X] Yes
- [ ] No