### PR TITLE
chore: fix 25 pre-existing flake8 violations across 8 nightly modules

### DIFF
--- a/modules/anidb.py
+++ b/modules/anidb.py
@@ -1,16 +1,14 @@
 import gzip
-import io
 import json
 import os
 import time
 import traceback
-import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta
 
 from lxml import etree
 
 from modules import util
-from modules.util import Failed, logger
+from modules.util import Failed
 
 logger = util.logger
 
@@ -316,12 +314,12 @@ class AniDB:
             # 7. Parse XML with error handling
             try:
                 xml_result = etree.fromstring(content)
-            except etree.XMLSyntaxError as e:
+            except etree.XMLSyntaxError:
                 logger.error(f"AniDB Error: Invalid XML response from {target_url}")
                 logger.error(f"Response content type: {response.headers.get('content-type', 'unknown')}")
                 try:
                     logger.error(f"Response preview: {content[:500].decode('utf-8', errors='replace')}")
-                except:
+                except Exception:
                     logger.error(f"Response preview (bytes): {content[:500]}")
                 raise Failed(f"AniDB Error: Endpoint may not be implemented - {target_url}")
 

--- a/modules/anilist.py
+++ b/modules/anilist.py
@@ -360,7 +360,7 @@ class AniList:
                 time.sleep(wait_time if wait_time > 0 else 10)
                 if level < 6:
                     return self._request(query, variables, level=level + 1)
-                raise Failed(f"AniList Error: Connection Failed")
+                raise Failed("AniList Error: Connection Failed")
             else:
                 raise Failed(f"AniList Error: {json_obj['errors'][0]['message']}")
         else:
@@ -500,7 +500,7 @@ class AniList:
             query ($user: String, $sort: [MediaListSort]) {
               MediaListCollection (userName: $user, sort: $sort, type: ANIME) {
                 lists {
-                  name 
+                  name
                   entries {
                     score(format: POINT_10)
                     media{id}

--- a/modules/imdb.py
+++ b/modules/imdb.py
@@ -890,7 +890,7 @@ class IMDb:
                 logger.info(f"    {k}: {data[k]}")
             return [(_i, "imdb") for _i in self._award(data)]
         elif method == "imdb_search":
-            logger.info(f"Processing IMDb Search:")
+            logger.info("Processing IMDb Search:")
             for k, v in data.items():
                 logger.info(f"    {k}: {v}")
             return [(_i, "imdb") for _i in self._pagination(data, "search")]

--- a/modules/mal.py
+++ b/modules/mal.py
@@ -216,7 +216,7 @@ class MyAnimeList:
             else:
                 return response
         except JSONDecodeError:
-            raise Failed(f"MyAnimeList Error: Connection Failed")
+            raise Failed("MyAnimeList Error: Connection Failed")
 
     def _jikan_request(self, url, params=None):
         logger.trace(f"URL: {jikan_base_url}{url}")

--- a/modules/mdblist.py
+++ b/modules/mdblist.py
@@ -1,9 +1,7 @@
 import time
 from datetime import datetime
-from json import JSONDecodeError
 
 from modules import util
-from modules.request import urlparse
 from modules.util import Failed, LimitReached
 
 logger = util.logger
@@ -138,7 +136,7 @@ class MDBList:
 
             self.get_item(media_provider="imdb", media_type="movie", media_id="tt0080684", ignore_cache=True)
         except LimitReached:
-            logger.info(f"MDBList API limit exhausted")
+            logger.info("MDBList API limit exhausted")
             self.limit = True
         except Failed as fe:
             logger.info(f"MDBList API connection failed: {fe}")

--- a/modules/mojo.py
+++ b/modules/mojo.py
@@ -205,13 +205,13 @@ class BoxOfficeMojo:
                 url = "/chart/top_lifetime_gross/" if data["chart"] == "domestic" else "/chart/ww_top_lifetime_gross/"
             else:
                 text += f" {data['content_rating_filter'].upper()}"
-                url = f"/chart/mpaa_title_lifetime_gross/"
+                url = "/chart/mpaa_title_lifetime_gross/"
                 params = {"by_mpaa": content_rating_options[data["content_rating_filter"]]}
             text += " Grosses"
         elif method == "mojo_never":
             pretty, arg_key = never_in_options[data["never"]]
             text = f"Top-Grossing Movies That Never Hit {pretty} {data['chart'].capitalize()}"
-            url = f"/chart/never_in_top/"
+            url = "/chart/never_in_top/"
             params = {"by_rank_threshold": data["never"]}
             if data["chart"] != "domestic":
                 params["area"] = self.never_options[data["chart"]]

--- a/modules/overlay.py
+++ b/modules/overlay.py
@@ -8,7 +8,7 @@ from plexapi.audio import Album
 from plexapi.video import Episode
 
 from modules import util
-from modules.util import Failed, OverlayError
+from modules.util import OverlayError
 
 logger = util.logger
 
@@ -157,7 +157,7 @@ class Overlay:
             self.data = {"name": str(self.data)}
             logger.warning(f"Overlay Warning: No overlay attribute using mapping name {self.data} as the overlay name")
         if "name" not in self.data or not self.data["name"]:
-            raise OverlayError(f"Overlay Error: Overlays must have the 'name' attribute")
+            raise OverlayError("Overlay Error: Overlays must have the 'name' attribute")
         self.name = str(self.data["name"])
 
         self.prefix = f"Overlay File ({self.overlay_file.file_num}) "
@@ -175,15 +175,15 @@ class Overlay:
         if "weight" in self.data:
             self.weight = util.parse("Overlay", "weight", self.data["weight"], datatype="int", parent="overlay", minimum=0)
         if "group" in self.data and (self.weight is None or not self.group):
-            raise OverlayError(f"Overlay Error: Overlay attribute 'group' requires the 'weight' attribute")
+            raise OverlayError("Overlay Error: Overlay attribute 'group' requires the 'weight' attribute")
         elif "queue" in self.data and (self.weight is None or not self.queue_name):
-            raise OverlayError(f"Overlay Error: Overlay attribute 'queue' requires the 'weight' attribute")
+            raise OverlayError("Overlay Error: Overlay attribute 'queue' requires the 'weight' attribute")
         elif self.group and self.queue_name:
-            raise OverlayError(f"Overlay Error: Overlay attributes 'group' and 'queue' cannot be used together")
+            raise OverlayError("Overlay Error: Overlay attributes 'group' and 'queue' cannot be used together")
         self.horizontal_offset, self.horizontal_align, self.vertical_offset, self.vertical_align = util.parse_cords(self.data, "overlay")
 
         if (self.horizontal_offset is None and self.vertical_offset is not None) or (self.vertical_offset is None and self.horizontal_offset is not None):
-            raise OverlayError(f"Overlay Error: Overlay attributes 'horizontal_offset' and 'vertical_offset' must be used together")
+            raise OverlayError("Overlay Error: Overlay attributes 'horizontal_offset' and 'vertical_offset' must be used together")
 
         self.scale_width, self.scale_height = util.parse_scale(self.data, "overlay")
 
@@ -206,12 +206,12 @@ class Overlay:
         if self.name == "backdrop":
             self.back_box = (back_width, back_height)
         elif self.back_align != "center" and back_width < 0:
-            raise OverlayError(f"Overlay Error: Overlay attribute 'back_align' only works when 'back_width' is used")
+            raise OverlayError("Overlay Error: Overlay attribute 'back_align' only works when 'back_width' is used")
         elif back_width >= 0 or back_height >= 0:
             self.back_box = (back_width, back_height)
         self.has_back = True if self.back_color or self.back_line_color else False
         if self.name != "backdrop" and self.has_back and not self.has_coordinates() and not self.queue_name:
-            raise OverlayError(f"Overlay Error: Overlay attributes 'horizontal_offset' and 'vertical_offset' are required when using 'backdrop'")
+            raise OverlayError("Overlay Error: Overlay attributes 'horizontal_offset' and 'vertical_offset' are required when using 'backdrop'")
 
         def get_and_save_image(image_url):
             response = self.requests.get(image_url)
@@ -272,7 +272,7 @@ class Overlay:
                 self.name = "blur(50)"
         elif self.name.startswith("text"):
             if not self.has_coordinates() and not self.queue_name:
-                raise OverlayError(f"Overlay Error: Overlay attributes 'horizontal_offset' and 'vertical_offset' are required when using 'text'")
+                raise OverlayError("Overlay Error: Overlay attributes 'horizontal_offset' and 'vertical_offset' are required when using 'text'")
             if self.path:
                 if not os.path.exists(self.path):
                     raise OverlayError(f"Overlay Error: Text overlay addon image not found at '{self.path}'")
@@ -348,7 +348,7 @@ class Overlay:
                 if text_mod is None:
                     self.name = f"text(<<{text}>>)"
                 else:
-                    self.name = f"text(<<{text}#>>)" if text_mod == "#" else f"text(<<{text}%>>{''  if text_mod == '0' else '%'})"
+                    self.name = f"text(<<{text}#>>)" if text_mod == "#" else f"text(<<{text}%>>{'' if text_mod == '0' else '%'})"
             if "<<originally_available[" in text:
                 match = re.search("<<originally_available\\[(.+)]>>", text)
                 if match:

--- a/modules/tmdb.py
+++ b/modules/tmdb.py
@@ -8,15 +8,6 @@ from tmdbapis import TMDbAPIs, TMDbException
 from modules import util
 from modules.util import Failed
 
-
-class NotFound(Failed):
-    """Raised when a TMDb Collection returns 404 — the collection may have been removed or renumbered on TMDb.
-
-    Distinct from Failed so callers can log actionable guidance for stale IDs that the user
-    did not directly configure (e.g. collection IDs auto-built from Plex metadata).
-    """
-
-
 logger = util.logger
 
 


### PR DESCRIPTION
## What type of PR is this?

- [X] Chore (maintenance, dependency bumps, housekeeping - no functional change)

## Description

Pure lint cleanup. **No behavioral changes.**

### Why this PR exists

PR #3232 added a CI lint job that runs `flake8` on the whole repo. That surfaced **25 pre-existing violations across 8 modules** that had accumulated on nightly because pre-commit hooks only re-check *staged* files. Files nobody edits silently drift out of compliance.

Companion to **#3234** (which addressed black + isort drift). Together, these two PRs unblock PR #3232's lint job.

### Violations breakdown

| Count | Code | Description |
|---|---|---|
| 14 | F541 | f-string is missing placeholders |
| 5 | F401 | imported but unused |
| 2 | F811 | redefinition of unused symbol |
| 1 | F841 | local variable assigned but never used |
| 1 | W291 | trailing whitespace |
| 1 | E722 | do not use bare `except` |
| 1 | E272 | multiple spaces before keyword |

### Files touched

| File | Issues |
|---|---|
| `modules/anidb.py` | F401 (`io`, `xml.etree.ElementTree`), F811 (`logger`), F841 (`e`), E722 (bare `except`) |
| `modules/anilist.py` | F541, W291 |
| `modules/imdb.py` | F541 |
| `modules/mal.py` | F541 |
| `modules/mdblist.py` | F401 (`JSONDecodeError`, `urlparse`), F541 |
| `modules/mojo.py` | 2× F541 |
| `modules/overlay.py` | F401 (`Failed`), 8× F541, E272 |
| `modules/tmdb.py` | F811 (duplicate `NotFound` class — kept the better docstring) |

### Notable: `modules/tmdb.py`

There were **two back-to-back** `class NotFound(Failed):` definitions (F811). Kept the second one which has the better docstring explaining why it's distinct from `Failed` (it lets callers downgrade noisy log lines for auto-discovered franchise collection IDs that were deleted upstream on TMDb).

### Verification

- All 200 existing tests pass on this branch
- 3 pre-existing test failures unchanged (they fail identically on plain nightly; **not caused by this PR**)
- `flake8 modules/ tests/ *.py` is clean except for `tests/test_operations.py` issues addressed in PR #3232
- `black --check` still passes
- All affected modules still import cleanly

### Merge order

This PR should merge **BEFORE** #3232 so PR 3232's lint job can pass without flagging pre-existing flake8 drift.

## Have you updated the Documentation to reflect changes?
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?
- [X] Not Applicable

## Have you updated the CHANGELOG.md?
- [X] Not Applicable (chore-only, no user-visible changes)
