### PR TITLE
Fix: image size validation TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix image size validation during metadata uploads so local poster/background/square art files are checked using their actual file size instead of the string `compare` field, avoiding a `TypeError` in operations.
+
 ## [v2.4.2] - 2026-06-22
 
 ### Added
@@ -136,7 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `other_name` in dynamic collections: `<<library_type>>` and `<<library_typeU>>` placeholders are now resolved (they were applied to `title_format` but not to `other_name`). Also fix a long-standing copy-paste bug where `other_name` supplied via `template_variables` was read from `self.temp_vars["remove_suffix"]` instead of `self.temp_vars["other_name"]`. #3215
 - Fix an issue with AniList search date modifiers not working. #3220
 - Fix Studio Defaults capitalization issues. #3221
-- Fix image size validation during metadata uploads so local poster/background/square art files are checked using their actual file size instead of the string `compare` field, avoiding a `TypeError` in operations.
+
 
 ## [v2.3.1] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `other_name` in dynamic collections: `<<library_type>>` and `<<library_typeU>>` placeholders are now resolved (they were applied to `title_format` but not to `other_name`). Also fix a long-standing copy-paste bug where `other_name` supplied via `template_variables` was read from `self.temp_vars["remove_suffix"]` instead of `self.temp_vars["other_name"]`. #3215
 - Fix an issue with AniList search date modifiers not working. #3220
 - Fix Studio Defaults capitalization issues. #3221
+- Fix image size validation during metadata uploads so local poster/background/square art files are checked using their actual file size instead of the string `compare` field, avoiding a `TypeError` in operations.
 
 ## [v2.3.1] - 2026-04-01
 

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1059,10 +1059,11 @@ class Plex(Library):
         return item_list
 
     def validate_image_size(self, image):
-        if image.compare < MAX_IMAGE_SIZE:
+        image_size = os.path.getsize(image.location)
+        if image_size < MAX_IMAGE_SIZE:
             return True
         else:
-            logger.error(f"Image too large: {image.location}, bytes {image.compare}, MAX {MAX_IMAGE_SIZE}")
+            logger.error(f"Image too large: {image.location}, bytes {image_size}, MAX {MAX_IMAGE_SIZE}")
             return False
 
     @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type((BadRequest, NotFound, Unauthorized)))

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from plexapi.exceptions import NotFound
 
 import modules.builder as builder_module
+import modules.plex as plex_module
 from modules.builder import CollectionBuilder, parts_collection_valid
 
 
@@ -273,3 +274,13 @@ def test_delete_marks_builder_deleted_and_skips_notifications():
     assert builder.library.deleted_items == [builder.obj]
     assert builder.library.reloaded_items == []
     assert builder.library.webhook_calls == 0
+
+
+def test_validate_image_size_uses_file_size(tmp_path, monkeypatch):
+    image_path = tmp_path / "image.jpg"
+    image_path.write_bytes(b"abc")
+
+    plex = plex_module.Plex.__new__(plex_module.Plex)
+    monkeypatch.setattr(plex_module, "MAX_IMAGE_SIZE", 2)
+
+    assert plex.validate_image_size(SimpleNamespace(location=str(image_path), compare="not-a-number")) is False


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG.md and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

This PR fixes a crash during library operations caused by validate_image_size() comparing image.compare as if it were numeric. ImageData.compare is a string, so the comparison could raise TypeError when Kometa tried to upload local poster/background/square art files.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, GitHub will automatically close the issue.
-->
- Related Issue #3227
- Closes #3227 

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

<!--
    This is optional and only necessary when your PR changes supported attributes,
    accepted values, or structure for Configuration Files, Collection Files,
    Metadata Files, Overlay Files, Playlist Files, or Defaults template variables.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the CHANGELOG.md?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG.md entry.
    We may ask you to update the CHANGELOG.md if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
