### PR TITLE
Fix AniList search date modifier error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -112,3 +112,4 @@ Fix `audio_language`/`subtitle_language` `plex_search` on show libraries returni
 Fix `other_name` in dynamic collections: `<<library_type>>` and `<<library_typeU>>` placeholders are now resolved (they were applied to `title_format` but not to `other_name`). Also fix a long-standing copy-paste bug where `other_name` supplied via `template_variables` was read from `self.temp_vars["remove_suffix"]` instead of `self.temp_vars["other_name"]`.
 Fix inconsistent asset poster selection and overlay cache invalidation when replacing local asset files.
 Invalidate cached Plex items after batched edits in operations so metadata files can override values in the same run instead of flip-flopping on later runs.
+Fix an issue with AniList search date modifiers not working

--- a/modules/anilist.py
+++ b/modules/anilist.py
@@ -14,7 +14,7 @@ attr_translation = {
     "year": "seasonYear", "adult": "isAdult", "start": "startDate", "end": "endDate", "tag_category": "tagCategory",
     "score": "averageScore", "min_tag_percent": "minimumTagRank", "country": "countryOfOrigin",
 }
-mod_translation = {"": "in", "not": "not_in", "before": "greater", "after": "lesser", "gt": "greater", "gte": "greater", "lt": "lesser", "lte": "lesser"}
+mod_translation = {"": "in", "not": "not_in", "before": "lesser", "after": "greater", "gt": "greater", "gte": "greater", "lt": "lesser", "lte": "lesser"}
 mod_searches = [
     "start.before", "start.after", "end.before", "end.after",
     "format", "format.not", "status", "status.not", "genre", "genre.not", "tag", "tag.not", "tag_category", "tag_category.not",

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -2092,7 +2092,7 @@ class CollectionBuilder:
                     elif search_attr in ["format", "status", "genre", "tag", "tag_category"]:
                         new_dictionary[lower_method] = self.config.AniList.validate(search_attr.replace("_", " ").title(), util.parse(self.Type, search_method, search_data))
                     elif search_attr in ["start", "end"]:
-                        new_dictionary[search_attr] = util.parse(
+                        new_dictionary[lower_method] = util.parse(
                             self.Type,
                             search_attr,
                             search_data,


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

Issue: AniList date filters like start.after and end.before were validated as plain start and end, dropping the modifier. That made Kometa generate invalid GraphQL arguments like startDate_in.

Fix: preserve the .before/.after modifier and map it to AniList’s range arguments, e.g. startDate_greater and endDate_lesser.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, GitHub will automatically close the issue.
-->
- Related Issue #
- Closes #2702

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [X] No

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
