### PR TITLE
chore: fix 2 lint violations in is_locked() introduced by #3235

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -414,7 +414,7 @@ def item_set(item, item_id):
 
 def is_locked(filepath):
     """Check if a file is locked without consuming file descriptors.
-    
+
     Returns None if file doesn't exist, True if locked, False if accessible.
     Uses stat-based detection instead of open() to avoid FD exhaustion.
     """
@@ -422,7 +422,7 @@ def is_locked(filepath):
         return None
     try:
         # Try to open and immediately close. Use context manager to ensure cleanup.
-        with open(filepath, "a") as f:
+        with open(filepath, "a"):
             pass
         return False
     except (IOError, OSError):


### PR DESCRIPTION
## What type of PR is this?

- [X] Chore (maintenance, dependency bumps, housekeeping - no functional change)

## Description

Two trivial lint fixes for code that landed in #3235 (fd-leak-fixes):

| Line | Code | Issue | Fix |
|---|---|---|---|
| `modules/util.py:417` | **W293** | blank line contains whitespace | strip the 4-space indent from the docstring blank line |
| `modules/util.py:425` | **F841** | local `f` is assigned but never used | change `with open(filepath, "a") as f: pass` to `with open(filepath, "a"): pass` |

Both were in the new `is_locked()` implementation. The docstring's blank separator line had stray indentation, and the `with` statement bound `f` even though the body is just `pass` — we only want the side effect of confirming the file can be opened.

### Why this slipped through

Pre-commit hooks only check files staged at commit time, not the full PR diff. When #3235 was merged via GitHub's UI, the per-line lint never re-ran. The new whole-repo CI lint job (added in #3232) then surfaced the drift.

### Why this is separate from #3232

PR #3232's lint job is failing on these two violations. Rather than fix them inline in #3232 (which would mix unrelated concerns), this PR addresses them in isolation. After this merges, rebasing #3232 onto the new nightly will make its lint pass.

### Verification

- `black --check --line-length 256 modules/ tests/ *.py` → clean
- `flake8 modules/ tests/ *.py` → clean (modulo tests/test_operations.py issues addressed in #3232)
- `is_locked()` behavior unchanged — only removed an unused variable binding

## Have you updated the Documentation to reflect changes?
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?
- [X] Not Applicable

## Have you updated the CHANGELOG.md?
- [X] Not Applicable (chore-only, no user-visible changes)
