### PR TITLE
chore: apply black + isort across the whole repo (formatting only)

### DIFF
--- a/kometa.py
+++ b/kometa.py
@@ -250,19 +250,14 @@ util.logger = logger
 from modules.builder import CollectionBuilder  # noqa: E402
 from modules.config import ConfigFile  # noqa: E402
 from modules.request import Requests  # noqa: E402
-from modules.util import Deleted, Failed, FilterFailed, NonExisting, NotScheduled, ServiceError, BuilderValidationError, OverlayError, MappingConvertError  # noqa: E402
-
+from modules.util import BuilderValidationError, Deleted, Failed, FilterFailed, MappingConvertError, NonExisting, NotScheduled, OverlayError, ServiceError  # noqa: E402
 
 plex_maintenance_error = "Plex Critical Error: Response 503 (service_unavailable) received. Plex may be running startup or maintenance tasks. Kometa cannot proceed until this is complete"
 
 
 def is_plex_maintenance_error(error):
     error_text = str(error)
-    return isinstance(error, BadRequest) and "(503) service_unavailable" in error_text and (
-        "title=\"Maintenance\"" in error_text
-        or "startup maintenance tasks" in error_text
-        or "currently running maintenance tasks" in error_text
-    )
+    return isinstance(error, BadRequest) and "(503) service_unavailable" in error_text and ('title="Maintenance"' in error_text or "startup maintenance tasks" in error_text or "currently running maintenance tasks" in error_text)
 
 
 def get_critical_error_message(error):
@@ -360,9 +355,7 @@ def process(attrs):
 
 
 def should_sync_collection(builder):
-    return builder.sync and builder.build_collection and bool(builder.remove_item_map) and (
-        not builder.found_items or len(builder.found_items) + builder.beginning_count >= builder.minimum
-    )
+    return builder.sync and builder.build_collection and bool(builder.remove_item_map) and (not builder.found_items or len(builder.found_items) + builder.beginning_count >= builder.minimum)
 
 
 def collection_count_after_run(beginning_count, items_added, items_removed):
@@ -594,6 +587,7 @@ def start(attrs):
                 logger.info("")
 
             convert_title = False
+
             def convert_summary_title(key):
                 summary = key.split(": ", 1)[1].rstrip(":")
                 if " for " not in summary:

--- a/modules/anidb.py
+++ b/modules/anidb.py
@@ -1,12 +1,16 @@
-import json, time, os
-from datetime import datetime, timedelta
-from lxml import etree
-from modules import util
-from modules.util import Failed, logger
 import gzip
 import io
+import json
+import os
+import time
 import traceback
 import xml.etree.ElementTree as ET
+from datetime import datetime, timedelta
+
+from lxml import etree
+
+from modules import util
+from modules.util import Failed, logger
 
 logger = util.logger
 
@@ -19,13 +23,14 @@ kometa_client_version = 1
 
 weights = {"anidb": 1000, "anidb_3_0": 600, "anidb_2_5": 500, "anidb_2_0": 400, "anidb_1_5": 300, "anidb_1_0": 200, "anidb_0_5": 100}
 
+
 class AniDBTitles:
     TITLES_URL = "https://anidb.net/api/anime-titles.xml.gz"
     CACHE_FILE = "config/anidb_cache/anime-titles.xml"
 
     def __init__(self, requests_obj):
         self.requests = requests_obj
-        self.title_map = {} # Maps title string -> AID
+        self.title_map = {}  # Maps title string -> AID
         self._load()
 
     def _load(self):
@@ -42,23 +47,18 @@ class AniDBTitles:
                 logger.info("Downloading Master Title List from AniDB...")
 
                 # AniDB requires a non-generic User-Agent and often checks identity
-                headers = {
-                    'User-Agent': f'Kometa/1.0 ({kometa_client})',
-                    'Accept-Encoding': 'gzip, deflate',
-                    'Host': 'anidb.net'
-                }
+                headers = {"User-Agent": f"Kometa/1.0 ({kometa_client})", "Accept-Encoding": "gzip, deflate", "Host": "anidb.net"}
                 response = self.requests.get(self.TITLES_URL, headers=headers)
                 if response.status_code == 200:
                     # Decompress Gzip in memory and save as plain XML
                     content = gzip.decompress(response.content)
                     os.makedirs(os.path.dirname(self.CACHE_FILE), exist_ok=True)
-                    with open(self.CACHE_FILE, 'wb') as f:
+                    with open(self.CACHE_FILE, "wb") as f:
                         f.write(content)
                 else:
                     logger.error("Failed to download title list.")
             else:
                 logger.info("Using cached Master Title List from AniDB.")
-
 
             # 2. Parse XML into a searchable Dictionary
             if os.path.exists(self.CACHE_FILE):
@@ -79,17 +79,17 @@ class AniDBTitles:
         """Returns the AID for a given title string, or None."""
         return self.title_map.get(query.lower())
 
+
 class AniDBObj:
     def __init__(self, anidb, anidb_id, data):
         self._anidb = anidb
         self.anidb_id = anidb_id
         self._data = data
 
-
         # def _parse(self, field_name, xpath, is_dict=False):
         #     # Find all elements matching the XPath
-        #     nodes = self.xml_root.xpath(xpath) 
-            
+        #     nodes = self.xml_root.xpath(xpath)
+
         #     if not nodes:
         #         return {} if is_dict else []
 
@@ -98,7 +98,7 @@ class AniDBObj:
         #         for node in nodes:
         #             # Use the 'id' attribute as the primary key
         #             tag_id = node.get('id')
-                    
+
         #             # Map internal children to dictionary keys
         #             tag_data = {
         #                 'name': node.findtext('name'),
@@ -108,24 +108,28 @@ class AniDBObj:
         #             }
         #             result[tag_id] = tag_data
         #         return result
-            
+
         #     # Default behavior for non-dict parsing
         #     return [node.text for node in nodes]
- 
+
         def _parse(attr, xpath, is_list=False, is_dict=False, is_int=False, is_float=False, is_date=False, fail=False):
             try:
                 # Handle data if it's coming from a dictionary (Cache)
                 if isinstance(data, dict):
-                    lookup_attr = attr if not attr == 'tmdb' else 'tmdb_id'
-                    
+                    lookup_attr = attr if not attr == "tmdb" else "tmdb_id"
+
                     if lookup_attr == "tmdb_id":
-                        result = [str(data['tmdb_id']), str(data['tmdb_type'])] if 'tmdb_id' in data and data['tmdb_id'] else []
+                        result = [str(data["tmdb_id"]), str(data["tmdb_type"])] if "tmdb_id" in data and data["tmdb_id"] else []
                         return result
 
-                    if is_list: return data[lookup_attr].split("|") if data[lookup_attr] else []
-                    if is_dict: return json.loads(data[lookup_attr]) if data[lookup_attr] else {}
-                    if is_int or is_float: return util.check_num(data[lookup_attr], is_int=is_int)
-                    if is_date: return datetime.strptime(data[lookup_attr], "%Y-%m-%d") if data[lookup_attr] else None
+                    if is_list:
+                        return data[lookup_attr].split("|") if data[lookup_attr] else []
+                    if is_dict:
+                        return json.loads(data[lookup_attr]) if data[lookup_attr] else {}
+                    if is_int or is_float:
+                        return util.check_num(data[lookup_attr], is_int=is_int)
+                    if is_date:
+                        return datetime.strptime(data[lookup_attr], "%Y-%m-%d") if data[lookup_attr] else None
                     return data[lookup_attr]
 
                 # Handle data if it's an XML Element (Fresh API Response)
@@ -133,13 +137,13 @@ class AniDBObj:
 
                 if attr == "tmdb":
                     # Return text results as strings
-                    result = [str(r).strip() if isinstance(r, str) else str(r.text).strip() if hasattr(r, 'text') else str(r) for r in parse_results] if parse_results else []
+                    result = [str(r).strip() if isinstance(r, str) else str(r.text).strip() if hasattr(r, "text") else str(r) for r in parse_results] if parse_results else []
                     return result
 
                 if attr == "tags":
                     return {ta.xpath("name/text()")[0]: 1001 if ta.get("infobox") else int(ta.get("weight")) for ta in parse_results}
 
-                if  attr == "titles":
+                if attr == "titles":
                     # API Titles: <title xml:lang="en" type="official">Title</title>
                     return {ta.get("{http://www.w3.org/XML/1998/namespace}lang"): ta.text for ta in parse_results}
 
@@ -148,7 +152,7 @@ class AniDBObj:
                 #     for node in parse_results:
                 #         # Use the 'id' attribute as the primary key
                 #         tag_id = node.get('id')
-                        
+
                 #         # Map internal children to dictionary keys
                 #         tag_data = {
                 #             'name': node.findtext('name'),
@@ -161,13 +165,15 @@ class AniDBObj:
 
                 if parse_results:
                     if is_list:
-                        return [r.text.strip() if hasattr(r, 'text') else str(r).strip() for r in parse_results]
-                    # 
+                        return [r.text.strip() if hasattr(r, "text") else str(r).strip() for r in parse_results]
+                    #
                     val = parse_results[0]
-                    text_val = val.text if hasattr(val, 'text') else str(val)
-                    
-                    if is_int or is_float: return util.check_num(text_val.strip(), is_int=is_int)
-                    if is_date: return datetime.strptime(text_val.strip(), "%Y-%m-%d")
+                    text_val = val.text if hasattr(val, "text") else str(val)
+
+                    if is_int or is_float:
+                        return util.check_num(text_val.strip(), is_int=is_int)
+                    if is_date:
+                        return datetime.strptime(text_val.strip(), "%Y-%m-%d")
                     return text_val.strip()
 
             except (ValueError, TypeError, IndexError):
@@ -181,19 +187,19 @@ class AniDBObj:
         self.main_title = _parse("main_title", "//title[@type='main']/text()", fail=True)
         self.titles = _parse("titles", "//title[@type='official']", is_dict=True)
         self.official_title = self.titles.get(self._anidb.language, self.main_title)
-        
+
         self.studio = _parse("studio", "//creators/name[@type='Animation Work']/text()")
         self.rating = _parse("rating", "//ratings/permanent/text()", is_float=True)
         self.average = _parse("average", "//ratings/temporary/text()", is_float=True)
         self.score = _parse("score", "//ratings/review/text()", is_float=True)
         self.released = _parse("released", "//startdate/text()", is_date=True)
-        
+
         self.tags = _parse("tags", "//anime/tags/tag", is_dict=True)
 
         # Resources (External Links)
         self.mal_id = _parse("mal_id", "//resource[@type='2']/externalentity/identifier/text()", is_int=True)
         self.imdb_id = _parse("imdb_id", "//resource[@type='43']/externalentity/identifier/text()")
-        
+
         # TMDB handling (Type 44)
         tmdb_list = _parse("tmdb", "//resource[@type='44']/externalentity/identifier/text()", is_list=True)
         self.tmdb_id = None
@@ -203,6 +209,7 @@ class AniDBObj:
                 self.tmdb_id = int(item)
             elif isinstance(item, str):
                 self.tmdb_type = item
+
 
 class AniDB:
     def __init__(self, requests_obj, cache, data):
@@ -250,12 +257,12 @@ class AniDB:
             time.sleep(self.min_delay - elapsed)
 
         # 2. Check Cache
-        aid = api_params.get('aid') if api_params else None
+        aid = api_params.get("aid") if api_params else None
         cache_file = f"config/anidb_cache/anime_{aid}.xml" if aid else None
         if cache_file and os.path.exists(cache_file) and cache_days > 0:
             file_age = datetime.fromtimestamp(os.path.getmtime(cache_file))
             if datetime.now() - file_age < timedelta(days=cache_days):
-                with open(cache_file, 'rb') as f:
+                with open(cache_file, "rb") as f:
                     return etree.fromstring(f.read())
 
         # 3. Setup Target and Headers
@@ -266,19 +273,16 @@ class AniDB:
         else:
             # Default to anime endpoint with aid
             target_url = f"{api_url}/anime/{aid}" if aid else api_url
-            
-        headers = {
-            'Accept-Encoding': 'gzip',
-            'User-Agent': f'Kometa/1.0 ({kometa_client})'
-        }
-        
+
+        headers = {"Accept-Encoding": "gzip", "User-Agent": f"Kometa/1.0 ({kometa_client})"}
+
         # Build query parameters (for search endpoints)
         payload = {}
-        if api_params and 'aid' not in api_params:
+        if api_params and "aid" not in api_params:
             payload.update(api_params)
-        
+
         # Add mature flag as query parameter
-        payload['mature'] = 'true' if self.enable_mature else 'false'
+        payload["mature"] = "true" if self.enable_mature else "false"
 
         # 4. Execute Request
         response = self.requests.get(target_url, params=payload if payload else None, headers=headers)
@@ -286,10 +290,10 @@ class AniDB:
 
         if response.status_code == 200:
             content = response.content
-            
+
             # 5. Manual Gzip Decompression Check
             # Even if 'requests' fails to auto-decode, we check the magic bytes for gzip (\x1f\x8b)
-            if content.startswith(b'\x1f\x8b'):
+            if content.startswith(b"\x1f\x8b"):
                 try:
                     content = gzip.decompress(content)
                 except Exception as e:
@@ -301,8 +305,8 @@ class AniDB:
                 return None
 
             # 6. Check if response is JSON (for tag endpoints)
-            content_type = response.headers.get('content-type', '')
-            if 'json' in content_type or content.strip().startswith(b'{') or content.strip().startswith(b'['):
+            content_type = response.headers.get("content-type", "")
+            if "json" in content_type or content.strip().startswith(b"{") or content.strip().startswith(b"["):
                 try:
                     return json.loads(content)
                 except json.JSONDecodeError as e:
@@ -320,15 +324,15 @@ class AniDB:
                 except:
                     logger.error(f"Response preview (bytes): {content[:500]}")
                 raise Failed(f"AniDB Error: Endpoint may not be implemented - {target_url}")
-            
+
             # 8. Save to cache
             if cache_file:
                 os.makedirs(os.path.dirname(cache_file), exist_ok=True)
-                with open(cache_file, 'wb') as f:
+                with open(cache_file, "wb") as f:
                     f.write(content)
-            
+
             return xml_result
-        
+
         elif response.status_code == 403:
             raise Failed("AniDB Error: 403 Banned (Too many requests or invalid Client ID)")
         elif response.status_code == 404:
@@ -337,11 +341,11 @@ class AniDB:
         else:
             logger.error(f"AniDB Error: HTTP {response.status_code} from {target_url}")
             return None
-            
+
         return None
 
     def _relations(self, anidb_id):
-        xml = self._request(api_params={'aid': anidb_id})
+        xml = self._request(api_params={"aid": anidb_id})
         return util.get_int_list(xml.xpath("//relatedanime/anime/@id"), "AniDB ID") if xml is not None else []
 
     def _validate(self, anidb_id):
@@ -352,7 +356,7 @@ class AniDB:
         aid = int(anidb_id)
 
         # 1. Check the local Master Title List (Fastest - No network)
-        if hasattr(self, 'titles_db') and aid in self.titles_db.title_map.values():
+        if hasattr(self, "titles_db") and aid in self.titles_db.title_map.values():
             return aid
 
         # 2. Check the Local XML Cache or fallback to API
@@ -365,21 +369,21 @@ class AniDB:
 
     def validate_anidb_ids(self, anidb_ids):
         """
-        Validates a list of AniDB IDs. 
+        Validates a list of AniDB IDs.
         Returns a list of valid integer IDs.
         """
         anidb_list = util.get_int_list(anidb_ids, "AniDB ID")
         anidb_values = []
-        
+
         for anidb_id in anidb_list:
             try:
                 anidb_values.append(self._validate(anidb_id))
             except Failed as e:
                 logger.error(e)
-        
+
         if not anidb_values:
             raise Failed(f"AniDB Error: No valid AniDB IDs found in input: {anidb_ids}")
-            
+
         return anidb_values
 
     def get_anime(self, anidb_id, ignore_cache=False):
@@ -402,7 +406,7 @@ class AniDB:
 
         # 3. Create the Object
         obj = AniDBObj(self, anidb_id, data_source)
-        
+
         # 4. Update Module Cache
         if self.cache and not ignore_cache:
             self.cache.update_anidb(expired, anidb_id, obj, self.expiration)
@@ -417,17 +421,17 @@ class AniDB:
         """
         params = {}
         if limit is not None:
-            params['limit'] = limit
-        
+            params["limit"] = limit
+
         response = self._request(api_params=params, endpoint=f"tags/{tag_id}", cache_days=1)
         if response is None:
             return []
-        
+
         # Handle JSON response
         if isinstance(response, dict):
-            results = response.get('results', [])
-            return [anime['aid'] for anime in results if 'aid' in anime]
-        
+            results = response.get("results", [])
+            return [anime["aid"] for anime in results if "aid" in anime]
+
         # Fallback to XML parsing if needed
         return util.get_int_list(response.xpath("//anime/@id"), "AniDB ID")
 
@@ -439,20 +443,17 @@ class AniDB:
             min_weight: Minimum tag weight filter (default: 0)
         """
         tag_list = tags if isinstance(tags, list) else [tags]
-        params = {
-            'tags': ','.join(tag_list),
-            'min_weight': min_weight
-        }
-        
+        params = {"tags": ",".join(tag_list), "min_weight": min_weight}
+
         response = self._request(api_params=params, endpoint="search/tags", cache_days=1)
         if response is None:
             return []
-        
+
         # Handle JSON response
         if isinstance(response, dict):
-            results = response.get('results', [])
-            return [anime['aid'] for anime in results if 'aid' in anime]
-        
+            results = response.get("results", [])
+            return [anime["aid"] for anime in results if "aid" in anime]
+
         # Fallback to XML parsing if needed
         return util.get_int_list(response.xpath("//anime/@id"), "AniDB ID")
 
@@ -465,14 +466,14 @@ class AniDB:
             anidb_ids.extend(self._relations(data))
         elif method == "anidb_tag":
             # data should be a dict with 'tag_id' and optionally 'limit'
-            tag_id = data.get('tag_id', data) if isinstance(data, dict) else data
-            limit = data.get('limit') if isinstance(data, dict) else None
+            tag_id = data.get("tag_id", data) if isinstance(data, dict) else data
+            limit = data.get("limit") if isinstance(data, dict) else None
             anidb_ids.extend(self._search_by_tags(tag_id, limit))
         elif method == "anidb_tag_name":
             # data should be a dict with 'tags' (list or string) and optionally 'min_weight'
-            tags = data.get('tags', data) if isinstance(data, dict) else data
-            min_weight = data.get('min_weight', 0) if isinstance(data, dict) else 0
+            tags = data.get("tags", data) if isinstance(data, dict) else data
+            min_weight = data.get("min_weight", 0) if isinstance(data, dict) else 0
             anidb_ids.extend(self._search_by_tag_names(tags, min_weight))
-        
+
         logger.debug(f"{len(anidb_ids)} AniDB IDs Found via {method}")
         return anidb_ids

--- a/modules/anilist.py
+++ b/modules/anilist.py
@@ -1,4 +1,5 @@
 import time
+
 from modules import util
 from modules.util import Failed
 
@@ -6,55 +7,322 @@ logger = util.logger
 
 builders = ["anilist_id", "anilist_popular", "anilist_trending", "anilist_relations", "anilist_studio", "anilist_top_rated", "anilist_search", "anilist_userlist"]
 pretty_names = {"score": "Average Score", "popular": "Popularity", "trending": "Trending"}
-pretty_user = {
-    "status": "Status", "score": "User Score", "progress": "Progress", "last_updated": "Last Updated",
-    "last_added": "Last Added", "start_date": "Start Date", "completed_date": "Completed Date", "popularity": "Popularity"
-}
+pretty_user = {"status": "Status", "score": "User Score", "progress": "Progress", "last_updated": "Last Updated", "last_added": "Last Added", "start_date": "Start Date", "completed_date": "Completed Date", "popularity": "Popularity"}
 attr_translation = {
-    "year": "seasonYear", "adult": "isAdult", "start": "startDate", "end": "endDate", "tag_category": "tagCategory",
-    "score": "averageScore", "min_tag_percent": "minimumTagRank", "country": "countryOfOrigin",
+    "year": "seasonYear",
+    "adult": "isAdult",
+    "start": "startDate",
+    "end": "endDate",
+    "tag_category": "tagCategory",
+    "score": "averageScore",
+    "min_tag_percent": "minimumTagRank",
+    "country": "countryOfOrigin",
 }
 mod_translation = {"": "in", "not": "not_in", "before": "lesser", "after": "greater", "gt": "greater", "gte": "greater", "lt": "lesser", "lte": "lesser"}
 mod_searches = [
-    "start.before", "start.after", "end.before", "end.after",
-    "format", "format.not", "status", "status.not", "genre", "genre.not", "tag", "tag.not", "tag_category", "tag_category.not",
-    "episodes.gt", "episodes.gte", "episodes.lt", "episodes.lte", "duration.gt", "duration.gte", "duration.lt", "duration.lte",
-    "score.gt", "score.gte", "score.lt", "score.lte", "popularity.gt", "popularity.gte", "popularity.lt", "popularity.lte"
+    "start.before",
+    "start.after",
+    "end.before",
+    "end.after",
+    "format",
+    "format.not",
+    "status",
+    "status.not",
+    "genre",
+    "genre.not",
+    "tag",
+    "tag.not",
+    "tag_category",
+    "tag_category.not",
+    "episodes.gt",
+    "episodes.gte",
+    "episodes.lt",
+    "episodes.lte",
+    "duration.gt",
+    "duration.gte",
+    "duration.lt",
+    "duration.lte",
+    "score.gt",
+    "score.gte",
+    "score.lt",
+    "score.lte",
+    "popularity.gt",
+    "popularity.gte",
+    "popularity.lt",
+    "popularity.lte",
 ]
 no_mod_searches = ["search", "season", "year", "adult", "min_tag_percent", "limit", "sort_by", "source", "country"]
 searches = mod_searches + no_mod_searches
 sort_options = {"score": "SCORE_DESC", "popular": "POPULARITY_DESC", "trending": "TRENDING_DESC"}
 userlist_sort_options = {
-    "score": "SCORE_DESC", "status": "STATUS_DESC", "progress": "PROGRESS_DESC",
-    "last_updated": "UPDATED_TIME_DESC", "last_added": "ADDED_TIME_DESC", "start_date": "STARTED_ON_DESC",
-    "completed_date": "FINISHED_ON_DESC", "popularity": "MEDIA_POPULARITY_DESC"
+    "score": "SCORE_DESC",
+    "status": "STATUS_DESC",
+    "progress": "PROGRESS_DESC",
+    "last_updated": "UPDATED_TIME_DESC",
+    "last_added": "ADDED_TIME_DESC",
+    "start_date": "STARTED_ON_DESC",
+    "completed_date": "FINISHED_ON_DESC",
+    "popularity": "MEDIA_POPULARITY_DESC",
 }
 media_season = {"winter": "WINTER", "spring": "SPRING", "summer": "SUMMER", "fall": "FALL"}
 media_format = {"tv": "TV", "short": "TV_SHORT", "movie": "MOVIE", "special": "SPECIAL", "ova": "OVA", "ona": "ONA", "music": "MUSIC"}
 media_status = {"finished": "FINISHED", "airing": "RELEASING", "not_yet_aired": "NOT_YET_RELEASED", "cancelled": "CANCELLED", "hiatus": "HIATUS"}
-media_source = {
-    "original": "ORIGINAL", "manga": "MANGA", "light_novel": "LIGHT_NOVEL", "visual_novel": "VISUAL_NOVEL",
-    "video_game": "VIDEO_GAME", "other": "OTHER", "novel": "NOVEL", "doujinshi": "DOUJINSHI", "anime": "ANIME"
-}
+media_source = {"original": "ORIGINAL", "manga": "MANGA", "light_novel": "LIGHT_NOVEL", "visual_novel": "VISUAL_NOVEL", "video_game": "VIDEO_GAME", "other": "OTHER", "novel": "NOVEL", "doujinshi": "DOUJINSHI", "anime": "ANIME"}
 base_url = "https://graphql.anilist.co"
 tag_query = "query{MediaTagCollection {name, category}}"
 genre_query = "query{GenreCollection}"
 country_codes = [
-    "af", "ax", "al", "dz", "as", "ad", "ao", "ai", "aq", "ag", "ar", "am", "aw", "au", "at", "az", "bs", "bh", "bd",
-    "bb", "by", "be", "bz", "bj", "bm", "bt", "bo", "bq", "ba", "bw", "bv", "br", "io", "bn", "bg", "bf", "bi", "cv",
-    "kh", "cm", "ca", "ky", "cf", "td", "cl", "cn", "cx", "cc", "co", "km", "cg", "cd", "ck", "cr", "ci", "hr", "cu",
-    "cw", "cy", "cz", "dk", "dj", "dm", "do", "ec", "eg", "sv", "gq", "er", "ee", "sz", "et", "fk", "fo", "fj", "fi",
-    "fr", "gf", "pf", "tf", "ga", "gm", "ge", "de", "gh", "gi", "gr", "gl", "gd", "gp", "gu", "gt", "gg", "gn", "gw",
-    "gy", "ht", "hm", "va", "hn", "hk", "hu", "is", "in", "id", "ir", "iq", "ie", "im", "il", "it", "jm", "jp", "je",
-    "jo", "kz", "ke", "ki", "kp", "kr", "kw", "kg", "la", "lv", "lb", "ls", "lr", "ly", "li", "lt", "lu", "mo", "mg",
-    "mw", "my", "mv", "ml", "mt", "mh", "mq", "mr", "mu", "yt", "mx", "fm", "md", "mc", "mn", "me", "ms", "ma", "mz",
-    "mm", "na", "nr", "np", "nl", "nc", "nz", "ni", "ne", "ng", "nu", "nf", "mk", "mp", "no", "om", "pk", "pw", "ps",
-    "pa", "pg", "py", "pe", "ph", "pn", "pl", "pt", "pr", "qa", "re", "ro", "ru", "rw", "bl", "sh", "kn", "lc", "mf",
-    "pm", "vc", "ws", "sm", "st", "sa", "sn", "rs", "sc", "sl", "sg", "sx", "sk", "si", "sb", "so", "za", "gs", "ss",
-    "es", "lk", "sd", "sr", "sj", "se", "ch", "sy", "tw", "tj", "tz", "th", "tl", "tg", "tk", "to", "tt", "tn", "tr",
-    "tm", "tc", "tv", "ug", "ua", "ae", "gb", "us", "um", "uy", "uz", "vu", "ve", "vn", "vg", "vi", "wf", "eh", "ye",
-    "zm", "zw",
+    "af",
+    "ax",
+    "al",
+    "dz",
+    "as",
+    "ad",
+    "ao",
+    "ai",
+    "aq",
+    "ag",
+    "ar",
+    "am",
+    "aw",
+    "au",
+    "at",
+    "az",
+    "bs",
+    "bh",
+    "bd",
+    "bb",
+    "by",
+    "be",
+    "bz",
+    "bj",
+    "bm",
+    "bt",
+    "bo",
+    "bq",
+    "ba",
+    "bw",
+    "bv",
+    "br",
+    "io",
+    "bn",
+    "bg",
+    "bf",
+    "bi",
+    "cv",
+    "kh",
+    "cm",
+    "ca",
+    "ky",
+    "cf",
+    "td",
+    "cl",
+    "cn",
+    "cx",
+    "cc",
+    "co",
+    "km",
+    "cg",
+    "cd",
+    "ck",
+    "cr",
+    "ci",
+    "hr",
+    "cu",
+    "cw",
+    "cy",
+    "cz",
+    "dk",
+    "dj",
+    "dm",
+    "do",
+    "ec",
+    "eg",
+    "sv",
+    "gq",
+    "er",
+    "ee",
+    "sz",
+    "et",
+    "fk",
+    "fo",
+    "fj",
+    "fi",
+    "fr",
+    "gf",
+    "pf",
+    "tf",
+    "ga",
+    "gm",
+    "ge",
+    "de",
+    "gh",
+    "gi",
+    "gr",
+    "gl",
+    "gd",
+    "gp",
+    "gu",
+    "gt",
+    "gg",
+    "gn",
+    "gw",
+    "gy",
+    "ht",
+    "hm",
+    "va",
+    "hn",
+    "hk",
+    "hu",
+    "is",
+    "in",
+    "id",
+    "ir",
+    "iq",
+    "ie",
+    "im",
+    "il",
+    "it",
+    "jm",
+    "jp",
+    "je",
+    "jo",
+    "kz",
+    "ke",
+    "ki",
+    "kp",
+    "kr",
+    "kw",
+    "kg",
+    "la",
+    "lv",
+    "lb",
+    "ls",
+    "lr",
+    "ly",
+    "li",
+    "lt",
+    "lu",
+    "mo",
+    "mg",
+    "mw",
+    "my",
+    "mv",
+    "ml",
+    "mt",
+    "mh",
+    "mq",
+    "mr",
+    "mu",
+    "yt",
+    "mx",
+    "fm",
+    "md",
+    "mc",
+    "mn",
+    "me",
+    "ms",
+    "ma",
+    "mz",
+    "mm",
+    "na",
+    "nr",
+    "np",
+    "nl",
+    "nc",
+    "nz",
+    "ni",
+    "ne",
+    "ng",
+    "nu",
+    "nf",
+    "mk",
+    "mp",
+    "no",
+    "om",
+    "pk",
+    "pw",
+    "ps",
+    "pa",
+    "pg",
+    "py",
+    "pe",
+    "ph",
+    "pn",
+    "pl",
+    "pt",
+    "pr",
+    "qa",
+    "re",
+    "ro",
+    "ru",
+    "rw",
+    "bl",
+    "sh",
+    "kn",
+    "lc",
+    "mf",
+    "pm",
+    "vc",
+    "ws",
+    "sm",
+    "st",
+    "sa",
+    "sn",
+    "rs",
+    "sc",
+    "sl",
+    "sg",
+    "sx",
+    "sk",
+    "si",
+    "sb",
+    "so",
+    "za",
+    "gs",
+    "ss",
+    "es",
+    "lk",
+    "sd",
+    "sr",
+    "sj",
+    "se",
+    "ch",
+    "sy",
+    "tw",
+    "tj",
+    "tz",
+    "th",
+    "tl",
+    "tg",
+    "tk",
+    "to",
+    "tt",
+    "tn",
+    "tr",
+    "tm",
+    "tc",
+    "tv",
+    "ug",
+    "ua",
+    "ae",
+    "gb",
+    "us",
+    "um",
+    "uy",
+    "uz",
+    "vu",
+    "ve",
+    "vn",
+    "vg",
+    "vi",
+    "wf",
+    "eh",
+    "ye",
+    "zm",
+    "zw",
 ]
+
 
 class AniList:
     def __init__(self, requests):
@@ -66,10 +334,14 @@ class AniList:
         if self._options:
             return self._options
         self._options = {
-            "Tag": {}, "Tag Category": {},
+            "Tag": {},
+            "Tag Category": {},
             "Genre": {g.lower().replace(" ", "-"): g for g in self._request(genre_query, {})["data"]["GenreCollection"]},
             "Country": {c: c.upper() for c in country_codes},
-            "Season": media_season, "Format": media_format, "Status": media_status, "Source": media_source,
+            "Season": media_season,
+            "Format": media_format,
+            "Status": media_status,
+            "Source": media_source,
         }
         for media_tag in self._request(tag_query, {})["data"]["MediaTagCollection"]:
             self._options["Tag"][media_tag["name"].lower().replace(" ", "-")] = media_tag["name"]
@@ -83,7 +355,7 @@ class AniList:
         json_obj = response.json()
         logger.trace(f"Response: {json_obj}")
         if "errors" in json_obj:
-            if json_obj['errors'][0]['message'] == "Too Many Requests.":
+            if json_obj["errors"][0]["message"] == "Too Many Requests.":
                 wait_time = int(response.headers["Retry-After"]) if "Retry-After" in response.headers else 0
                 time.sleep(wait_time if wait_time > 0 else 10)
                 if level < 6:
@@ -126,7 +398,7 @@ class AniList:
 
     def _search(self, **kwargs):
         media_vars = f"sort: {sort_options[kwargs['sort_by']]}, type: ANIME"
-        variables = {"sort": sort_options[kwargs['sort_by']]}
+        variables = {"sort": sort_options[kwargs["sort_by"]]}
         for key, value in kwargs.items():
             if key not in ["sort_by", "limit"]:
                 if "." in key:
@@ -142,7 +414,7 @@ class AniList:
                     except Failed as e:
                         raise Failed(f"Collection Error: anilist_search {key}: {e}")
                 elif attr in ["format", "status", "genre", "tag", "tag_category"]:
-                    temp_value = [self.options[attr.replace('_', ' ').title()][v.lower().replace(' / ', '-').replace(' ', '-')] for v in value]
+                    temp_value = [self.options[attr.replace("_", " ").title()][v.lower().replace(" / ", "-").replace(" ", "-")] for v in value]
                     if attr in ["format", "status"]:
                         value = f"[{', '.join(temp_value)}]"
                     else:
@@ -210,8 +482,7 @@ class AniList:
             anilist_id, name = self._validate_id(anilist_id)
             anilist_ids.append(anilist_id)
         json_obj = self._request(query, {"id": anilist_id})
-        edges = [media["node"]["id"] for media in json_obj["data"]["Media"]["relations"]["edges"]
-                 if media["relationType"] not in ["CHARACTER", "OTHER"] and media["node"]["type"] == "ANIME"]
+        edges = [media["node"]["id"] for media in json_obj["data"]["Media"]["relations"]["edges"] if media["relationType"] not in ["CHARACTER", "OTHER"] and media["node"]["type"] == "ANIME"]
         for media in json_obj["data"]["Media"]["relations"]["nodes"]:
             if media["id"] and media["id"] not in ignore_ids and media["id"] in edges and media["type"] == "ANIME":
                 new_anilist_ids.append(media["id"])
@@ -280,7 +551,8 @@ class AniList:
             try:
                 self._request(query, {"id": anilist_id})
                 anilist_values.append(anilist_id)
-            except Failed as e:     logger.error(e)
+            except Failed as e:
+                logger.error(e)
         if len(anilist_values) > 0:
             return anilist_values
         raise Failed(f"AniList Error: No valid AniList IDs in {anilist_ids}")
@@ -309,7 +581,7 @@ class AniList:
             elif method not in builders:
                 raise Failed(f"AniList Error: Method {method} not supported")
             message = f"Processing {method.replace('_', ' ').title().replace('Anilist', 'AniList')}:\n    Sort By {pretty_names[data['sort_by']]}"
-            if data['limit'] > 0:
+            if data["limit"] > 0:
                 message += f"\n    Limit to {data['limit']} Anime"
             for key, value in data.items():
                 if key not in ["limit", "sort_by"]:

--- a/modules/apprise_notify.py
+++ b/modules/apprise_notify.py
@@ -1,4 +1,5 @@
 import apprise as apprise_lib
+
 from modules import util, webhooks
 from modules.util import Failed
 

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -14,7 +14,7 @@ from modules import anidb, anilist, icheckmovies, imdb, letterboxd, mal, mdblist
 from modules.overlay import Overlay
 from modules.poster import KometaImage
 from modules.request import quote
-from modules.util import Deleted, Failed, FilterFailed, NonExisting, NotScheduled, NotScheduledRange, ServiceError, BuilderValidationError
+from modules.util import BuilderValidationError, Deleted, Failed, FilterFailed, NonExisting, NotScheduled, NotScheduledRange, ServiceError
 
 logger = util.logger
 
@@ -1654,7 +1654,9 @@ class CollectionBuilder:
             raise BuilderValidationError(f"{self.Type} Error: No builders allowed with blank_collection")
 
         if not isinstance(self.custom_sort, list) and self.custom_sort and (len(self.builders) > 1 or self.builders[0][0] not in custom_sort_builders):
-            raise BuilderValidationError(f"{self.Type} Error: " + ("Playlists" if self.playlist else "collection_order: custom") + (f" can only be used with a single builder per {self.type}" if len(self.builders) > 1 else f" cannot be used with {self.builders[0][0]}"))
+            raise BuilderValidationError(
+                f"{self.Type} Error: " + ("Playlists" if self.playlist else "collection_order: custom") + (f" can only be used with a single builder per {self.type}" if len(self.builders) > 1 else f" cannot be used with {self.builders[0][0]}")
+            )
 
         if "add_missing" not in self.radarr_details:
             self.radarr_details["add_missing"] = self.library.Radarr.add_missing if self.library.Radarr else False
@@ -2245,30 +2247,18 @@ class CollectionBuilder:
                             invalid_categories.append(category_filter)
 
                     if award_filters and not final_awards:
-                        raise BuilderValidationError(
-                            f"{self.Type} Error: imdb_award award_filter attribute invalid: "
-                            f"none of the provided award_filter values exist: [{', '.join(award_filters)}]. "
-                            f"Valid Award Options: [{', '.join(award_names)}]"
-                        )
+                        raise BuilderValidationError(f"{self.Type} Error: imdb_award award_filter attribute invalid: " f"none of the provided award_filter values exist: [{', '.join(award_filters)}]. " f"Valid Award Options: [{', '.join(award_names)}]")
 
                     if category_filters and not final_category:
                         raise BuilderValidationError(
-                            f"{self.Type} Error: imdb_award category_filter attribute invalid: "
-                            f"none of the provided category_filter values exist: [{', '.join(category_filters)}]. "
-                            f"Valid Category Options: [{', '.join(category_names)}]"
+                            f"{self.Type} Error: imdb_award category_filter attribute invalid: " f"none of the provided category_filter values exist: [{', '.join(category_filters)}]. " f"Valid Category Options: [{', '.join(category_names)}]"
                         )
 
                     for invalid_award in invalid_awards:
-                        logger.warning(
-                            f"{self.Type} Warning: imdb_award award_filter attribute invalid: "
-                            f"{invalid_award} not found and will be ignored"
-                        )
+                        logger.warning(f"{self.Type} Warning: imdb_award award_filter attribute invalid: " f"{invalid_award} not found and will be ignored")
 
                     for invalid_category in invalid_categories:
-                        logger.warning(
-                            f"{self.Type} Warning: imdb_award category_filter attribute invalid: "
-                            f"{invalid_category} not found and will be ignored"
-                        )
+                        logger.warning(f"{self.Type} Warning: imdb_award category_filter attribute invalid: " f"{invalid_category} not found and will be ignored")
 
                 self.builders.append(
                     (
@@ -3520,7 +3510,7 @@ class CollectionBuilder:
                 if rating_key in getattr(pl_library, "show_map", {}).get(ignored_id, []):
                     return True
         return False
-    
+
     def filter_and_save_items(self, ids):
         total_ids = len(ids)
         items = []
@@ -4148,13 +4138,13 @@ class CollectionBuilder:
             if isinstance(data, dict) and data:
                 has_percentage = "percentage" in data
                 has_count = "count" in data
-                
+
                 if has_percentage and has_count:
                     raise BuilderValidationError(f"{self.Type} Error: Cannot use both percentage and count in {attribute} filter. Please use one or the other.")
-                
+
                 percentage = None
                 count = None
-                
+
                 if has_count:
                     if data["count"] is None:
                         logger.warning(f"{self.Type} Warning: count filter attribute is blank")
@@ -4178,13 +4168,13 @@ class CollectionBuilder:
                 else:
                     # Default to percentage if neither is specified
                     percentage = self.default_percent
-                
+
                 final_filters = {}
                 if count is not None:
                     final_filters["count"] = count
                 else:
                     final_filters["percentage"] = percentage
-                    
+
                 for filter_method, filter_data in data.items():
                     filter_attr, filter_modifier, filter_final = self.library.split(filter_method)
                     message = None

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -51,53 +51,40 @@ class Cache:
                     "tmdb_episode_data",
                 ]:
                     cursor.execute(f"DROP TABLE IF EXISTS {old_table}")
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS guids_map (
+                cursor.execute("""CREATE TABLE IF NOT EXISTS guids_map (
                     key INTEGER PRIMARY KEY,
                     plex_guid TEXT UNIQUE,
                     t_id TEXT,
                     imdb_id TEXT,
                     media_type TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS imdb_to_tmdb_map (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS imdb_to_tmdb_map (
                     key INTEGER PRIMARY KEY,
                     imdb_id TEXT UNIQUE,
                     tmdb_id TEXT,
                     media_type TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS imdb_to_tvdb_map2 (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS imdb_to_tvdb_map2 (
                     key INTEGER PRIMARY KEY,
                     imdb_id TEXT UNIQUE,
                     tvdb_id TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS tmdb_to_tvdb_map2 (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS tmdb_to_tvdb_map2 (
                     key INTEGER PRIMARY KEY,
                     tmdb_id TEXT UNIQUE,
                     tvdb_id TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS letterboxd_map (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS letterboxd_map (
                     key INTEGER PRIMARY KEY,
                     letterboxd_id TEXT UNIQUE,
                     tmdb_id TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS mojo_map (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS mojo_map (
                     key INTEGER PRIMARY KEY,
                     mojo_url TEXT UNIQUE,
                     imdb_id TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS omdb_data3 (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS omdb_data3 (
                     key INTEGER PRIMARY KEY,
                     imdb_id TEXT UNIQUE,
                     title TEXT,
@@ -112,10 +99,8 @@ class Cache:
                     series_id TEXT,
                     season_num INTEGER,
                     episode_num INTEGER,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS mdb_data5 (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS mdb_data5 (
                     key INTEGER PRIMARY KEY,
                     key_id TEXT UNIQUE,
                     title TEXT,
@@ -140,10 +125,8 @@ class Cache:
                     certification TEXT,
                     commonsense TEXT,
                     age_rating TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS anidb_data4 (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS anidb_data4 (
                     key INTEGER PRIMARY KEY,
                     anidb_id INTEGER UNIQUE,
                     main_title TEXT,
@@ -158,10 +141,8 @@ class Cache:
                     imdb_id TEXT,
                     tmdb_id INTEGER,
                     tmdb_type TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS mal_data4 (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS mal_data4 (
                     key INTEGER PRIMARY KEY,
                     mal_id INTEGER UNIQUE,
                     title TEXT,
@@ -179,10 +160,8 @@ class Cache:
                     expiration_date TEXT,
                     explicit_genres TEXT,
                     themes TEXT,
-                    demographics TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS tmdb_movie_data2 (
+                    demographics TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS tmdb_movie_data2 (
                     key INTEGER PRIMARY KEY,
                     tmdb_id INTEGER,
                     language TEXT,
@@ -204,10 +183,8 @@ class Cache:
                     collection_id INTEGER,
                     collection_name TEXT,
                     expiration_date TEXT,
-                    UNIQUE(tmdb_id, language))"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS tmdb_show_data4 (
+                    UNIQUE(tmdb_id, language))""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS tmdb_show_data4 (
                     key INTEGER PRIMARY KEY,
                     tmdb_id INTEGER,
                     language TEXT,
@@ -233,10 +210,8 @@ class Cache:
                     countries TEXT,
                     seasons TEXT,
                     expiration_date TEXT,
-                    UNIQUE(tmdb_id, language))"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS tmdb_episode_data2 (
+                    UNIQUE(tmdb_id, language))""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS tmdb_episode_data2 (
                     key INTEGER PRIMARY KEY,
                     tmdb_id INTEGER,
                     season_number INTEGER,
@@ -251,10 +226,8 @@ class Cache:
                     imdb_id TEXT,
                     tvdb_id INTEGER,
                     expiration_date TEXT,
-                    UNIQUE(tmdb_id, season_number, episode_number, language))"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS tvdb_data4 (
+                    UNIQUE(tmdb_id, season_number, episode_number, language))""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS tvdb_data4 (
                     key INTEGER PRIMARY KEY,
                     tvdb_id INTEGER UNIQUE,
                     type TEXT,
@@ -265,74 +238,54 @@ class Cache:
                     background_url TEXT,
                     release_date TEXT,
                     genres TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS tvdb_map (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS tvdb_map (
                     key INTEGER PRIMARY KEY,
                     tvdb_url TEXT UNIQUE,
                     tvdb_id INTEGER,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS anime_map (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS anime_map (
                     key INTEGER PRIMARY KEY,
                     anidb TEXT UNIQUE,
                     anilist TEXT,
                     myanimelist TEXT,
                     kitsu TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS image_maps (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS image_maps (
                     key INTEGER PRIMARY KEY,
-                    library TEXT UNIQUE)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS radarr_adds (
+                    library TEXT UNIQUE)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS radarr_adds (
                     key INTEGER PRIMARY KEY,
                     tmdb_id TEXT,
-                    library TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS sonarr_adds (
+                    library TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS sonarr_adds (
                     key INTEGER PRIMARY KEY,
                     tvdb_id TEXT,
-                    library TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS list_cache (
+                    library TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS list_cache (
                     key INTEGER PRIMARY KEY,
                     list_type TEXT,
                     list_data TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS list_ids (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS list_ids (
                     key INTEGER PRIMARY KEY,
                     list_key TEXT,
                     media_id TEXT,
-                    media_type TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS letterboxd_incremental_state (
+                    media_type TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS letterboxd_incremental_state (
                     key INTEGER PRIMARY KEY,
                     username TEXT,
                     page_type TEXT,
                     last_timestamp TEXT,
                     last_item_ids TEXT,
                     last_updated TEXT,
-                    UNIQUE(username, page_type))"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS imdb_keywords (
+                    UNIQUE(username, page_type))""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS imdb_keywords (
                     key INTEGER PRIMARY KEY,
                     imdb_id TEXT,
                     keywords TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS imdb_parental (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS imdb_parental (
                     key INTEGER PRIMARY KEY,
                     imdb_id TEXT,
                     nudity TEXT,
@@ -340,54 +293,43 @@ class Cache:
                     profanity TEXT,
                     alcohol TEXT,
                     frightening TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS ergast_race (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS ergast_race (
                     key INTEGER PRIMARY KEY,
                     season INTEGER,
                     round INTEGER,
                     name TEXT,
                     date TEXT,
-                    expiration_date TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS overlay_special_text2 (
+                    expiration_date TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS overlay_special_text2 (
                     key INTEGER PRIMARY KEY,
                     rating_key TEXT,
                     type TEXT,
-                    text TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS testing (
+                    text TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS testing (
                     key INTEGER PRIMARY KEY,
                     name TEXT,
                     value1 TEXT,
                     value2 TEXT,
-                    success TEXT)"""
-                )
-                cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS plex_people_cache (
+                    success TEXT)""")
+                cursor.execute("""CREATE TABLE IF NOT EXISTS plex_people_cache (
                     key INTEGER PRIMARY KEY,
                     item_id TEXT,
                     people_type TEXT,
                     people_data TEXT,
                     expiration_date TEXT,
-                    UNIQUE(item_id, people_type))"""
-                )
+                    UNIQUE(item_id, people_type))""")
                 cursor.execute("PRAGMA table_info(plex_people_cache)")
                 plex_people_columns = [row[1] for row in cursor.fetchall()]
                 if "item_id" not in plex_people_columns:
                     cursor.execute("DROP TABLE IF EXISTS plex_people_cache")
-                    cursor.execute(
-                        """CREATE TABLE IF NOT EXISTS plex_people_cache (
+                    cursor.execute("""CREATE TABLE IF NOT EXISTS plex_people_cache (
                         key INTEGER PRIMARY KEY,
                         item_id TEXT,
                         people_type TEXT,
                         people_data TEXT,
                         expiration_date TEXT,
-                        UNIQUE(item_id, people_type))"""
-                    )
+                        UNIQUE(item_id, people_type))""")
                 cursor.execute("SELECT count(name) FROM sqlite_master WHERE type='table' AND name='image_map'")
                 if cursor.fetchone()[0] > 0:
                     cursor.execute("SELECT DISTINCT library FROM image_map")
@@ -1056,68 +998,54 @@ class Cache:
                 row = cursor.fetchone()
                 if row and row["key"]:
                     table_name = f"image_map_{row['key']}"
-                    cursor.execute(
-                        f"""CREATE TABLE IF NOT EXISTS {table_name}_overlays (
+                    cursor.execute(f"""CREATE TABLE IF NOT EXISTS {table_name}_overlays (
                         key INTEGER PRIMARY KEY,
                         rating_key TEXT UNIQUE,
                         overlay TEXT,
                         compare TEXT,
-                        location TEXT)"""
-                    )
-                    cursor.execute(
-                        f"""CREATE TABLE IF NOT EXISTS {table_name}_square_arts (
+                        location TEXT)""")
+                    cursor.execute(f"""CREATE TABLE IF NOT EXISTS {table_name}_square_arts (
                         key INTEGER PRIMARY KEY,
                         rating_key TEXT UNIQUE,
                         overlay TEXT,
                         compare TEXT,
-                        location TEXT)"""
-                    )
+                        location TEXT)""")
                 else:
                     cursor.execute("INSERT OR IGNORE INTO image_maps(library) VALUES(?)", (library,))
                     cursor.execute("SELECT * FROM image_maps WHERE library = ?", (library,))
                     row = cursor.fetchone()
                     if row and row["key"]:
                         table_name = f"image_map_{row['key']}"
-                        cursor.execute(
-                            f"""CREATE TABLE IF NOT EXISTS {table_name} (
+                        cursor.execute(f"""CREATE TABLE IF NOT EXISTS {table_name} (
                             key INTEGER PRIMARY KEY,
                             rating_key TEXT UNIQUE,
                             overlay TEXT,
                             compare TEXT,
-                            location TEXT)"""
-                        )
-                        cursor.execute(
-                            f"""CREATE TABLE IF NOT EXISTS {table_name}_backgrounds (
+                            location TEXT)""")
+                        cursor.execute(f"""CREATE TABLE IF NOT EXISTS {table_name}_backgrounds (
                             key INTEGER PRIMARY KEY,
                             rating_key TEXT UNIQUE,
                             overlay TEXT,
                             compare TEXT,
-                            location TEXT)"""
-                        )
-                        cursor.execute(
-                            f"""CREATE TABLE IF NOT EXISTS {table_name}_logos (
+                            location TEXT)""")
+                        cursor.execute(f"""CREATE TABLE IF NOT EXISTS {table_name}_logos (
                             key INTEGER PRIMARY KEY,
                             rating_key TEXT UNIQUE,
                             overlay TEXT,
                             compare TEXT,
-                            location TEXT)"""
-                        )
-                        cursor.execute(
-                            f"""CREATE TABLE IF NOT EXISTS {table_name}_overlays (
+                            location TEXT)""")
+                        cursor.execute(f"""CREATE TABLE IF NOT EXISTS {table_name}_overlays (
                             key INTEGER PRIMARY KEY,
                             rating_key TEXT UNIQUE,
                             overlay TEXT,
                             compare TEXT,
-                            location TEXT)"""
-                        )
-                        cursor.execute(
-                            f"""CREATE TABLE IF NOT EXISTS {table_name}_square_arts (
+                            location TEXT)""")
+                        cursor.execute(f"""CREATE TABLE IF NOT EXISTS {table_name}_square_arts (
                             key INTEGER PRIMARY KEY,
                             rating_key TEXT UNIQUE,
                             overlay TEXT,
                             compare TEXT,
-                            location TEXT)"""
-                        )
+                            location TEXT)""")
         return table_name
 
     def query_image_map(self, rating_key, table_name):

--- a/modules/convert.py
+++ b/modules/convert.py
@@ -1,13 +1,16 @@
 import re
-from modules import util
-from modules.util import Failed, NonExisting, MappingConvertError
-from modules.request import urlparse
+
 from plexapi.exceptions import BadRequest
 from requests.exceptions import ConnectionError
+
+from modules import util
+from modules.request import urlparse
+from modules.util import Failed, MappingConvertError, NonExisting
 
 logger = util.logger
 
 anime_lists_url = "https://raw.githubusercontent.com/Kometa-Team/Anime-IDs/master/anime_ids.json"
+
 
 class Convert:
     def __init__(self, requests, cache, tmdb):
@@ -296,9 +299,12 @@ class Convert:
                     for guid_tag in item.guids:
                         try:
                             url_parsed = urlparse(guid_tag.id)
-                            if url_parsed.scheme == "tvdb" and library.is_show:                 tvdb_id.append(int(url_parsed.netloc))
-                            elif url_parsed.scheme == "imdb":               imdb_id.append(url_parsed.netloc)
-                            elif url_parsed.scheme == "tmdb":               tmdb_id.append(int(url_parsed.netloc))
+                            if url_parsed.scheme == "tvdb" and library.is_show:
+                                tvdb_id.append(int(url_parsed.netloc))
+                            elif url_parsed.scheme == "imdb":
+                                imdb_id.append(url_parsed.netloc)
+                            elif url_parsed.scheme == "tmdb":
+                                tmdb_id.append(int(url_parsed.netloc))
                         except ValueError:
                             pass
                 except ConnectionError:
@@ -308,9 +314,12 @@ class Convert:
                 if not tvdb_id and not imdb_id and not tmdb_id:
                     library.query(item.refresh)
                     raise MappingConvertError("Mapping Error: Please refresh metadata on this item/library")
-            elif item_type == "imdb":                       imdb_id.append(check_id)
-            elif item_type == "thetvdb":                    tvdb_id.append(int(check_id))
-            elif item_type == "themoviedb":                 tmdb_id.append(int(check_id))
+            elif item_type == "imdb":
+                imdb_id.append(check_id)
+            elif item_type == "thetvdb":
+                tvdb_id.append(int(check_id))
+            elif item_type == "themoviedb":
+                tmdb_id.append(int(check_id))
             elif item_type in ["xbmcnfo", "xbmcnfotv"]:
                 if len(check_id) > 10:
                     raise MappingConvertError(f"Mapping Error: XMBC NFO Local ID '{check_id}'")
@@ -336,8 +345,10 @@ class Convert:
                     anidb_id = self._mal_to_anidb[int(check_id)]
                 else:
                     raise MappingConvertError(f"Convert Error: No AniDB ID found for MyAnimeList ID '{check_id}'")
-            elif item_type == "local":                      raise NonExisting("No match in Plex")
-            else:                                           raise NonExisting(f"Agent {item_type} not supported")
+            elif item_type == "local":
+                raise NonExisting("No match in Plex")
+            else:
+                raise NonExisting(f"Agent {item_type} not supported")
 
             if anidb_id:
                 if anidb_id in self._anidb_to_imdb:

--- a/modules/ergast.py
+++ b/modules/ergast.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+
 from modules import util
 from modules.util import Failed
 
@@ -8,17 +9,58 @@ base_url = "https://api.jolpi.ca/ergast/f1/"
 
 translations = {
     "nl": {
-        "70th Anniversary": "70th Anniversary", "Abu Dhabi": "Abu Dhabi", "Argentine": "Argentinië", "Australian": "Australië",
-        "Austrian": "Oostenrijk", "Azerbaijan": "Azerbeidzjan", "Bahrain": "Bahrein", "Belgian": "België", "Brazilian": "Brazilië",
-        "British": "Groot-Brittannië", "Caesars Palace": "Caesars Palace", "Canadian": "Canada", "Chinese": "China", "Dallas": "Dallas",
-        "Detroit": "Detroit", "Dutch": "Nederland", "Eifel": "Eifel", "Emilia Romagna": "Emilia Romagna", "European": "Europa",
-        "French": "Frankrijk", "German": "Duitsland", "Hungarian": "Hongarije", "Indian": "India", "Indianapolis 500": "Indianapolis 500",
-        "Italian": "Italië", "Japanese": "Japan", "Korean": "Zuid-Korea", "Luxembourg": "Luxemburg", "Malaysian": "Maleisië",
-        "Mexican": "Mexico", "Mexico City": "Mexico City", "Miami": "Miami", "Monaco": "Monaco", "Moroccan": "Marroko",
-        "Pacific": "Pacific", "Pescara": "Pescara", "Portuguese": "Portugal", "Qatar": "Qatar", "Russian": "Rusland",
-        "Sakhir": "Sakhir", "San Marino": "San Marino", "Saudi Arabian": "Saudi Arabië", "Singapore": "Singapore",
-        "South African": "Zuid-Afrika", "Spanish": "Spanje", "Styrian": "Stiermarken", "Swedish": "Zweden", "Swiss": "Zwitserland",
-        "São Paulo": "São Paulo", "Turkish": "Turkije", "Tuscan": "Toscane", "United States": "Verenigde Staten"
+        "70th Anniversary": "70th Anniversary",
+        "Abu Dhabi": "Abu Dhabi",
+        "Argentine": "Argentinië",
+        "Australian": "Australië",
+        "Austrian": "Oostenrijk",
+        "Azerbaijan": "Azerbeidzjan",
+        "Bahrain": "Bahrein",
+        "Belgian": "België",
+        "Brazilian": "Brazilië",
+        "British": "Groot-Brittannië",
+        "Caesars Palace": "Caesars Palace",
+        "Canadian": "Canada",
+        "Chinese": "China",
+        "Dallas": "Dallas",
+        "Detroit": "Detroit",
+        "Dutch": "Nederland",
+        "Eifel": "Eifel",
+        "Emilia Romagna": "Emilia Romagna",
+        "European": "Europa",
+        "French": "Frankrijk",
+        "German": "Duitsland",
+        "Hungarian": "Hongarije",
+        "Indian": "India",
+        "Indianapolis 500": "Indianapolis 500",
+        "Italian": "Italië",
+        "Japanese": "Japan",
+        "Korean": "Zuid-Korea",
+        "Luxembourg": "Luxemburg",
+        "Malaysian": "Maleisië",
+        "Mexican": "Mexico",
+        "Mexico City": "Mexico City",
+        "Miami": "Miami",
+        "Monaco": "Monaco",
+        "Moroccan": "Marroko",
+        "Pacific": "Pacific",
+        "Pescara": "Pescara",
+        "Portuguese": "Portugal",
+        "Qatar": "Qatar",
+        "Russian": "Rusland",
+        "Sakhir": "Sakhir",
+        "San Marino": "San Marino",
+        "Saudi Arabian": "Saudi Arabië",
+        "Singapore": "Singapore",
+        "South African": "Zuid-Afrika",
+        "Spanish": "Spanje",
+        "Styrian": "Stiermarken",
+        "Swedish": "Zweden",
+        "Swiss": "Zwitserland",
+        "São Paulo": "São Paulo",
+        "Turkish": "Turkije",
+        "Tuscan": "Toscane",
+        "United States": "Verenigde Staten",
     }
 }
 
@@ -66,6 +108,7 @@ names = {
         "Sprint Shootout Session": "Sprint Shootout",
     }
 }
+
 
 class Race:
     def __init__(self, data, language, round_prefix, shorten_gp):
@@ -126,7 +169,7 @@ class Race:
                 output = "Pre-Qualifying Build-up"
             elif any([x in title for x in terms["post"]]):
                 output = "Post-Qualifying Analysis"
-            elif any ([x in title for x in terms["notebook"]]):
+            elif any([x in title for x in terms["notebook"]]):
                 output = "Ted's Qualifying Notebook"
             else:
                 output = "Qualifying"
@@ -152,11 +195,9 @@ class Race:
         if "2160" in title or "4K" in title:
             output = f"{output} (4K)"
 
-        if (sprint_weekend and any([x in output for x in ["Sprint", "Free Practice 2"]])) or \
-                (not sprint_weekend and any([x in output for x in ["Qualifying", "Free Practice 3"]])):
+        if (sprint_weekend and any([x in output for x in ["Sprint", "Free Practice 2"]])) or (not sprint_weekend and any([x in output for x in ["Qualifying", "Free Practice 3"]])):
             video_date = self.date - timedelta(days=1)
-        elif (sprint_weekend and any([x in output for x in ["Qualifying", "Free Practice 1", "Formula 1 Cafe"]])) or \
-                (not sprint_weekend and any([x in output for x in ["Free Practice 1", "Free Practice 2", "Formula 1 Cafe"]])):
+        elif (sprint_weekend and any([x in output for x in ["Qualifying", "Free Practice 1", "Formula 1 Cafe"]])) or (not sprint_weekend and any([x in output for x in ["Free Practice 1", "Free Practice 2", "Formula 1 Cafe"]])):
             video_date = self.date - timedelta(days=2)
         else:
             video_date = self.date

--- a/modules/github.py
+++ b/modules/github.py
@@ -1,4 +1,5 @@
 import re
+
 from modules import util
 from modules.util import Failed
 
@@ -8,6 +9,7 @@ raw_url = "https://raw.githubusercontent.com"
 base_url = "https://api.github.com"
 kometa_base = f"{base_url}/repos/Kometa-Team/Kometa"
 configs_raw_url = f"{raw_url}/Kometa-Team/Community-Configs"
+
 
 class GitHub:
     def __init__(self, requests, params):

--- a/modules/gotify.py
+++ b/modules/gotify.py
@@ -1,4 +1,5 @@
 from json import JSONDecodeError
+
 from modules import util, webhooks
 from modules.util import Failed
 

--- a/modules/icheckmovies.py
+++ b/modules/icheckmovies.py
@@ -6,6 +6,7 @@ logger = util.logger
 builders = ["icheckmovies_list", "icheckmovies_list_details"]
 base_url = "https://www.icheckmovies.com/lists/"
 
+
 class ICheckMovies:
     def __init__(self, requests):
         self.requests = requests
@@ -16,7 +17,7 @@ class ICheckMovies:
 
     def _parse_list(self, list_url):
         imdb_urls = self._request(list_url, "//a[@class='optionIcon optionIMDB external']/@href")
-        return [(t[t.find("/tt") + 1:-1], "imdb") for t in imdb_urls]
+        return [(t[t.find("/tt") + 1 : -1], "imdb") for t in imdb_urls]
 
     def get_list_description(self, list_url):
         descriptions = self._request(list_url, "//div[@class='span-19 last']/p/em/text()")

--- a/modules/imdb.py
+++ b/modules/imdb.py
@@ -1,14 +1,18 @@
-import csv, gzip, json, math, os, re, shutil
+import csv
+import gzip
+import json
+import math
+import os
+import re
+import shutil
+
 from modules import util
 from modules.util import Failed
 
 logger = util.logger
 
 builders = ["imdb_list", "imdb_id", "imdb_chart", "imdb_watchlist", "imdb_search", "imdb_award"]
-movie_charts = [
-    "box_office", "popular_movies", "top_movies", "top_english", "lowest_rated",
-    "top_indian", "top_tamil", "top_telugu", "top_malayalam", "trending_india", "trending_tamil", "trending_telugu"
-]
+movie_charts = ["box_office", "popular_movies", "top_movies", "top_english", "lowest_rated", "top_indian", "top_tamil", "top_telugu", "top_malayalam", "trending_india", "trending_tamil", "trending_telugu"]
 show_charts = ["popular_shows", "top_shows", "trending_india"]
 charts = {
     "box_office": "Box Office",
@@ -47,55 +51,99 @@ chart_urls = {
 # that returns exact chart data in correct rank order (bypasses HTML scraping + AWS WAF)
 chart_graphql_map = {
     # chartTitles query: returns edges->node->id, has total field
-    "top_movies":       {"query": "chartTitles", "chartType": "TOP_RATED_MOVIES", "first": 250},
-    "top_shows":        {"query": "chartTitles", "chartType": "TOP_RATED_TV_SHOWS", "first": 250},
-    "popular_movies":   {"query": "chartTitles", "chartType": "MOST_POPULAR_MOVIES", "first": 100},
-    "popular_shows":    {"query": "chartTitles", "chartType": "MOST_POPULAR_TV_SHOWS", "first": 100},
-    "lowest_rated":     {"query": "chartTitles", "chartType": "LOWEST_RATED_MOVIES", "first": 100},
-    "top_english":      {"query": "chartTitles", "chartType": "TOP_RATED_ENGLISH_MOVIES", "first": 250},
-    "top_indian":       {"query": "chartTitles", "chartType": "TOP_RATED_INDIAN_MOVIES", "first": 250},
-    "top_tamil":        {"query": "chartTitles", "chartType": "TOP_RATED_TAMIL_MOVIES", "first": 250},
-    "top_telugu":       {"query": "chartTitles", "chartType": "TOP_RATED_TELUGU_MOVIES", "first": 250},
-    "top_malayalam":    {"query": "chartTitles", "chartType": "TOP_RATED_MALAYALAM_MOVIES", "first": 250},
+    "top_movies": {"query": "chartTitles", "chartType": "TOP_RATED_MOVIES", "first": 250},
+    "top_shows": {"query": "chartTitles", "chartType": "TOP_RATED_TV_SHOWS", "first": 250},
+    "popular_movies": {"query": "chartTitles", "chartType": "MOST_POPULAR_MOVIES", "first": 100},
+    "popular_shows": {"query": "chartTitles", "chartType": "MOST_POPULAR_TV_SHOWS", "first": 100},
+    "lowest_rated": {"query": "chartTitles", "chartType": "LOWEST_RATED_MOVIES", "first": 100},
+    "top_english": {"query": "chartTitles", "chartType": "TOP_RATED_ENGLISH_MOVIES", "first": 250},
+    "top_indian": {"query": "chartTitles", "chartType": "TOP_RATED_INDIAN_MOVIES", "first": 250},
+    "top_tamil": {"query": "chartTitles", "chartType": "TOP_RATED_TAMIL_MOVIES", "first": 250},
+    "top_telugu": {"query": "chartTitles", "chartType": "TOP_RATED_TELUGU_MOVIES", "first": 250},
+    "top_malayalam": {"query": "chartTitles", "chartType": "TOP_RATED_MALAYALAM_MOVIES", "first": 250},
     # boxOfficeWeekendChart query: returns entries->title->id
-    "box_office":       {"query": "boxOfficeWeekendChart"},
+    "box_office": {"query": "boxOfficeWeekendChart"},
     # topTrendingSetsPredefined query: returns edges->node->item->...on Title->id
-    "trending_india":   {"query": "topTrendingSetsPredefined", "predefined": "INDIA_TITLE_TRENDS_UPCOMING", "first": 50},
-    "trending_tamil":   {"query": "topTrendingSetsPredefined", "predefined": "INDIA_TITLE_TRENDS_RELEASED_TAMIL", "first": 200},
-    "trending_telugu":  {"query": "topTrendingSetsPredefined", "predefined": "INDIA_TITLE_TRENDS_RELEASED_TELUGU", "first": 200},
+    "trending_india": {"query": "topTrendingSetsPredefined", "predefined": "INDIA_TITLE_TRENDS_UPCOMING", "first": 50},
+    "trending_tamil": {"query": "topTrendingSetsPredefined", "predefined": "INDIA_TITLE_TRENDS_RELEASED_TAMIL", "first": 200},
+    "trending_telugu": {"query": "topTrendingSetsPredefined", "predefined": "INDIA_TITLE_TRENDS_RELEASED_TELUGU", "first": 200},
 }
 
 imdb_search_attributes = [
     "limit",
     "sort_by",
     "title",
-    "type", "type.not",
-    "release.after", "release.before", "rating.gte", "rating.lte",
-    "votes.gte", "votes.lte",
-    "genre", "genre.any", "genre.not",
-    "interests", "interests.any", "interests.not",
-    "topic", "topic.any", "topic.not",
-    "alternate_version", "alternate_version.any", "alternate_version.not",
-    "crazy_credit", "crazy_credit.any", "crazy_credit.not",
-    "location", "location.any", "location.not",
-    "goof", "goof.any", "goof.not",
-    "plot", "plot.any", "plot.not",
-    "quote", "quote.any", "quote.not",
-    "soundtrack", "soundtrack.any", "soundtrack.not",
-    "trivia", "trivia.any", "trivia.not",
-    "event", "event.winning",
-    "imdb_top", "imdb_bottom",
+    "type",
+    "type.not",
+    "release.after",
+    "release.before",
+    "rating.gte",
+    "rating.lte",
+    "votes.gte",
+    "votes.lte",
+    "genre",
+    "genre.any",
+    "genre.not",
+    "interests",
+    "interests.any",
+    "interests.not",
+    "topic",
+    "topic.any",
+    "topic.not",
+    "alternate_version",
+    "alternate_version.any",
+    "alternate_version.not",
+    "crazy_credit",
+    "crazy_credit.any",
+    "crazy_credit.not",
+    "location",
+    "location.any",
+    "location.not",
+    "goof",
+    "goof.any",
+    "goof.not",
+    "plot",
+    "plot.any",
+    "plot.not",
+    "quote",
+    "quote.any",
+    "quote.not",
+    "soundtrack",
+    "soundtrack.any",
+    "soundtrack.not",
+    "trivia",
+    "trivia.any",
+    "trivia.not",
+    "event",
+    "event.winning",
+    "imdb_top",
+    "imdb_bottom",
     "company",
     "content_rating",
-    "country", "country.any", "country.not", "country.origin",
-    "keyword", "keyword.any", "keyword.not",
-    "series", "series.not",
-    "list", "list.any", "list.not",
-    "language", "language.any", "language.not", "language.primary",
-    "popularity.gte", "popularity.lte",
+    "country",
+    "country.any",
+    "country.not",
+    "country.origin",
+    "keyword",
+    "keyword.any",
+    "keyword.not",
+    "series",
+    "series.not",
+    "list",
+    "list.any",
+    "list.not",
+    "language",
+    "language.any",
+    "language.not",
+    "language.primary",
+    "popularity.gte",
+    "popularity.lte",
     "character",
-    "cast", "cast.any", "cast.not",
-    "runtime.gte", "runtime.lte",
+    "cast",
+    "cast.any",
+    "cast.not",
+    "runtime.gte",
+    "runtime.lte",
     "adult",
 ]
 sort_by_options = {
@@ -121,15 +169,52 @@ list_sort_by_options = {
 }
 list_sort_options = [f"{a}.{d}" for a in list_sort_by_options for d in ["asc", "desc"]]
 title_type_options = {
-    "movie": "movie", "tv_series": "tvSeries", "short": "short", "tv_episode": "tvEpisode", "tv_mini_series": "tvMiniSeries",
-    "tv_movie": "tvMovie", "tv_special": "tvSpecial", "tv_short": "tvShort", "video_game": "videoGame", "video": "video",
-    "music_video": "musicVideo", "podcast_series": "podcastSeries", "podcast_episode": "podcastEpisode"
+    "movie": "movie",
+    "tv_series": "tvSeries",
+    "short": "short",
+    "tv_episode": "tvEpisode",
+    "tv_mini_series": "tvMiniSeries",
+    "tv_movie": "tvMovie",
+    "tv_special": "tvSpecial",
+    "tv_short": "tvShort",
+    "video_game": "videoGame",
+    "video": "video",
+    "music_video": "musicVideo",
+    "podcast_series": "podcastSeries",
+    "podcast_episode": "podcastEpisode",
 }
-genre_options = {a.lower(): a for a in [
-    "Action", "Adventure", "Animation", "Biography", "Comedy", "Documentary", "Drama", "Crime", "Family", "History",
-    "News", "Short", "Western", "Sport", "Reality-TV", "Horror", "Fantasy", "Film-Noir", "Music", "Romance",
-    "Talk-Show", "Thriller", "War", "Sci-Fi", "Musical", "Mystery", "Game-Show"
-]}
+genre_options = {
+    a.lower(): a
+    for a in [
+        "Action",
+        "Adventure",
+        "Animation",
+        "Biography",
+        "Comedy",
+        "Documentary",
+        "Drama",
+        "Crime",
+        "Family",
+        "History",
+        "News",
+        "Short",
+        "Western",
+        "Sport",
+        "Reality-TV",
+        "Horror",
+        "Fantasy",
+        "Film-Noir",
+        "Music",
+        "Romance",
+        "Talk-Show",
+        "Thriller",
+        "War",
+        "Sci-Fi",
+        "Musical",
+        "Mystery",
+        "Game-Show",
+    ]
+}
 interest_options = {
     "action": "in0000001",
     "action_epic": "in0000002",
@@ -387,6 +472,7 @@ list_hash_url = "https://raw.githubusercontent.com/Kometa-Team/IMDb-Hash/master/
 watchlist_hash_url = "https://raw.githubusercontent.com/Kometa-Team/IMDb-Hash/master/WATCHLIST_HASH"
 graphql_url = "https://api.graphql.imdb.com/"
 list_url = f"{base_url}/list/ls"
+
 
 class IMDb:
     def __init__(self, requests, cache, default_dir):
@@ -662,11 +748,7 @@ class IMDb:
         step = "list" if list_type == "list" else "predefinedList"
         if list_type == "watchlist" and response_json["data"].get("predefinedList") is None:
             user_id = data["user_id"]
-            raise Failed(
-                f"IMDb Error: No public watchlist found for user '{user_id}'. "
-                f"Ensure the watchlist exists and is set to public. "
-                f"If your config uses a ur### ID, update it to the p.xxxxxxx format shown in your watchlist URL at imdb.com."
-            )
+            raise Failed(f"IMDb Error: No public watchlist found for user '{user_id}'. " f"Ensure the watchlist exists and is set to public. " f"If your config uses a ur### ID, update it to the p.xxxxxxx format shown in your watchlist URL at imdb.com.")
         search_data = response_json["data"][step]["titleListItemSearch"] if is_list else response_json["data"]["advancedTitleSearch"]
         total = search_data["total"]
         limit = data["limit"]
@@ -751,10 +833,7 @@ class IMDb:
         query_type = cfg["query"]
 
         if query_type == "chartTitles":
-            gql = (
-                "{ chartTitles(chart: { chartType: %s }, first: %d) "
-                "{ edges { node { id } } total } }" % (cfg["chartType"], cfg["first"])
-            )
+            gql = "{ chartTitles(chart: { chartType: %s }, first: %d) " "{ edges { node { id } } total } }" % (cfg["chartType"], cfg["first"])
             data = self._graph_request({"query": gql})["data"]
             return [edge["node"]["id"] for edge in data["chartTitles"]["edges"]]
 
@@ -764,12 +843,7 @@ class IMDb:
             return [entry["title"]["id"] for entry in data["boxOfficeWeekendChart"]["entries"]]
 
         elif query_type == "topTrendingSetsPredefined":
-            gql = (
-                "{ topTrendingSetsPredefined(first: %d, input: "
-                "{ topTrendingSetPredefined: %s }) "
-                "{ edges { node { item { ... on Title { id } } } } } }"
-                % (cfg["first"], cfg["predefined"])
-            )
+            gql = "{ topTrendingSetsPredefined(first: %d, input: " "{ topTrendingSetPredefined: %s }) " "{ edges { node { item { ... on Title { id } } } } } }" % (cfg["first"], cfg["predefined"])
             data = self._graph_request({"query": gql})["data"]
             return [edge["node"]["item"]["id"] for edge in data["topTrendingSetsPredefined"]["edges"]]
 
@@ -915,8 +989,7 @@ class IMDb:
                 modifier = f".{modifier[7:]}"
                 if test_number is None or util.is_number_filter(test_number, modifier, filter_data):
                     return False
-            elif (not list(set(filter_data["keywords"]) & set(attrs)) and modifier == "") \
-                    or (list(set(filter_data["keywords"]) & set(attrs)) and modifier == ".not"):
+            elif (not list(set(filter_data["keywords"]) & set(attrs)) and modifier == "") or (list(set(filter_data["keywords"]) & set(attrs)) and modifier == ".not"):
                 return False
         return True
 
@@ -939,7 +1012,7 @@ class IMDb:
         if event_id not in self._web_event_validation:
             self._web_event_validation[event_id] = []
             for year_data in self._request(f"{base_url}/event/{event_id}", page_props=True)["historyEventEditions"]:
-                extra = '' if year_data["instanceWithinYear"] == 1 else f"-{year_data['instanceWithinYear']}"
+                extra = "" if year_data["instanceWithinYear"] == 1 else f"-{year_data['instanceWithinYear']}"
                 self._web_event_validation[event_id].append(f"{year_data['year']}{extra}")
         return False, self._web_event_validation[event_id]
 

--- a/modules/logs.py
+++ b/modules/logs.py
@@ -226,11 +226,7 @@ class MyLogger:
     def stacktrace(self, trace=False):
         stack = traceback.format_exc()
 
-        suppress_stacktrace_patterns = [
-            r"Plex Error: .* not found",
-            r"No matches found with regex pattern",
-            r"Plex Error: No Items found in Plex"
-        ]
+        suppress_stacktrace_patterns = [r"Plex Error: .* not found", r"No matches found with regex pattern", r"Plex Error: No Items found in Plex"]
 
         if any(re.search(pattern, stack) for pattern in suppress_stacktrace_patterns):
             return

--- a/modules/mal.py
+++ b/modules/mal.py
@@ -1,37 +1,57 @@
-import re, secrets, time, webbrowser
+import re
+import secrets
+import time
+import webbrowser
 from datetime import datetime
 from json import JSONDecodeError
+
 from modules import util
 from modules.util import Failed, TimeoutExpired
 
 logger = util.logger
 
-builders = [
-    "mal_id", "mal_all", "mal_airing", "mal_upcoming", "mal_tv", "mal_ova", "mal_movie", "mal_special",
-    "mal_popular", "mal_favorite", "mal_season", "mal_suggested", "mal_userlist", "mal_genre", "mal_studio", "mal_search"
-]
-mal_ranked_name = {
-    "mal_all": "all", "mal_airing": "airing", "mal_upcoming": "upcoming", "mal_tv": "tv", "mal_ova": "ova",
-    "mal_movie": "movie", "mal_special": "special", "mal_popular": "bypopularity", "mal_favorite": "favorite"
-}
+builders = ["mal_id", "mal_all", "mal_airing", "mal_upcoming", "mal_tv", "mal_ova", "mal_movie", "mal_special", "mal_popular", "mal_favorite", "mal_season", "mal_suggested", "mal_userlist", "mal_genre", "mal_studio", "mal_search"]
+mal_ranked_name = {"mal_all": "all", "mal_airing": "airing", "mal_upcoming": "upcoming", "mal_tv": "tv", "mal_ova": "ova", "mal_movie": "movie", "mal_special": "special", "mal_popular": "bypopularity", "mal_favorite": "favorite"}
 mal_ranked_pretty = {
-    "mal_all": "MyAnimeList All", "mal_airing": "MyAnimeList Airing", "mal_search": "MyAnimeList Search",
-    "mal_upcoming": "MyAnimeList Upcoming", "mal_tv": "MyAnimeList TV", "mal_ova": "MyAnimeList OVA",
-    "mal_movie": "MyAnimeList Movie", "mal_special": "MyAnimeList Special", "mal_popular": "MyAnimeList Popular",
-    "mal_favorite": "MyAnimeList Favorite", "mal_genre": "MyAnimeList Genre", "mal_studio": "MyAnimeList Studio"
+    "mal_all": "MyAnimeList All",
+    "mal_airing": "MyAnimeList Airing",
+    "mal_search": "MyAnimeList Search",
+    "mal_upcoming": "MyAnimeList Upcoming",
+    "mal_tv": "MyAnimeList TV",
+    "mal_ova": "MyAnimeList OVA",
+    "mal_movie": "MyAnimeList Movie",
+    "mal_special": "MyAnimeList Special",
+    "mal_popular": "MyAnimeList Popular",
+    "mal_favorite": "MyAnimeList Favorite",
+    "mal_genre": "MyAnimeList Genre",
+    "mal_studio": "MyAnimeList Studio",
 }
 season_sort_translation = {"score": "anime_score", "anime_score": "anime_score", "members": "anime_num_list_users", "anime_num_list_users": "anime_num_list_users"}
 season_sort_options = ["score", "members"]
 pretty_names = {
-    "anime_score": "Score", "list_score": "Score", "anime_num_list_users": "Members", "list_updated_at": "Last Updated",
-    "anime_title": "Title", "anime_start_date": "Start Date", "all": "All Anime", "watching": "Currently Watching",
-    "completed": "Completed", "on_hold": "On Hold", "dropped": "Dropped", "plan_to_watch": "Plan to Watch"
+    "anime_score": "Score",
+    "list_score": "Score",
+    "anime_num_list_users": "Members",
+    "list_updated_at": "Last Updated",
+    "anime_title": "Title",
+    "anime_start_date": "Start Date",
+    "all": "All Anime",
+    "watching": "Currently Watching",
+    "completed": "Completed",
+    "on_hold": "On Hold",
+    "dropped": "Dropped",
+    "plan_to_watch": "Plan to Watch",
 }
 userlist_sort_translation = {
-    "score": "list_score", "list_score": "list_score",
-    "last_updated": "list_updated_at", "list_updated": "list_updated_at", "list_updated_at": "list_updated_at",
-    "title": "anime_title", "anime_title": "anime_title",
-    "start_date": "anime_start_date", "anime_start_date": "anime_start_date"
+    "score": "list_score",
+    "list_score": "list_score",
+    "last_updated": "list_updated_at",
+    "list_updated": "list_updated_at",
+    "list_updated_at": "list_updated_at",
+    "title": "anime_title",
+    "anime_title": "anime_title",
+    "start_date": "anime_start_date",
+    "anime_start_date": "anime_start_date",
 }
 userlist_sort_options = ["score", "last_updated", "title", "start_date"]
 userlist_status = ["all", "watching", "completed", "on_hold", "dropped", "plan_to_watch"]
@@ -49,7 +69,7 @@ urls = {
     "ranking": f"{base_url}anime/ranking",
     "season": f"{base_url}anime/season",
     "suggestions": f"{base_url}anime/suggestions",
-    "user": f"{base_url}users"
+    "user": f"{base_url}users",
 }
 
 
@@ -137,20 +157,17 @@ class MyAnimeList:
             logger.info("Login and click the Allow option. You will then be redirected to a localhost")
             logger.info("url that most likely won't load, which is fine. Copy the URL and paste it below")
             webbrowser.open(url, new=2)
-            try:                                url = util.logger_input("URL").strip()
-            except TimeoutExpired:              raise Failed("Input Timeout: URL required.")
-            if not url:                         raise Failed("MyAnimeList Error: No input MyAnimeList code required.")
+            try:
+                url = util.logger_input("URL").strip()
+            except TimeoutExpired:
+                raise Failed("Input Timeout: URL required.")
+            if not url:
+                raise Failed("MyAnimeList Error: No input MyAnimeList code required.")
         match = re.search("code=([^&]+)", str(url))
         if not match:
             raise Failed("MyAnimeList Error: Invalid URL")
         code = match.group(1)
-        data = {
-            "client_id": self.client_id,
-            "client_secret": self.client_secret,
-            "code": code,
-            "code_verifier": code_verifier,
-            "grant_type": "authorization_code"
-        }
+        data = {"client_id": self.client_id, "client_secret": self.client_secret, "code": code, "code_verifier": code_verifier, "grant_type": "authorization_code"}
         new_authorization = self._oauth(data)
         if "error" in new_authorization:
             raise Failed("MyAnimeList Error: Invalid code")
@@ -168,12 +185,7 @@ class MyAnimeList:
     def _refresh(self):
         if self.authorization and "refresh_token" in self.authorization and self.authorization["refresh_token"]:
             logger.info("Refreshing Access Token...")
-            data = {
-                "client_id": self.client_id,
-                "client_secret": self.client_secret,
-                "refresh_token": self.authorization["refresh_token"],
-                "grant_type": "refresh_token"
-            }
+            data = {"client_id": self.client_id, "client_secret": self.client_secret, "refresh_token": self.authorization["refresh_token"], "grant_type": "refresh_token"}
             refreshed_authorization = self._oauth(data)
             return self._save(refreshed_authorization)
         return False
@@ -182,12 +194,7 @@ class MyAnimeList:
         if authorization is not None and "access_token" in authorization and authorization["access_token"] and self._check(authorization):
             if self.authorization != authorization and not self.read_only:
                 yaml = self.requests.file_yaml(self.config_path)
-                yaml.data["mal"]["authorization"] = {
-                    "access_token": authorization["access_token"],
-                    "token_type": authorization["token_type"],
-                    "expires_in": authorization["expires_in"],
-                    "refresh_token": authorization["refresh_token"]
-                }
+                yaml.data["mal"]["authorization"] = {"access_token": authorization["access_token"], "token_type": authorization["token_type"], "expires_in": authorization["expires_in"], "refresh_token": authorization["refresh_token"]}
                 logger.info(f"Saving authorization information to {self.config_path}")
                 yaml.save()
                 logger.secret(authorization["access_token"])
@@ -204,8 +211,10 @@ class MyAnimeList:
         try:
             response = self.requests.get_json(url, headers={"Authorization": f"Bearer {token}"})
             logger.trace(f"Response: {response}")
-            if "error" in response:         raise Failed(f"MyAnimeList Error: {response['error']}")
-            else:                           return response
+            if "error" in response:
+                raise Failed(f"MyAnimeList Error: {response['error']}")
+            else:
+                return response
         except JSONDecodeError:
             raise Failed(f"MyAnimeList Error: Connection Failed")
 

--- a/modules/mdblist.py
+++ b/modules/mdblist.py
@@ -1,6 +1,7 @@
 import time
 from datetime import datetime
 from json import JSONDecodeError
+
 from modules import util
 from modules.request import urlparse
 from modules.util import Failed, LimitReached
@@ -10,9 +11,31 @@ logger = util.logger
 # --- REQUIRED MODULE ATTRIBUTES ---
 builders = ["mdblist_list"]
 sort_names = [
-    "rank", "score", "score_average", "released", "releasedigital", "imdbrating", "imdbvotes", "imdbpopular", 
-    "tmdbpopular", "rogerebert", "rtomatoes", "rtaudience", "metacritic", "myanimelist", "letterrating", "lettervotes",
-    "last_air_date", "budget", "revenue", "runtime", "title", "sort_title", "random", "usort", "added"
+    "rank",
+    "score",
+    "score_average",
+    "released",
+    "releasedigital",
+    "imdbrating",
+    "imdbvotes",
+    "imdbpopular",
+    "tmdbpopular",
+    "rogerebert",
+    "rtomatoes",
+    "rtaudience",
+    "metacritic",
+    "myanimelist",
+    "letterrating",
+    "lettervotes",
+    "last_air_date",
+    "budget",
+    "revenue",
+    "runtime",
+    "title",
+    "sort_title",
+    "random",
+    "usort",
+    "added",
 ]
 
 list_sorts = [f"{s}.asc" for s in sort_names] + [f"{s}.desc" for s in sort_names]
@@ -21,6 +44,7 @@ base_url = "https://mdblist.com/lists/"
 api_url = "https://api.mdblist.com/"
 
 headers = {"User-Agent": "Kometa"}
+
 
 class MDbObj:
     def __init__(self, data):
@@ -77,6 +101,7 @@ class MDbObj:
         self.commonsense = bool(data.get("commonsense"))
         self.age_rating = data.get("age_rating")
 
+
 class MDBList:
     def __init__(self, requests, cache):
         self.requests = requests
@@ -105,13 +130,13 @@ class MDBList:
             self.patron = response.get("patron_status", False)
             self.api_requests = response.get("api_requests", 0)
             self.api_requests_count = response.get("api_requests_count", 0)
-    
+
             logger.info(f"MDBList Connection Verified (Supporter: {self.supporter})")
             logger.info(f"Patron Status: {self.patron}")
             logger.info(f"Daily API Requests: {self.api_requests}")
             logger.info(f"API Requests Used Today: {self.api_requests_count}")
-            
-            self.get_item(media_provider='imdb', media_type='movie', media_id="tt0080684", ignore_cache=True)
+
+            self.get_item(media_provider="imdb", media_type="movie", media_id="tt0080684", ignore_cache=True)
         except LimitReached:
             logger.info(f"MDBList API limit exhausted")
             self.limit = True
@@ -128,33 +153,33 @@ class MDBList:
         final_params = {"apikey": self.apikey}
         if params:
             final_params.update(params)
-        
+
         # Respect API Rate limits
         time.sleep(0.2 if self.supporter else 1.0)
-        
+
         response = self.requests.get(url, params=final_params)
-        
+
         if response.status_code != 200:
             raise Failed(f"MDBList Error: {response.status_code} - {response.text}")
 
         json_data = response.json()
         if isinstance(json_data, dict) and json_data.get("response") is False:
-            if json_data.get('error') in ["API Limit Reached!", "API Rate Limit Reached!"]:
+            if json_data.get("error") in ["API Limit Reached!", "API Rate Limit Reached!"]:
                 self.limit = True
                 raise LimitReached(f"MDBList Error: {json_data.get('error')}")
             raise Failed(f"MDBList Error: {json_data.get('error')}")
-            
+
         return json_data, response.headers
 
     def get_item(self, media_provider=None, media_type=None, media_id=None, ignore_cache=False):
 
         is_movie = media_type == "movie"
 
-        if media_provider == 'imdb':
+        if media_provider == "imdb":
             key = media_id
-        elif media_provider == 'tmdb':
+        elif media_provider == "tmdb":
             key = f"{'tm' if is_movie else 'ts'}{media_id}"
-        elif media_provider == 'tvdb':
+        elif media_provider == "tvdb":
             key = f"{'tvm' if is_movie else 'tvs'}{media_id}"
         else:
             raise Failed("MDBList Error: media_provider, media_type, media_id Required")
@@ -179,8 +204,8 @@ class MDBList:
 
     def get_series(self, tvdb_id):
         return self.get_item(media_provider="tvdb", media_type="show", media_id=tvdb_id)
- 
-    def get_movie(self, tmdb_id): 
+
+    def get_movie(self, tmdb_id):
         return self.get_item(media_provider="tmdb", media_type="movie", media_id=tmdb_id)
 
     def validate_mdblist_lists(self, error_type, mdb_lists):
@@ -188,15 +213,12 @@ class MDBList:
         for mdb_dict in util.get_list(mdb_lists, split=False):
             if not isinstance(mdb_dict, dict):
                 mdb_dict = {"url": mdb_dict}
-            
+
             url = mdb_dict.get("url", "").strip("/")
             if not url.startswith(base_url.strip("/")):
                 raise Failed(f"{error_type} Error: {url} must start with {base_url}")
 
-            list_object = {
-                "url": url,
-                "limit": int(mdb_dict.get("limit", 0))
-            }
+            list_object = {"url": url, "limit": int(mdb_dict.get("limit", 0))}
 
             if "sort_by" in mdb_dict:
                 sort_by = mdb_dict["sort_by"]
@@ -213,7 +235,7 @@ class MDBList:
         external_id = list_path.split("/external/")[-1] if "/external/" in list_path else None
 
         items_url = f"{api_url}external/lists/{external_id}/items/" if external_id else f"{api_url}lists/{list_path}/items/"
-        meta_url  = f"{api_url}external/lists/{external_id}" if external_id else f"{api_url}lists/{list_path}"
+        meta_url = f"{api_url}external/lists/{external_id}" if external_id else f"{api_url}lists/{list_path}"
 
         sort, direction = data["sort_by"].split(".") if "sort_by" in data else (None, None)
         results = []
@@ -264,7 +286,7 @@ class MDBList:
                     else:
                         items = page_data.get("shows")
 
-                    if len(items) == 0 and "items" in page_data: # type: ignore
+                    if len(items) == 0 and "items" in page_data:  # type: ignore
                         items = page_data["items"]
 
                 elif isinstance(page_data, list):
@@ -272,7 +294,7 @@ class MDBList:
             except Exception as e:
                 raise Failed(f"MDBList Error: Could not fetch list items: {e}")
 
-            for item in items: # type: ignore
+            for item in items:  # type: ignore
                 if 0 < limit_config <= len(results):
                     return results
 
@@ -282,7 +304,7 @@ class MDBList:
                     type_key = "tmdb" if m_type.lower() == "movie" else "tmdb_show"
                     results.append((tmdb_id, type_key))
 
-            offset += len(items) # type: ignore
+            offset += len(items)  # type: ignore
 
             if total_count:
                 percent = min(int((len(results) / total_count) * 100), 100)
@@ -292,7 +314,7 @@ class MDBList:
                 suffix = "..." if has_more else ""
                 logger.info(f"MDBList Sync Progress: {len(results)} items fetched{suffix}")
 
-            if len(items) == 0: # type: ignore
+            if len(items) == 0:  # type: ignore
                 break
 
         return results

--- a/modules/meta.py
+++ b/modules/meta.py
@@ -1377,10 +1377,7 @@ class MetadataFile(DataFile):
                                             _en = self.config.GitHub.translation_yaml("en")
                                             _tr = self.config.GitHub.translation_yaml(self.language)
                                             if _trans_key_val in _en.get("collections", {}):
-                                                _trans_base = (
-                                                    _tr.get("collections", {}).get(_trans_key_val, {}).get("name")
-                                                    or _en["collections"][_trans_key_val].get("name")
-                                                )
+                                                _trans_base = _tr.get("collections", {}).get(_trans_key_val, {}).get("name") or _en["collections"][_trans_key_val].get("name")
                                         except Exception:
                                             pass
                                     _base = _trans_base if _trans_base else title_format

--- a/modules/mojo.py
+++ b/modules/mojo.py
@@ -1,8 +1,10 @@
 from datetime import datetime
+
+from num2words import num2words
+
 from modules import util
 from modules.request import parse_qs, urlparse
 from modules.util import Failed
-from num2words import num2words
 
 logger = util.logger
 
@@ -119,7 +121,7 @@ holiday_options = {
     "post_thanksgiving_weekend": ("Post-Thanksgiving Weekend", "us_post_thanksgiving_weekend"),
     "christmas_day": ("Christmas Day", "christmas_day"),
     "christmas_weekend": ("Christmas Weekend", "us_christmas_weekend"),
-    "new_years_eve": ("New Year's Eve", "newyearseve")
+    "new_years_eve": ("New Year's Eve", "newyearseve"),
 }
 base_url = "https://www.boxofficemojo.com"
 
@@ -181,7 +183,7 @@ class BoxOfficeMojo:
             output.extend(response.xpath(f"//td[contains(@class, 'mojo-field-type-{field_name}')]/a/@href"))
         if not limit or len(output) < limit:
             limit = len(output)
-        return [i[:i.index("?")] for i in output[:limit]]
+        return [i[: i.index("?")] for i in output[:limit]]
 
     def _imdb(self, url):
         response = self._request(url)
@@ -204,7 +206,7 @@ class BoxOfficeMojo:
             else:
                 text += f" {data['content_rating_filter'].upper()}"
                 url = f"/chart/mpaa_title_lifetime_gross/"
-                params = {"by_mpaa": content_rating_options[data['content_rating_filter']]}
+                params = {"by_mpaa": content_rating_options[data["content_rating_filter"]]}
             text += " Grosses"
         elif method == "mojo_never":
             pretty, arg_key = never_in_options[data["never"]]
@@ -218,7 +220,7 @@ class BoxOfficeMojo:
 
             if data["range"] == "daily":
                 day = datetime.strptime(data["range_data"], "%Y-%m-%d")
-                day = day.strftime("%b {th}, %Y").replace("{th}", num2words(day.day, to='ordinal_num'))
+                day = day.strftime("%b {th}, %Y").replace("{th}", num2words(day.day, to="ordinal_num"))
                 chart_title = f"{day}"
                 url = f"/date/{data['range_data']}/"
             elif data["range"] == "weekend":

--- a/modules/notifiarr.py
+++ b/modules/notifiarr.py
@@ -1,7 +1,9 @@
 from json import JSONDecodeError
+
+from tenacity import retry, retry_if_not_exception_type, stop_after_attempt, wait_fixed
+
 from modules import util
 from modules.util import Failed
-from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_not_exception_type
 
 logger = util.logger
 

--- a/modules/ntfy.py
+++ b/modules/ntfy.py
@@ -24,11 +24,7 @@ class Ntfy:
             raise Failed("ntfy Error: Invalid details")
 
     def _request(self, message: str, title: str = None, priority: int = 3):
-        headers = {
-            "Authorization": f"Bearer {self.token}",
-            "Icon": "https://kometa.wiki/en/latest/assets/icon.png",
-            "Priority": str(priority)
-        }
+        headers = {"Authorization": f"Bearer {self.token}", "Icon": "https://kometa.wiki/en/latest/assets/icon.png", "Priority": str(priority)}
         if title:
             headers["Title"] = title
 

--- a/modules/omdb.py
+++ b/modules/omdb.py
@@ -1,11 +1,13 @@
 from datetime import datetime
+from json import JSONDecodeError
+
 from modules import util
 from modules.util import Failed
-from json import JSONDecodeError
 
 logger = util.logger
 
 base_url = "http://www.omdbapi.com/"
+
 
 class OMDbObj:
     def __init__(self, imdb_id, data):
@@ -16,7 +18,7 @@ class OMDbObj:
 
         def _parse(key, is_int=False, is_float=False, is_date=False, replace=None):
             try:
-                value = str(data[key]).replace(replace, '') if replace else data[key]
+                value = str(data[key]).replace(replace, "") if replace else data[key]
                 if is_int:
                     return int(value)
                 elif is_float:
@@ -43,7 +45,7 @@ class OMDbObj:
         try:
             for rating in data["Ratings"]:
                 if rating["Source"] == "Rotten Tomatoes":
-                    data["tempRT"] = rating["Value"] # This is a hack to allow _parse to work without changes
+                    data["tempRT"] = rating["Value"]  # This is a hack to allow _parse to work without changes
                     self.rotten_tomatoes = _parse("tempRT", is_int=True, replace="%")
                     break
         except KeyError:
@@ -54,6 +56,7 @@ class OMDbObj:
         self.series_id = _parse("seriesID")
         self.season_num = _parse("Season", is_int=True)
         self.episode_num = _parse("Episode", is_int=True)
+
 
 class OMDb:
     def __init__(self, requests, cache, params):
@@ -80,7 +83,7 @@ class OMDb:
             return omdb
         else:
             try:
-                error = response.json()['Error']
+                error = response.json()["Error"]
                 if error == "Request limit reached!":
                     self.limit = True
             except JSONDecodeError:

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -138,6 +138,7 @@ class Operations:
 
         def should_be_deleted(col_in, labels_in, configured_in, managed_in, less_in):
             return self._should_be_deleted(col_in, labels_in, configured_in, managed_in, less_in, configured_names=configured_names)
+
         if self.library.split_duplicates:
             items = self.library.search(**{"duplicate": True})
             for item in items:

--- a/modules/overlay.py
+++ b/modules/overlay.py
@@ -1,10 +1,14 @@
-import os, re, time
+import os
+import re
+import time
 from datetime import datetime
-from modules import util
-from modules.util import Failed, OverlayError
+
 from PIL import Image, ImageColor, ImageDraw, ImageFont
 from plexapi.audio import Album
 from plexapi.video import Episode
+
+from modules import util
+from modules.util import Failed, OverlayError
 
 logger = util.logger
 
@@ -39,7 +43,7 @@ rating_sources = [
     "plex_tomatoesaudience_rating",
     "tmdb_rating",
     "trakt_rating",
-    "trakt_user_rating"
+    "trakt_user_rating",
 ]
 float_vars = ["audience_rating", "critic_rating", "user_rating"] + rating_sources
 int_vars = ["runtime", "total_runtime", "season_number", "episode_number", "episode_count", "versions"]
@@ -48,12 +52,28 @@ types_for_var = {
     "movie_show_season_episode_artist_album": ["runtime", "title", "user_rating"],
     "movie_show_episode_album": ["critic_rating", "originally_available"],
     "movie_show_season_episode": [
-        "imdb_rating", "mdb_average_rating", "mdb_imdb_rating", "mdb_letterboxd_rating",
-        "mdb_metacritic_rating", "mdb_metacriticuser_rating", "mdb_rating",
-        "mdb_tmdb_rating", "mdb_tomatoes_rating", "mdb_tomatoesaudience_rating",
-        "mdb_trakt_rating", "mdb_myanimelist_rating", "omdb_rating", "omdb_imdb_rating", "tmdb_rating",
-        "omdb_metascore_rating", "omdb_tomatoes_rating", "plex_imdb_rating", "plex_tmdb_rating",
-        "plex_tomatoes_rating", "plex_tomatoesaudience_rating", "trakt_rating",
+        "imdb_rating",
+        "mdb_average_rating",
+        "mdb_imdb_rating",
+        "mdb_letterboxd_rating",
+        "mdb_metacritic_rating",
+        "mdb_metacriticuser_rating",
+        "mdb_rating",
+        "mdb_tmdb_rating",
+        "mdb_tomatoes_rating",
+        "mdb_tomatoesaudience_rating",
+        "mdb_trakt_rating",
+        "mdb_myanimelist_rating",
+        "omdb_rating",
+        "omdb_imdb_rating",
+        "tmdb_rating",
+        "omdb_metascore_rating",
+        "omdb_tomatoes_rating",
+        "plex_imdb_rating",
+        "plex_tmdb_rating",
+        "plex_tomatoes_rating",
+        "plex_tomatoesaudience_rating",
+        "trakt_rating",
     ],
     "movie_show_season": ["original_title", "trakt_user_rating"],
     "show_season_artist_album": ["total_runtime"],
@@ -63,7 +83,7 @@ types_for_var = {
     "season_episode": ["season_number", "show_title"],
     "show_season": ["episode_count"],
     "movie": ["edition"],
-    "episode": ["episode_number", "season_title"]
+    "episode": ["episode_number", "season_title"],
 }
 var_mods = {
     "bitrate": ["", "H", "L"],
@@ -88,6 +108,7 @@ vars_by_type = {
     "album": [f"{item}{m}" for check, sub in types_for_var.items() for item in sub for m in var_mods[item] if "album" in check],
 }
 
+
 def get_canvas_size(item):
     if isinstance(item, Episode):
         return landscape_dim
@@ -95,6 +116,7 @@ def get_canvas_size(item):
         return square_dim
     else:
         return portrait_dim
+
 
 class Overlay:
     def __init__(self, config, library, overlay_file, original_mapping_name, overlay_data, suppress, level):
@@ -171,6 +193,7 @@ class Overlay:
                     return ImageColor.getcolor(self.data[attr], "RGBA")
                 except ValueError:
                     raise OverlayError(f"Overlay Error: Overlay value '{attr}: {self.data[attr]}' invalid")
+
         self.back_color = color("back_color")
         self.back_radius = util.parse("Overlay", "back_radius", self.data["back_radius"], datatype="int", parent="overlay") if "back_radius" in self.data and self.data["back_radius"] else None
         self.back_line_color = color("back_line_color")
@@ -397,12 +420,7 @@ class Overlay:
             overlay_image = Image.new("RGBA", canvas_box, (255, 255, 255, 0))
             drawing = ImageDraw.Draw(overlay_image)
             if self.has_back:
-                cords = (
-                    start_x - self.back_padding,
-                    start_y - self.back_padding,
-                    start_x + (back_width if self.back_box else box_width) + self.back_padding,
-                    start_y + (back_height if self.back_box else box_height) + self.back_padding
-                )
+                cords = (start_x - self.back_padding, start_y - self.back_padding, start_x + (back_width if self.back_box else box_width) + self.back_padding, start_y + (back_height if self.back_box else box_height) + self.back_padding)
                 if self.back_radius:
                     drawing.rounded_rectangle(cords, fill=self.back_color, outline=self.back_line_color, width=self.back_line_width, radius=self.back_radius)
                 else:
@@ -438,8 +456,7 @@ class Overlay:
                     addon_y = main_y + ((text_height - image_height) / 2)
 
             if text is not None:
-                drawing.text((int(main_x), int(main_y)), text, font=self.font, fill=self.font_color,
-                             stroke_fill=self.stroke_color, stroke_width=self.stroke_width, anchor="lt")
+                drawing.text((int(main_x), int(main_y)), text, font=self.font, fill=self.font_color, stroke_fill=self.stroke_color, stroke_width=self.stroke_width, anchor="lt")
             if addon_x is not None:
                 main_x = addon_x
                 main_y = addon_y
@@ -457,8 +474,7 @@ class Overlay:
             output += f"{self.back_box[0]}{self.back_box[1]}{self.back_align}"
         if self.addon_position is not None:
             output += f"{self.addon_position}{self.addon_offset}"
-        for value in [self.font_color, self.back_color, self.back_radius, self.back_padding, self.back_line_color,
-                      self.back_line_width, self.stroke_color, self.stroke_width, self.scale_width, self.scale_height]:
+        for value in [self.font_color, self.back_color, self.back_radius, self.back_padding, self.back_line_color, self.back_line_width, self.stroke_color, self.stroke_width, self.scale_width, self.scale_height]:
             if value is not None:
                 output += f"{value}"
         return output
@@ -467,7 +483,7 @@ class Overlay:
         return self.horizontal_offset is not None and self.vertical_offset is not None
 
     def get_text_size(self, text):
-        return ImageDraw.Draw(Image.new("RGBA", (0, 0))).textbbox((0, 0), text, font=self.font, anchor='lt')
+        return ImageDraw.Draw(Image.new("RGBA", (0, 0))).textbbox((0, 0), text, font=self.font, anchor="lt")
 
     def get_coordinates(self, canvas_box, box, new_cords=None):
         if new_cords is None and not self.has_coordinates():

--- a/modules/overlays.py
+++ b/modules/overlays.py
@@ -9,7 +9,7 @@ from plexapi.video import Episode, Season
 
 from modules import overlay, plex, util
 from modules.builder import CollectionBuilder
-from modules.util import Failed, FilterFailed, LimitReached, NotScheduled, OverlayError, MappingConvertError, ServiceError
+from modules.util import Failed, FilterFailed, LimitReached, MappingConvertError, NotScheduled, OverlayError, ServiceError
 
 logger = util.logger
 

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -113,6 +113,8 @@ def get_asset_image_matches(file_filter, file_name):
     matches = [m for m in util.glob_filter(file_filter) if os.path.isfile(m) and os.path.splitext(m)[1].lower() in asset_image_extensions]
     exact_matches = [m for m in matches if os.path.splitext(os.path.basename(m))[0].lower() == file_name.lower()]
     return exact_matches or matches
+
+
 show_translation = {
     "title": "show.title",
     "country": "show.country",
@@ -1366,7 +1368,7 @@ class Plex(Library):
 
         # Custom collection hubs: identifier="custom.collection.{sectionKey}.{ratingKey}". Built-in hubs have no trailing numeric ratingKey — skip them.
         hubs = []
-        for elem in (response or []):
+        for elem in response or []:
             identifier = elem.attrib.get("identifier", "")
             parts = identifier.split(".")
             if len(parts) < 4 or parts[0] != "custom" or parts[1] != "collection":
@@ -1376,11 +1378,13 @@ class Plex(Library):
             except ValueError:
                 continue
             title = elem.attrib.get("title", "")
-            hubs.append({
-                "ratingKey": rk,
-                "identifier": identifier,
-                "title": title,
-            })
+            hubs.append(
+                {
+                    "ratingKey": rk,
+                    "identifier": identifier,
+                    "title": title,
+                }
+            )
 
         if not hubs:
             logger.info("No items in hub list, skipping sort")
@@ -1390,10 +1394,7 @@ class Plex(Library):
         hub_rating_keys = {h["ratingKey"] for h in hubs}
         for rk, (priority, name) in hub_priorities.items():
             if rk not in hub_rating_keys:
-                logger.warning(
-                    f"Plex Warning: hub_priority set on collection '{name}' but it is not promoted to any hub. "
-                    f"Ensure visible_library, visible_home, or visible_shared is enabled."
-                )
+                logger.warning(f"Plex Warning: hub_priority set on collection '{name}' but it is not promoted to any hub. " f"Ensure visible_library, visible_home, or visible_shared is enabled.")
 
         # hub_title_sorts is populated in builder.py from plexapi collection objects; falls back to title for unprocessed collections.
         def _sort_key(h, mode):
@@ -1422,6 +1423,7 @@ class Plex(Library):
         # Sort unprioritised by auto_sort_hubs mode
         if sort_mode == "random":
             import random
+
             random.shuffle(unprioritised)
         else:
             unprioritised = sorted(unprioritised, key=lambda h: _sort_key(h, sort_mode), reverse=reverse)

--- a/modules/radarr.py
+++ b/modules/radarr.py
@@ -1,7 +1,8 @@
-from modules import util
-from modules.util import Failed, Continue
 from arrapi import RadarrAPI
 from arrapi.exceptions import ArrException
+
+from modules import util
+from modules.util import Continue, Failed
 
 logger = util.logger
 
@@ -11,6 +12,7 @@ monitor_translation = {"movie": "movieOnly", "collection": "movieAndCollection",
 apply_tags_translation = {"": "add", "sync": "replace", "remove": "remove"}
 availability_descriptions = {"announced": "For Announced", "cinemas": "For In Cinemas", "released": "For Released", "db": "For PreDB"}
 monitor_descriptions = {"movie": "Monitor Only the Movie", "collection": "Monitor the Movie and Collection", "none": "Do not Monitor"}
+
 
 class Radarr:
     def __init__(self, requests, cache, library, params):
@@ -24,7 +26,7 @@ class Radarr:
         try:
             self.api = RadarrAPI(self.url, self.token, session=self.requests.session)
             self.api.respect_list_exclusions_when_adding()
-            self.api._validate_add_options(params["root_folder_path"], params["quality_profile"]) # noqa
+            self.api._validate_add_options(params["root_folder_path"], params["quality_profile"])  # noqa
             self.profiles = self.api.quality_profile()
         except ArrException as e:
             raise Failed(e)
@@ -133,8 +135,7 @@ class Radarr:
                 pass
             if movies and (len(movies) == 100 or len(tmdb_ids) == i):
                 try:
-                    _a, _e, _i, _x = self.api.add_multiple_movies(movies, folder, quality_profile, monitor, search,
-                                                                  availability, tags, per_request=100)
+                    _a, _e, _i, _x = self.api.add_multiple_movies(movies, folder, quality_profile, monitor, search, availability, tags, per_request=100)
                     added.extend(_a)
                     exists.extend(_e)
                     invalid.extend(_i)

--- a/modules/request.py
+++ b/modules/request.py
@@ -1,15 +1,23 @@
-import base64, cloudscraper, os, ruamel.yaml, requests, time
+import base64
+import os
+import time
+from urllib import parse
+
+import cloudscraper
+import requests
+import ruamel.yaml
 from lxml import html
+from requests.exceptions import ConnectionError
+from tenacity import retry, stop_after_attempt, wait_fixed
+
 from modules import util
 from modules.poster import ImageData
 from modules.util import Failed
-from requests.exceptions import ConnectionError
-from tenacity import retry, stop_after_attempt, wait_fixed
-from urllib import parse
 
 logger = util.logger
 
 image_content_types = ["image/png", "image/jpeg", "image/webp"]
+
 
 def get_header(headers, header, language):
     if headers:
@@ -18,10 +26,7 @@ def get_header(headers, header, language):
         if header and not language:
             language = "en-US,en;q=0.5"
         if language:
-            return {
-                "Accept-Language": "eng" if language == "default" else language,
-                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:147.0) Gecko/20100101 Firefox/147.0"
-            }
+            return {"Accept-Language": "eng" if language == "default" else language, "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:147.0) Gecko/20100101 Firefox/147.0"}
 
 
 def quote(data):
@@ -38,6 +43,7 @@ def parse_qs(data):
 
 def urlparse(data):
     return parse.urlparse(str(data))
+
 
 class Version:
     def __init__(self, version_string="Unknown", part_string=""):
@@ -57,6 +63,7 @@ class Version:
 
     def __str__(self):
         return f"{self.full}.{self.part}" if self.part else self.full
+
 
 class Requests:
     def __init__(self, local, part, env_branch, git_branch, verify_ssl=True):
@@ -88,6 +95,7 @@ class Requests:
         session.verify = False
         if session.verify is False:
             import urllib3
+
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     def download_image(self, title, image_url, download_directory, session=None, image_type="poster", filename=None):
@@ -131,7 +139,7 @@ class Requests:
     def get_stream(self, url, location, info="Item"):
         with self.session.get(url, stream=True) as r:
             r.raise_for_status()
-            total_length = r.headers.get('content-length')
+            total_length = r.headers.get("content-length")
             if total_length is not None:
                 total_length = int(total_length)
             dl = 0
@@ -168,7 +176,7 @@ class Requests:
         return self.session.get(url, json=json, headers=get_header(headers, header, language), params=params)
 
     def get_image_encoded(self, url):
-        return base64.b64encode(self.get(url).content).decode('utf-8')
+        return base64.b64encode(self.get(url).content).decode("utf-8")
 
     def post_html(self, url, data=None, json=None, headers=None, header=None, language=None):
         return html.fromstring(self.post(url, data=data, json=json, headers=headers, header=header, language=language).content)
@@ -263,7 +271,7 @@ class YAML:
                 self.data = self.yaml.load(input_data)
             else:
                 if start_empty or (create and not os.path.exists(self.path)):
-                    with open(self.path, 'w'):
+                    with open(self.path, "w"):
                         pass
                     self.data = {}
                 else:
@@ -275,7 +283,7 @@ class YAML:
                 e = f"Tabs are not allowed in YAML files; only spaces are allowed.\nfirst tab character found at:\n{location}"
             else:
                 e = str(e).replace("\n", "\n      ")
-            
+
             raise Failed(f"YAML Error: {e}")
         except Exception as e:
             raise Failed(f"YAML Error: {e}")
@@ -286,5 +294,5 @@ class YAML:
 
     def save(self):
         if self.path:
-            with open(self.path, 'w', encoding="utf-8") as fp:
+            with open(self.path, "w", encoding="utf-8") as fp:
                 self.yaml.dump(self.data, fp)

--- a/modules/sonarr.py
+++ b/modules/sonarr.py
@@ -1,21 +1,15 @@
-from modules import util
-from modules.util import Failed, Continue
 from arrapi import SonarrAPI
 from arrapi.exceptions import ArrException
+
+from modules import util
+from modules.util import Continue, Failed
 
 logger = util.logger
 
 builders = ["sonarr_all", "sonarr_taglist"]
 series_types = ["standard", "daily", "anime"]
-monitor_translation = {
-    "all": "all", "future": "future", "missing": "missing", "existing": "existing",
-    "pilot": "pilot", "first": "firstSeason", "latest": "latestSeason", "none": "none"
-}
-series_type_descriptions = {
-    "standard": "Episodes released with SxxEyy pattern",
-    "daily": "Episodes released daily or less frequently that use year-month-day (2017-05-25)",
-    "anime": "Episodes released using an absolute episode number"
-}
+monitor_translation = {"all": "all", "future": "future", "missing": "missing", "existing": "existing", "pilot": "pilot", "first": "firstSeason", "latest": "latestSeason", "none": "none"}
+series_type_descriptions = {"standard": "Episodes released with SxxEyy pattern", "daily": "Episodes released daily or less frequently that use year-month-day (2017-05-25)", "anime": "Episodes released using an absolute episode number"}
 monitor_descriptions = {
     "all": "Monitor all episodes except specials",
     "future": "Monitor episodes that have not aired yet",
@@ -24,9 +18,10 @@ monitor_descriptions = {
     "pilot": "Monitor the first episode. All other episodes will be ignored",
     "first": "Monitor all episodes of the first season. All other seasons will be ignored",
     "latest": "Monitor all episodes of the latest season and future seasons",
-    "none": "No episodes will be monitored"
+    "none": "No episodes will be monitored",
 }
 apply_tags_translation = {"": "add", "sync": "replace", "remove": "remove"}
+
 
 class Sonarr:
     def __init__(self, requests, cache, library, params):
@@ -40,7 +35,7 @@ class Sonarr:
         try:
             self.api = SonarrAPI(self.url, self.token, session=self.requests.session)
             self.api.respect_list_exclusions_when_adding()
-            self.api._validate_add_options(params["root_folder_path"], params["quality_profile"], params["language_profile"]) # noqa
+            self.api._validate_add_options(params["root_folder_path"], params["quality_profile"], params["language_profile"])  # noqa
             self.profiles = self.api.quality_profile()
         except ArrException as e:
             raise Failed(e)
@@ -83,7 +78,7 @@ class Sonarr:
         monitor = monitor_translation[options["monitor"] if "monitor" in options else self.monitor]
         quality_profile = options["quality"] if "quality" in options else self.quality_profile
         language_profile = options["language"] if "language" in options else self.language_profile
-        language_profile = language_profile if self.api._raw.v3 else 1 # noqa
+        language_profile = language_profile if self.api._raw.v3 else 1  # noqa
         series_type = options["series"] if "series" in options else self.series_type
         season = options["season"] if "season" in options else self.season_folder
         tags = options["tag"] if "tag" in options else self.tag
@@ -157,8 +152,7 @@ class Sonarr:
                 pass
             if shows and (len(shows) == 100 or len(tvdb_ids) == i):
                 try:
-                    _a, _e, _i, _x = self.api.add_multiple_series(shows, folder, quality_profile, language_profile, monitor,
-                                                                  season, search, cutoff_search, series_type, tags, per_request=100)
+                    _a, _e, _i, _x = self.api.add_multiple_series(shows, folder, quality_profile, language_profile, monitor, season, search, cutoff_search, series_type, tags, per_request=100)
                     added.extend(_a)
                     exists.extend(_e)
                     invalid.extend(_i)

--- a/modules/tautulli.py
+++ b/modules/tautulli.py
@@ -1,11 +1,13 @@
-from modules import util
-from modules.util import Failed
 from plexapi.exceptions import BadRequest
 from plexapi.video import Movie, Show
+
+from modules import util
+from modules.util import Failed
 
 logger = util.logger
 
 builders = ["tautulli_popular", "tautulli_watched"]
+
 
 class Tautulli:
     def __init__(self, requests, library, params):
@@ -33,7 +35,7 @@ class Tautulli:
             params["section_id"] = self.section_id
         response = self._request("get_home_stats", params=params)
         stat_id = f"{'popular' if data['list_type'] == 'popular' else 'top'}_{'movies' if self.library.is_movie else 'tv'}"
-        stat_type = "users_watched" if data['list_type'] == 'popular' else "total_plays"
+        stat_type = "users_watched" if data["list_type"] == "popular" else "total_plays"
 
         items = None
         for entry in response["response"]["data"]:
@@ -45,8 +47,8 @@ class Tautulli:
 
         rating_keys = []
         for item in items:
-            if (all_items or item["section_id"] == self.section_id) and len(rating_keys) < int(data['list_size']):
-                if int(item[stat_type]) < data['list_minimum']:
+            if (all_items or item["section_id"] == self.section_id) and len(rating_keys) < int(data["list_size"]):
+                if int(item[stat_type]) < data["list_minimum"]:
                     continue
                 try:
                     plex_item = self.library.fetch_item(int(item["rating_key"]))

--- a/modules/tmdb.py
+++ b/modules/tmdb.py
@@ -16,6 +16,7 @@ class NotFound(Failed):
     did not directly configure (e.g. collection IDs auto-built from Plex metadata).
     """
 
+
 logger = util.logger
 
 
@@ -404,12 +405,9 @@ class TMDb:
             except NotFound as e:
                 logger.error(e)
                 if type_map[tmdb_method] == "Collection":
-                    logger.error(f"TMDb Error: Collection ID {tmdb_id} may have been removed from TMDb. "
-                                 f"If this is auto-built by the franchise default, add '{tmdb_id}' to "
-                                 f"your exclude list in template_variables to suppress this error.")
+                    logger.error(f"TMDb Error: Collection ID {tmdb_id} may have been removed from TMDb. " f"If this is auto-built by the franchise default, add '{tmdb_id}' to " f"your exclude list in template_variables to suppress this error.")
                 else:
-                    logger.error(f"TMDb Error: {type_map[tmdb_method]} ID {tmdb_id} may have been removed "
-                                 f"from TMDb. Verify it still exists and update your config.")
+                    logger.error(f"TMDb Error: {type_map[tmdb_method]} ID {tmdb_id} may have been removed " f"from TMDb. Verify it still exists and update your config.")
             except Failed as e:
                 all_not_found = False
                 logger.error(e)

--- a/modules/util.py
+++ b/modules/util.py
@@ -62,19 +62,26 @@ class NotScheduled(Exception):
 class NotScheduledRange(NotScheduled):
     pass
 
+
 class BuilderValidationError(Failed):
     pass
+
 
 class OverlayError(Failed):
     pass
 
+
 class NoValueFound(Failed):
     pass
+
+
 class MappingConvertError(Failed):
     pass
 
+
 class ServiceError(Failed):
     pass
+
 
 class retry_if_http_429_error(retry_if_exception):
 
@@ -728,9 +735,11 @@ def schedule_check(attribute, data, current_time, run_hour, is_all=False):
                             if current_time.day == int(param):
                                 all_check += 1
                             elif int(param) > last_day.day:
-                                logger.warning(f"Schedule Warning: monthly({param}) will not run this month; "
-                                               f"{current_time.strftime('%B')} does not have a {num2words(param, to='ordinal_num')} day. "
-                                               f"Use monthly(last) if you want to schedule for the last day of every month.")
+                                logger.warning(
+                                    f"Schedule Warning: monthly({param}) will not run this month; "
+                                    f"{current_time.strftime('%B')} does not have a {num2words(param, to='ordinal_num')} day. "
+                                    f"Use monthly(last) if you want to schedule for the last day of every month."
+                                )
                         else:
                             raise ValueError
                     except ValueError:

--- a/modules/webhooks.py
+++ b/modules/webhooks.py
@@ -1,8 +1,10 @@
 from json import JSONDecodeError
+
 from modules import util
 from modules.util import Failed
 
 logger = util.logger
+
 
 def get_message(json):
     message = ""
@@ -10,14 +12,16 @@ def get_message(json):
     if json["event"] == "run_end":
         priority = 4
         title = "Run Completed"
-        message = f"Start Time: {json['start_time']}\n" \
-                  f"End Time: {json['end_time']}\n" \
-                  f"Run Time: {json['run_time']}\n" \
-                  f"Collections Created: {json['collections_created']}\n" \
-                  f"Collections Modified: {json['collections_modified']}\n" \
-                  f"Collections Deleted: {json['collections_deleted']}\n" \
-                  f"Items Added: {json['items_added']}\n" \
-                  f"Items Removed: {json['items_removed']}"
+        message = (
+            f"Start Time: {json['start_time']}\n"
+            f"End Time: {json['end_time']}\n"
+            f"Run Time: {json['run_time']}\n"
+            f"Collections Created: {json['collections_created']}\n"
+            f"Collections Modified: {json['collections_modified']}\n"
+            f"Collections Deleted: {json['collections_deleted']}\n"
+            f"Items Added: {json['items_added']}\n"
+            f"Items Removed: {json['items_removed']}"
+        )
         if json["added_to_radarr"]:
             message += f"\n{json['added_to_radarr']} Movies Added To Radarr"
         if json["added_to_sonarr"]:
@@ -29,9 +33,7 @@ def get_message(json):
     elif json["event"] == "version":
         priority = 2
         title = "New Version Available"
-        message = f"Current: {json['current']}\n" \
-                  f"Latest: {json['latest']}\n" \
-                  f"Notes: {json['notes']}"
+        message = f"Current: {json['current']}\n" f"Latest: {json['latest']}\n" f"Notes: {json['notes']}"
     elif json["event"] == "delete":
         if "library_name" in json:
             title = "Collection Deleted"
@@ -62,15 +64,15 @@ def get_message(json):
             message += f"{new_line if message else ''}Error Message: {json['error']}"
         else:
             title = f"{'Collection' if 'collection' in json else 'Playlist'} {'Created' if json['created'] else 'Modified'}"
-            if json['radarr_adds']:
+            if json["radarr_adds"]:
                 message += f"{new_line if message else ''}{len(json['radarr_adds'])} Radarr Additions:"
-            if json['sonarr_adds']:
+            if json["sonarr_adds"]:
                 message += f"{new_line if message else ''}{len(json['sonarr_adds'])} Sonarr Additions:"
             message += f"{new_line if message else ''}{len(json['additions'])} Additions:"
-            for add_dict in json['additions']:
+            for add_dict in json["additions"]:
                 message += f"\n{add_dict['title']}"
             message += f"{new_line if message else ''}{len(json['removals'])} Removals:"
-            for add_dict in json['removals']:
+            for add_dict in json["removals"]:
                 message += f"\n{add_dict['title']}"
 
     return message, title, priority
@@ -126,6 +128,7 @@ class Webhooks:
                     response_json = response.json()
                     logger.trace(f"Response: {response_json}")
                     if webhook == "notifiarr" and self.notifiarr and response.status_code == 400:
+
                         def remove_from_config(text, hook_cat):
                             if response_json["details"]["response"] == text:
                                 yaml = self.requests.file_yaml(self.config.config_path)
@@ -139,6 +142,7 @@ class Webhooks:
                                         yaml.data["webhooks"][hook_cat] = None
                                 if changed:
                                     yaml.save()
+
                         remove_from_config("Kometa updated trigger is not enabled", "changes")
                         remove_from_config("Kometa created trigger is not enabled", "changes")
                         remove_from_config("Kometa deleted trigger is not enabled", "changes")
@@ -169,39 +173,47 @@ class Webhooks:
 
     def end_time_hooks(self, start_time, end_time, run_time, stats):
         if self.run_end_webhooks:
-            self._request(self.run_end_webhooks, {
-                "event": "run_end",
-                "start_time": start_time.strftime("%Y-%m-%d %H:%M:%S"),
-                "end_time": end_time.strftime("%Y-%m-%d %H:%M:%S"),
-                "run_time": run_time,
-                "collections_created": stats["created"],
-                "collections_modified": stats["modified"],
-                "collections_deleted": stats["deleted"],
-                "items_added": stats["added"],
-                "items_removed": stats["removed"],
-                "added_to_radarr": stats["radarr"],
-                "added_to_sonarr": stats["sonarr"],
-                "names": stats["names"]
-            })
+            self._request(
+                self.run_end_webhooks,
+                {
+                    "event": "run_end",
+                    "start_time": start_time.strftime("%Y-%m-%d %H:%M:%S"),
+                    "end_time": end_time.strftime("%Y-%m-%d %H:%M:%S"),
+                    "run_time": run_time,
+                    "collections_created": stats["created"],
+                    "collections_modified": stats["modified"],
+                    "collections_deleted": stats["deleted"],
+                    "items_added": stats["added"],
+                    "items_removed": stats["removed"],
+                    "added_to_radarr": stats["radarr"],
+                    "added_to_sonarr": stats["sonarr"],
+                    "names": stats["names"],
+                },
+            )
 
     def error_hooks(self, text, server=None, library=None, collection=None, playlist=None, critical=True):
         if self.error_webhooks:
             json = {"event": "error", "error": str(text), "critical": critical}
-            if server:          json["server_name"] = str(server)
-            if library:         json["library_name"] = str(library)
-            if collection:      json["collection"] = str(collection)
-            if playlist:        json["playlist"] = str(playlist)
+            if server:
+                json["server_name"] = str(server)
+            if library:
+                json["library_name"] = str(library)
+            if collection:
+                json["collection"] = str(collection)
+            if playlist:
+                json["playlist"] = str(playlist)
             self._request(self.error_webhooks, json)
 
     def delete_hooks(self, message, server=None, library=None):
         if self.delete_webhooks:
             json = {"event": "delete", "message": str(message)}
-            if server:          json["server_name"] = str(server)
-            if library:         json["library_name"] = str(library)
+            if server:
+                json["server_name"] = str(server)
+            if library:
+                json["library_name"] = str(library)
             self._request(self.delete_webhooks, json)
 
-    def collection_hooks(self, webhooks, collection, poster_url=None, background_url=None, created=False,
-                         additions=None, removals=None, radarr=None, sonarr=None, playlist=False):
+    def collection_hooks(self, webhooks, collection, poster_url=None, background_url=None, created=False, additions=None, removals=None, radarr=None, sonarr=None, playlist=False):
         if self.library:
             thumb = None
             if not poster_url and collection.thumb and next((f for f in collection.fields if f.name == "thumb"), None):
@@ -209,21 +221,24 @@ class Webhooks:
             art = None
             if not playlist and not background_url and collection.art and next((f for f in collection.fields if f.name == "art"), None):
                 art = self.requests.get_image_encoded(f"{self.library.url}{collection.art}?X-Plex-Token={self.library.token}")
-            self._request(webhooks, {
-                "event": "changes",
-                "server_name": self.library.PlexServer.friendlyName,
-                "library_name": self.library.name,
-                "playlist" if playlist else "collection": collection.title,
-                "created": created,
-                "poster": thumb,
-                "background": art,
-                "poster_url": poster_url,
-                "background_url": background_url,
-                "additions": additions if additions else [],
-                "removals": removals if removals else [],
-                "radarr_adds": radarr if radarr else [],
-                "sonarr_adds": sonarr if sonarr else [],
-            })
+            self._request(
+                webhooks,
+                {
+                    "event": "changes",
+                    "server_name": self.library.PlexServer.friendlyName,
+                    "library_name": self.library.name,
+                    "playlist" if playlist else "collection": collection.title,
+                    "created": created,
+                    "poster": thumb,
+                    "background": art,
+                    "poster_url": poster_url,
+                    "background_url": background_url,
+                    "additions": additions if additions else [],
+                    "removals": removals if removals else [],
+                    "radarr_adds": radarr if radarr else [],
+                    "sonarr_adds": sonarr if sonarr else [],
+                },
+            )
 
     def slack(self, json):
         if json["event"] == "run_end":
@@ -231,28 +246,21 @@ class Webhooks:
             rows = [
                 [("*Start Time*", json["start_time"]), ("*End Time*", json["end_time"]), ("*Run Time*", json["run_time"])],
                 [],
-                [
-                    (":heavy_plus_sign: *Collections Created*", str(json["collections_created"])),
-                    (":infinity: *Collections Modified*", str(json["collections_modified"])),
-                    (":heavy_minus_sign: *Collections Deleted*", str(json["collections_deleted"]))
-                ]
+                [(":heavy_plus_sign: *Collections Created*", str(json["collections_created"])), (":infinity: *Collections Modified*", str(json["collections_modified"])), (":heavy_minus_sign: *Collections Deleted*", str(json["collections_deleted"]))],
             ]
             if json["added_to_radarr"] or json["added_to_sonarr"]:
                 rows.append([])
             if json["added_to_radarr"]:
-                rows.append([("*Added To Radarr*", json['added_to_radarr'])])
+                rows.append([("*Added To Radarr*", json["added_to_radarr"])])
             if json["added_to_sonarr"]:
-                rows.append([("*Added To Sonarr*", json['added_to_sonarr'])])
+                rows.append([("*Added To Sonarr*", json["added_to_sonarr"])])
 
         elif json["event"] == "run_start":
             title = ":information_source: Kometa Has Started!"
             rows = [[("*Start Time*", json["start_time"])]]
         elif json["event"] == "version":
             title = "Kometa Has a New Version Available"
-            rows = [
-                [("*Current Version*", json["current"]), ("*Latest Version*", json["latest"])],
-                [(json["notes"], )]
-            ]
+            rows = [[("*Current Version*", json["current"]), ("*Latest Version*", json["latest"])], [(json["notes"],)]]
         else:
             rows = []
             row1 = []
@@ -274,7 +282,7 @@ class Webhooks:
             elif "error" in json:
                 title = f":warning: Kometa Encountered {'a Critical' if json['critical'] else 'an'} Error"
                 rows.append([])
-                rows.append([(json["error"], )])
+                rows.append([(json["error"],)])
             else:
                 title = f"{':heavy_plus_sign:' if json['created'] else ':infinity:'} A {text} has Been {'Created' if json['created'] else 'Modified'}!"
 
@@ -292,19 +300,13 @@ class Webhooks:
                 if json["additions"]:
                     rows.append([])
                     rows.append([("*Items Added*", " ")])
-                    rows.append([(get_field_text(json["additions"]), )])
+                    rows.append([(get_field_text(json["additions"]),)])
                 if json["removals"]:
                     rows.append([])
                     rows.append([("*Items Removed*", " ")])
-                    rows.append([(get_field_text(json["removals"]), )])
+                    rows.append([(get_field_text(json["removals"]),)])
 
-        new_json = {
-            "text": title,
-            "blocks": [{
-                "type": "header",
-                "text": {"type": "plain_text", "text": title}
-            }]
-        }
+        new_json = {"text": title, "blocks": [{"type": "header", "text": {"type": "plain_text", "text": title}}]}
 
         if rows:
             for row in rows:
@@ -317,9 +319,9 @@ class Webhooks:
                         for col in row:
                             section["fields"].append({"type": "mrkdwn", "text": col[0]})
                             section["fields"].append({"type": "plain_text", "text": col[1]})
-                        new_json["blocks"].append(section) # noqa
+                        new_json["blocks"].append(section)  # noqa
                 else:
-                    new_json["blocks"].append({"type": "divider"}) # noqa
+                    new_json["blocks"].append({"type": "divider"})  # noqa
         return new_json
 
     def discord(self, json):
@@ -333,8 +335,8 @@ class Webhooks:
                 [
                     ("Created", json["collections_created"] if json["collections_created"] else "0"),
                     ("Modified", json["collections_modified"] if json["collections_modified"] else "0"),
-                    ("Deleted", json["collections_deleted"] if json["collections_deleted"] else "0")
-                ]
+                    ("Deleted", json["collections_deleted"] if json["collections_deleted"] else "0"),
+                ],
             ]
             if json["added_to_radarr"]:
                 rows.append([(f"{json['added_to_radarr']} Movies Added To Radarr", None)])
@@ -345,10 +347,7 @@ class Webhooks:
             description = json["start_time"]
         elif json["event"] == "version":
             title = "New Version Available"
-            rows = [
-                [("Current", json["current"]), ("Latest", json["latest"])],
-                [("New Commits", json["notes"])]
-            ]
+            rows = [[("Current", json["current"]), ("Latest", json["latest"])], [("New Commits", json["notes"])]]
         else:
             row1 = []
             text = ""
@@ -387,16 +386,7 @@ class Webhooks:
                     rows.append([("Items Added", get_field_text(json["additions"]))])
                 if json["removals"]:
                     rows.append([("Items Removed", get_field_text(json["removals"]))])
-        new_json = {
-            "embeds": [
-                {
-                    "title": title,
-                    "color": 0x00bc8c
-                }
-            ],
-            "username": "Kobota",
-            "avatar_url": "https://github.com/Kometa-Team/Kometa/raw/master/.github/bot.png"
-        }
+        new_json = {"embeds": [{"title": title, "color": 0x00BC8C}], "username": "Kobota", "avatar_url": "https://github.com/Kometa-Team/Kometa/raw/master/.github/bot.png"}
         if description:
             new_json["embeds"][0]["description"] = description
 

--- a/tests/test_apprise_notify.py
+++ b/tests/test_apprise_notify.py
@@ -1,12 +1,13 @@
 from unittest.mock import MagicMock, patch
+
 import pytest
 
 from modules.util import Failed
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_params(config_path="/config/apprise.yml"):
     return {"config": config_path}
@@ -23,11 +24,13 @@ def _make_apobj(num_services=1):
 # __init__ tests
 # ---------------------------------------------------------------------------
 
+
 class TestAppriseNotifyInit:
     @patch("modules.apprise_notify.apprise_lib")
     def test_loads_config_path(self, mock_lib):
         """AppriseConfig.add is called with the configured path."""
         from modules.apprise_notify import AppriseNotify
+
         ac = MagicMock()
         apobj = _make_apobj(1)
         mock_lib.AppriseConfig.return_value = ac
@@ -40,6 +43,7 @@ class TestAppriseNotifyInit:
     def test_raises_failed_when_no_services_loaded(self, mock_lib):
         """Raises Failed when the Apprise object has zero loaded services."""
         from modules.apprise_notify import AppriseNotify
+
         ac = MagicMock()
         apobj = _make_apobj(0)
         mock_lib.AppriseConfig.return_value = ac
@@ -52,6 +56,7 @@ class TestAppriseNotifyInit:
     def test_succeeds_when_services_loaded(self, mock_lib):
         """No exception raised when at least one service loads successfully."""
         from modules.apprise_notify import AppriseNotify
+
         ac = MagicMock()
         apobj = _make_apobj(2)
         mock_lib.AppriseConfig.return_value = ac
@@ -69,10 +74,12 @@ class TestAppriseNotifyInit:
 # We inject a mock _apobj after construction and assert against those strings.
 # ---------------------------------------------------------------------------
 
+
 class TestAppriseNotifyNotification:
     def _make_instance(self):
         """Build an AppriseNotify and swap _apobj for a fresh mock."""
         from modules.apprise_notify import AppriseNotify
+
         with patch("modules.apprise_notify.apprise_lib") as mock_lib:
             mock_lib.AppriseConfig.return_value = MagicMock()
             mock_lib.Apprise.return_value = _make_apobj(1)
@@ -84,19 +91,21 @@ class TestAppriseNotifyNotification:
     def test_run_end_sends_success(self):
         """run_end event (priority 4) maps to NotifyType.SUCCESS = 'success'."""
         instance, mock_apobj = self._make_instance()
-        instance.notification({
-            "event": "run_end",
-            "start_time": "2026-01-01 05:00:00",
-            "end_time": "2026-01-01 05:30:00",
-            "run_time": "30 minutes",
-            "collections_created": 1,
-            "collections_modified": 2,
-            "collections_deleted": 0,
-            "items_added": 10,
-            "items_removed": 0,
-            "added_to_radarr": 0,
-            "added_to_sonarr": 0,
-        })
+        instance.notification(
+            {
+                "event": "run_end",
+                "start_time": "2026-01-01 05:00:00",
+                "end_time": "2026-01-01 05:30:00",
+                "run_time": "30 minutes",
+                "collections_created": 1,
+                "collections_modified": 2,
+                "collections_deleted": 0,
+                "items_added": 10,
+                "items_removed": 0,
+                "added_to_radarr": 0,
+                "added_to_sonarr": 0,
+            }
+        )
         mock_apobj.notify.assert_called_once()
         _, kwargs = mock_apobj.notify.call_args
         assert kwargs["notify_type"] == "success"
@@ -105,11 +114,13 @@ class TestAppriseNotifyNotification:
     def test_error_sends_failure(self):
         """error event (priority 5) maps to NotifyType.FAILURE = 'failure'."""
         instance, mock_apobj = self._make_instance()
-        instance.notification({
-            "event": "error",
-            "error": "Something went wrong",
-            "critical": True,
-        })
+        instance.notification(
+            {
+                "event": "error",
+                "error": "Something went wrong",
+                "critical": True,
+            }
+        )
         mock_apobj.notify.assert_called_once()
         _, kwargs = mock_apobj.notify.call_args
         assert kwargs["notify_type"] == "failure"
@@ -118,12 +129,14 @@ class TestAppriseNotifyNotification:
     def test_version_sends_info(self):
         """version event (priority 2) maps to NotifyType.INFO = 'info'."""
         instance, mock_apobj = self._make_instance()
-        instance.notification({
-            "event": "version",
-            "current": "2.3.1",
-            "latest": "2.4.0",
-            "notes": "Bug fixes",
-        })
+        instance.notification(
+            {
+                "event": "version",
+                "current": "2.3.1",
+                "latest": "2.4.0",
+                "notes": "Bug fixes",
+            }
+        )
         mock_apobj.notify.assert_called_once()
         _, kwargs = mock_apobj.notify.call_args
         assert kwargs["notify_type"] == "info"
@@ -137,12 +150,14 @@ class TestAppriseNotifyNotification:
         with patch("modules.apprise_notify.util") as mock_util:
             mock_logger = MagicMock()
             mock_util.logger = mock_logger
-            instance.notification({
-                "event": "version",
-                "current": "2.3.1",
-                "latest": "2.4.0",
-                "notes": "Bug fixes",
-            })
+            instance.notification(
+                {
+                    "event": "version",
+                    "current": "2.3.1",
+                    "latest": "2.4.0",
+                    "notes": "Bug fixes",
+                }
+            )
 
         mock_logger.warning.assert_called_once()
         warning_msg = mock_logger.warning.call_args[0][0]

--- a/tests/test_imdb.py
+++ b/tests/test_imdb.py
@@ -1,6 +1,8 @@
 """Tests for modules/imdb.py -- focused on parental_guide edge cases."""
-import pytest
+
 from unittest.mock import MagicMock
+
+import pytest
 
 from modules.imdb import IMDb
 from modules.util import Failed
@@ -16,6 +18,7 @@ def make_imdb(graph_response):
 # ---------------------------------------------------------------------------
 # Regression: demonstrate the bugs that existed before the fix
 # ---------------------------------------------------------------------------
+
 
 def test_parental_guide_none_response_pre_fix_raises_attribute_error():
     """Phase 1 regression: .get() on None raised AttributeError before the fix.
@@ -45,6 +48,7 @@ def test_parental_guide_null_title_pre_fix_raises_attribute_error():
 # Fix: _graph_request returns None (network/auth failure or empty response)
 # ---------------------------------------------------------------------------
 
+
 def test_parental_guide_none_response_raises_failed():
     """When _graph_request returns None, parental_guide raises Failed (not AttributeError)
     so operations.py can catch it and skip the item gracefully."""
@@ -58,14 +62,13 @@ def test_parental_guide_none_response_does_not_raise_attribute_error():
     imdb = make_imdb(graph_response=None)
     with pytest.raises(Exception) as exc_info:
         imdb.parental_guide("tt9999999")
-    assert not isinstance(exc_info.value, AttributeError), (
-        "AttributeError escaped -- the None guard is missing"
-    )
+    assert not isinstance(exc_info.value, AttributeError), "AttributeError escaped -- the None guard is missing"
 
 
 # ---------------------------------------------------------------------------
 # Fix: IMDb returns {"data": {"title": null}} for unknown IDs
 # ---------------------------------------------------------------------------
+
 
 def test_parental_guide_null_title_raises_failed():
     """When IMDb returns null for the title (ID not in their DB), parental_guide
@@ -80,14 +83,13 @@ def test_parental_guide_null_title_does_not_raise_attribute_error():
     imdb = make_imdb(graph_response={"data": {"title": None}})
     with pytest.raises(Exception) as exc_info:
         imdb.parental_guide("tt9999999")
-    assert not isinstance(exc_info.value, AttributeError), (
-        "AttributeError escaped -- the null title guard is missing"
-    )
+    assert not isinstance(exc_info.value, AttributeError), "AttributeError escaped -- the null title guard is missing"
 
 
 # ---------------------------------------------------------------------------
 # Fix: IMDb returns {"data": {"title": {"parentsGuide": null}}}
 # ---------------------------------------------------------------------------
+
 
 def test_parental_guide_null_parents_guide_raises_failed():
     """When the title exists but parentsGuide is null, parental_guide raises Failed."""
@@ -101,14 +103,13 @@ def test_parental_guide_null_parents_guide_does_not_raise_attribute_error():
     imdb = make_imdb(graph_response={"data": {"title": {"parentsGuide": None}}})
     with pytest.raises(Exception) as exc_info:
         imdb.parental_guide("tt9999999")
-    assert not isinstance(exc_info.value, AttributeError), (
-        "AttributeError escaped -- the null parentsGuide guard is missing"
-    )
+    assert not isinstance(exc_info.value, AttributeError), "AttributeError escaped -- the null parentsGuide guard is missing"
 
 
 # ---------------------------------------------------------------------------
 # Happy path: valid response with parental guide data
 # ---------------------------------------------------------------------------
+
 
 def test_parental_guide_valid_response():
     """A well-formed GraphQL response returns the expected parental dict."""
@@ -134,17 +135,10 @@ def test_parental_guide_valid_response():
 # Edge case: empty categories list
 # ---------------------------------------------------------------------------
 
+
 def test_parental_guide_empty_categories_raises_failed():
     """An empty categories list (title exists but no guide data) raises Failed."""
-    graph_response = {
-        "data": {
-            "title": {
-                "parentsGuide": {
-                    "categories": []
-                }
-            }
-        }
-    }
+    graph_response = {"data": {"title": {"parentsGuide": {"categories": []}}}}
     imdb = make_imdb(graph_response=graph_response)
     with pytest.raises(Failed, match="No Parental Guide Found"):
         imdb.parental_guide("tt0000000")
@@ -156,6 +150,7 @@ def test_parental_guide_empty_categories_raises_failed():
 # IMDb stopped showing ur######## IDs in their UI. Users now see p.xxxxxxx
 # in watchlist URLs. These tests cover both formats as bare IDs and full URLs.
 # ---------------------------------------------------------------------------
+
 
 class TestValidateImdbWatchlist:
 

--- a/tests/test_letterboxd.py
+++ b/tests/test_letterboxd.py
@@ -182,9 +182,7 @@ def test_list_fallback_extracts_movies_when_letterboxdpy_returns_empty(monkeypat
             "movies": {},
         }
     }
-    requests = FakeRequests(
-        {
-            "https://letterboxd.com/demo/list/staff-picks/": """
+    requests = FakeRequests({"https://letterboxd.com/demo/list/staff-picks/": """
                 <html><body>
                     <ul>
                         <li class="posteritem">
@@ -195,9 +193,7 @@ def test_list_fallback_extracts_movies_when_letterboxdpy_returns_empty(monkeypat
                         </li>
                     </ul>
                 </body></html>
-            """
-        }
-    )
+            """})
     adapter = Letterboxd(requests, FakeCache())
 
     items = adapter._get_list_items("https://letterboxd.com/demo/list/staff-picks/", 0, "en")
@@ -221,9 +217,7 @@ def test_list_url_is_normalized_before_fallback(monkeypatch):
             "movies": {},
         }
     }
-    requests = FakeRequests(
-        {
-            "https://letterboxd.com/demo/list/staff-picks/": """
+    requests = FakeRequests({"https://letterboxd.com/demo/list/staff-picks/": """
                 <html><body>
                     <ul>
                         <li class="posteritem">
@@ -231,9 +225,7 @@ def test_list_url_is_normalized_before_fallback(monkeypatch):
                         </li>
                     </ul>
                 </body></html>
-            """
-        }
-    )
+            """})
     adapter = Letterboxd(requests, FakeCache())
 
     items = adapter._get_list_items("https://letterboxd.com/demo/list/staff-picks", 0, "en")
@@ -242,9 +234,7 @@ def test_list_url_is_normalized_before_fallback(monkeypatch):
 
 
 def test_detail_list_url_extracts_rating_from_star_glyphs():
-    requests = FakeRequests(
-        {
-            "https://letterboxd.com/demo/list/staff-picks/detail/": """
+    requests = FakeRequests({"https://letterboxd.com/demo/list/staff-picks/detail/": """
                 <html><body>
                     <article class="list-detailed-entry">
                         <div class="react-component" data-item-link="/film/first-film/" data-item-name="First Film (2001)" data-postered-identifier="{&quot;uid&quot;:&quot;film:111&quot;}"></div>
@@ -255,9 +245,7 @@ def test_detail_list_url_extracts_rating_from_star_glyphs():
                         </div>
                     </article>
                 </body></html>
-            """
-        }
-    )
+            """})
     adapter = Letterboxd(requests, FakeCache())
 
     items = adapter._get_list_items("https://letterboxd.com/demo/list/staff-picks/detail/", 0, "en")
@@ -278,18 +266,12 @@ def test_request_html_retries_with_scraper_on_cloudflare_challenge(monkeypatch, 
     monkeypatch.setattr(letterboxd_module, "Movie", FakeMovie)
     monkeypatch.setattr(letterboxd_module, "Scraper", FakeScraper)
     monkeypatch.setattr(letterboxd_module, "User", FakeUser)
-    requests = FakeRequests(
-        {
-            "https://letterboxd.com/demo/list/staff-picks/": """
+    requests = FakeRequests({"https://letterboxd.com/demo/list/staff-picks/": """
                 <html><head><title>Just a moment...</title></head><body>Enable JavaScript and cookies to continue</body></html>
-            """
-        }
-    )
-    FakeScraper.html_pages = {
-        "https://letterboxd.com/demo/list/staff-picks/": """
+            """})
+    FakeScraper.html_pages = {"https://letterboxd.com/demo/list/staff-picks/": """
             <html><body><div data-film-id="111" data-item-link="/film/first-film/" data-item-name="First Film (2001)"></div></body></html>
-        """
-    }
+        """}
     adapter = Letterboxd(requests, FakeCache())
 
     response = adapter._request_html("https://letterboxd.com/demo/list/staff-picks/", "en")
@@ -356,9 +338,7 @@ def test_watchlist_falls_back_when_letterboxdpy_returns_empty(monkeypatch, patch
     monkeypatch.setattr(letterboxd_module, "User", FakeUser)
     monkeypatch.setattr(letterboxd_module, "Watchlist", FakeWatchlist)
     FakeWatchlist.payloads = {"demo": {"movies": {}}}
-    requests = FakeRequests(
-        {
-            "https://letterboxd.com/demo/watchlist/": """
+    requests = FakeRequests({"https://letterboxd.com/demo/watchlist/": """
                 <html><body>
                     <ul>
                         <li class="griditem">
@@ -366,9 +346,7 @@ def test_watchlist_falls_back_when_letterboxdpy_returns_empty(monkeypatch, patch
                         </li>
                     </ul>
                 </body></html>
-            """
-        }
-    )
+            """})
     adapter = Letterboxd(requests, FakeCache())
 
     items = adapter._get_list_items("https://letterboxd.com/demo/watchlist", 0, "en")
@@ -406,9 +384,7 @@ def test_user_scoped_films_url_uses_fallback_not_letterboxdpy(monkeypatch, patch
     monkeypatch.setattr(letterboxd_module, "Scraper", FakeScraper)
     monkeypatch.setattr(letterboxd_module, "User", FakeUser)
     FakeFilms.calls = []
-    requests = FakeRequests(
-        {
-            "https://letterboxd.com/raphh11/films/rated/0.5/": """
+    requests = FakeRequests({"https://letterboxd.com/raphh11/films/rated/0.5/": """
                 <html><body>
                     <ul>
                         <li class="griditem">
@@ -417,9 +393,7 @@ def test_user_scoped_films_url_uses_fallback_not_letterboxdpy(monkeypatch, patch
                         </li>
                     </ul>
                 </body></html>
-            """
-        }
-    )
+            """})
     adapter = Letterboxd(requests, FakeCache())
 
     items = adapter._get_list_items("https://letterboxd.com/raphh11/films/rated/0.5/", 0, "en")
@@ -435,17 +409,13 @@ def test_user_scoped_films_fallback_extracts_direct_react_components(monkeypatch
     monkeypatch.setattr(letterboxd_module, "Movie", FakeMovie)
     monkeypatch.setattr(letterboxd_module, "Scraper", FakeScraper)
     monkeypatch.setattr(letterboxd_module, "User", FakeUser)
-    requests = FakeRequests(
-        {
-            "https://letterboxd.com/raphh11/films/rated/0.5/": """
+    requests = FakeRequests({"https://letterboxd.com/raphh11/films/rated/0.5/": """
                 <html><body>
                     <section>
                         <div class="react-component poster" data-item-link="/film/direct-react/" data-item-name="Direct React (1988)" data-postered-identifier="{&quot;uid&quot;:&quot;film:777&quot;}"></div>
                     </section>
                 </body></html>
-            """
-        }
-    )
+            """})
     adapter = Letterboxd(requests, FakeCache())
 
     items = adapter._get_list_items("https://letterboxd.com/raphh11/films/rated/0.5/", 0, "en")
@@ -586,9 +556,7 @@ def test_user_reviews_fallback_extracts_review_entries(monkeypatch, patch_logger
     monkeypatch.setattr(letterboxd_module, "Scraper", FakeScraper)
     monkeypatch.setattr(letterboxd_module, "User", FakeUser)
     FakeUser.payloads = {"reviewer": {"reviews": {}}}
-    requests = FakeRequests(
-        {
-            "https://letterboxd.com/reviewer/films/reviews/": """
+    requests = FakeRequests({"https://letterboxd.com/reviewer/films/reviews/": """
                 <html><body>
                     <div class="viewing-list">
                         <div class="film-detail">
@@ -603,9 +571,7 @@ def test_user_reviews_fallback_extracts_review_entries(monkeypatch, patch_logger
                         </div>
                     </div>
                 </body></html>
-            """
-        }
-    )
+            """})
     adapter = Letterboxd(requests, FakeCache())
 
     items = adapter._get_user_entries("reviewer", "reviews", "en")
@@ -621,9 +587,7 @@ def test_user_films_fallback_extracts_watched_entries(monkeypatch, patch_logger)
     monkeypatch.setattr(letterboxd_module, "Scraper", FakeScraper)
     monkeypatch.setattr(letterboxd_module, "User", FakeUser)
     FakeUser.payloads = {"watcher": {"films": {}}}
-    requests = FakeRequests(
-        {
-            "https://letterboxd.com/watcher/films/": """
+    requests = FakeRequests({"https://letterboxd.com/watcher/films/": """
                 <html><body>
                     <ul>
                         <li class="griditem">
@@ -635,9 +599,7 @@ def test_user_films_fallback_extracts_watched_entries(monkeypatch, patch_logger)
                         </li>
                     </ul>
                 </body></html>
-            """
-        }
-    )
+            """})
     adapter = Letterboxd(requests, FakeCache())
 
     items = adapter._get_user_entries("watcher", "films", "en")

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -7,6 +7,7 @@ so every managed collection appeared "unconfigured" and was deleted.
 
 Fix: use self.library.collection_names (pre-populated from YAML before the run_order loop).
 """
+
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,10 +20,10 @@ ops_module.logger = MagicMock()
 
 from modules.operations import Operations
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def make_ops(collections, collection_names):
     """Return a minimal Operations instance with mocked config and library."""
@@ -46,6 +47,7 @@ def make_col(title, childCount=5, smart=False):
 # Regression: demonstrate the bug that existed before the fix
 # ---------------------------------------------------------------------------
 
+
 def test_configured_check_pre_fix_uses_wrong_attribute():
     """Pre-fix regression: the broken code checked col.title in library.collections
     (populated during the collection run) rather than library.collection_names
@@ -57,22 +59,20 @@ def test_configured_check_pre_fix_uses_wrong_attribute():
     This test replicates the broken logic inline to prove the flaw.
     """
     collection_names = ["SAG Award Winners"]
-    collections = []        # always empty when operations runs first
-    configured_in = False   # user setting: delete unconfigured collections
+    collections = []  # always empty when operations runs first
+    configured_in = False  # user setting: delete unconfigured collections
 
     # Broken logic (old line 99):
-    is_configured_broken = "SAG Award Winners" in collections       # False (wrong: it IS configured)
+    is_configured_broken = "SAG Award Winners" in collections  # False (wrong: it IS configured)
     configured_check_broken = configured_in == is_configured_broken  # False == False → True (DELETE!)
 
-    assert configured_check_broken, (
-        "Bug not reproduced: broken code should trigger delete for a configured collection "
-        "when library.collections is empty"
-    )
+    assert configured_check_broken, "Bug not reproduced: broken code should trigger delete for a configured collection " "when library.collections is empty"
 
 
 # ---------------------------------------------------------------------------
 # Core fix: _should_be_deleted uses library.collection_names
 # ---------------------------------------------------------------------------
+
 
 def test_all_none_never_deletes():
     """Safety guard: when all criteria are None, nothing is deleted."""
@@ -121,6 +121,7 @@ def test_configured_true_collection_not_in_names_not_deleted():
 # managed flag
 # ---------------------------------------------------------------------------
 
+
 def test_managed_true_deletes_kometa_label():
     """managed=True → delete collections labelled Kometa."""
     ops = make_ops(collections=[], collection_names=[])
@@ -160,6 +161,7 @@ def test_managed_false_keeps_kometa():
 # combined configured + managed (the real-world #3168 scenario)
 # ---------------------------------------------------------------------------
 
+
 def test_combined_managed_true_configured_false_keeps_configured_collection():
     """delete_collections: {configured: false, managed: true}
 
@@ -172,10 +174,7 @@ def test_combined_managed_true_configured_false_keeps_configured_collection():
     ops = make_ops(collections=[], collection_names=["SAG Award Winners"])
     col = make_col("SAG Award Winners")
     result = ops._should_be_deleted(col, ["Kometa"], configured_in=False, managed_in=True, less_in=None)
-    assert result is False, (
-        "Managed + configured collection must not be deleted by "
-        "delete_collections: {configured: false, managed: true}"
-    )
+    assert result is False, "Managed + configured collection must not be deleted by " "delete_collections: {configured: false, managed: true}"
 
 
 def test_combined_managed_true_configured_false_deletes_unconfigured_collection():
@@ -184,7 +183,7 @@ def test_combined_managed_true_configured_false_deletes_unconfigured_collection(
     A Kometa-managed collection that is NOT in collection_names (stale/renamed) should be deleted.
     """
     ops = make_ops(collections=[], collection_names=["SAG Award Winners"])
-    col = make_col("Spirit Best Feature Winners")   # old name, no longer in YAML
+    col = make_col("Spirit Best Feature Winners")  # old name, no longer in YAML
     result = ops._should_be_deleted(col, ["Kometa"], configured_in=False, managed_in=True, less_in=None)
     assert result is True, "Managed + unconfigured (stale) collection should be deleted"
 
@@ -192,6 +191,7 @@ def test_combined_managed_true_configured_false_deletes_unconfigured_collection(
 # ---------------------------------------------------------------------------
 # less (childCount threshold)
 # ---------------------------------------------------------------------------
+
 
 def test_less_deletes_small_collection():
     """less=5: collection with 3 items should be deleted."""
@@ -225,6 +225,7 @@ def test_less_none_childcount_treated_as_zero():
 # collection_names pre-populated vs collections (the timing mismatch)
 # ---------------------------------------------------------------------------
 
+
 def test_collection_names_used_not_collections():
     """Explicit proof that _should_be_deleted reads collection_names, not collections.
 
@@ -233,7 +234,7 @@ def test_collection_names_used_not_collections():
     """
     # collection_names says configured, collections says not (as it was during run)
     ops = make_ops(
-        collections=[],                        # empty -- as it is when ops runs first
+        collections=[],  # empty -- as it is when ops runs first
         collection_names=["César Award Winners"],
     )
     col = make_col("César Award Winners")
@@ -241,6 +242,4 @@ def test_collection_names_used_not_collections():
     # If it incorrectly uses library.collections: is_configured=False → configured_check=True → DELETE
     # If it correctly uses library.collection_names: is_configured=True → configured_check=False → KEEP
     result = ops._should_be_deleted(col, ["Kometa"], configured_in=False, managed_in=True, less_in=None)
-    assert result is False, (
-        "_should_be_deleted is reading library.collections instead of library.collection_names"
-    )
+    assert result is False, "_should_be_deleted is reading library.collections instead of library.collection_names"


### PR DESCRIPTION
## What type of PR is this?

- [X] Chore (maintenance, dependency bumps, housekeeping - no functional change)

## Description

Pure formatting cleanup. **No behavioral changes.**

### Why this PR exists

PR #3232 added the first CI lint job that runs `black --check` on the whole repo, which surfaced **31 files with accumulated formatting drift**. To keep #3232 focused on test infrastructure, this cleanup was extracted into its own dedicated PR.

### Why did this drift accumulate?

Pre-commit hooks (via `prek`) only re-check **staged** files. Files that nobody edits silently drift out of `black`/`isort` compliance over time. The new CI lint job in #3232 catches that going forward — but the historical backlog still needs a one-time pass.

### What changed

- `black --line-length 256` on `modules/ tests/ *.py` (31 files reformatted)
- `isort --profile black` on `modules/ tests/ *.py` (a few files reordered)

**Typical `black` changes:**
- Multi-line dicts/lists collapsed to a single line when they fit in 256 chars
- Multi-line dicts/lists that don't fit get fully expanded (one item per line)
- Trailing whitespace stripped
- Standardized string quoting where black prefers it

### Note on flake8

This PR deliberately stops at `black` + `isort`. Pre-existing flake8 violations on nightly are NOT addressed here — they warrant their own focused PR.

### Verification

- All 200 existing tests still pass on this branch
- 3 pre-existing test failures unchanged (identical to plain nightly)
- `black --check --line-length 256 modules/ tests/ *.py` -> clean
- `isort --check-only --profile black modules/ tests/ *.py` -> clean

### Prevention going forward

Contributors should run `prek run --all-files` before pushing. The CI lint job from #3232 catches future drift automatically.

### Merge order

This PR should merge **BEFORE** #3232 so PR 3232's lint job can pass without flagging pre-existing drift.

## Have you updated the Documentation to reflect changes?
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?
- [X] Not Applicable

## Have you updated the CHANGELOG.md?
- [X] Not Applicable (chore-only, no user-visible changes)
