### PR TITLE
Prevent duplicate collection creation

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -85,6 +85,7 @@ customizable
 customizations
 césar
 d'or
+DBRepair
 dbader
 de
 death
@@ -163,6 +164,7 @@ homescreen
 homescreens
 hra
 html
+htmlcontent
 http
 https
 hu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internal: add `.gitattributes` to normalize line endings to LF on commit for all text sources, flag image/font/PSD files as binary so Git won't try to diff them, and add `linguist-vendored`/`linguist-generated` hints for cleaner GitHub language stats. Renormalized `defaults/overlays/languages.yml` which had been checked in with CRLF endings since a 2025 community PR. Also adds `export-ignore` entries so `git archive` source tarballs no longer ship `tests/`, `.github/`, or other dev-only files.
 - Internal: extend the `test`, `imports`, and `smoke` CI jobs to a Linux + Windows OS matrix so POSIX-only regressions (the class of bug that produced #3244) get caught before merge instead of at user launch. Adds an AST-based regression test (`test_issue_3244_*`) that statically pins the `try/except ImportError` guard around `import resource` in `kometa.py` and asserts every `resource.<attr>` reference at module scope sits inside an `if resource is not None:` block.
 - Prevent Kometa from creating duplicate collections when Plex search misses an existing same-named collection by falling back to the full collection inventory before creating.
+- Add an end-of-run warning when duplicate collection titles are detected in a Plex library and suggest checking Plex DBRepair if the duplicates are unexpected.
 
 ## [v2.4.3] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix custom `rating<n>_file` (and `git`/`repo`/`url`) overlay images being silently replaced by a built-in `default`/`pmm` asset.
+- Prevent Kometa from creating duplicate collections when Plex search misses an existing same-named collection by falling back to the full collection inventory before creating.
 - Fix overlay cache poisoning where application state was written for unresolved overlays (e.g. no IMDb rating), causing the item to be permanently skipped even after a rating became available.
 - Fix duplicate rows accumulating in `overlay_special_text2` on every run due to a missing `UNIQUE(rating_key, type)` constraint.
 - Ignore episode logo and square-art files during asset-directory discovery because Plex episodes only support poster and background artwork.
@@ -86,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internal: add a GitHub Actions test workflow with separate jobs for `lint` (black + isort + flake8), `test` (pytest with 20% coverage gate), `regression` (regression-only suite), `schema` (JSON Schema validation of `json-schema/*.json` + kitchen-sink config), `imports` (auto-discovered import smoke check across all 40 modules), `perf` (slow-test reporting via `pytest --durations-min`), and `smoke` (`kometa.py --help` + minimal-config dry-run). (#3232)
 - Internal: add `.gitattributes` to normalize line endings to LF on commit for all text sources, flag image/font/PSD files as binary so Git won't try to diff them, and add `linguist-vendored`/`linguist-generated` hints for cleaner GitHub language stats. Renormalized `defaults/overlays/languages.yml` which had been checked in with CRLF endings since a 2025 community PR. Also adds `export-ignore` entries so `git archive` source tarballs no longer ship `tests/`, `.github/`, or other dev-only files.
 - Internal: extend the `test`, `imports`, and `smoke` CI jobs to a Linux + Windows OS matrix so POSIX-only regressions (the class of bug that produced #3244) get caught before merge instead of at user launch. Adds an AST-based regression test (`test_issue_3244_*`) that statically pins the `try/except ImportError` guard around `import resource` in `kometa.py` and asserts every `resource.<attr>` reference at module scope sits inside an `if resource is not None:` block.
+- Prevent Kometa from creating duplicate collections when Plex search misses an existing same-named collection by falling back to the full collection inventory before creating.
 
 ## [v2.4.3] - 2026-06-22
 

--- a/kometa.py
+++ b/kometa.py
@@ -750,6 +750,7 @@ def run_config(config, stats):
         # logger.remove_playlists_handler()
 
     amount_added = 0
+    collections_ran = False
     if not run_args["operations-only"] and not run_args["overlays-only"] and not run_args["playlists-only"]:
         has_run_again = False
         for library in config.libraries:
@@ -841,7 +842,6 @@ def run_config(config, stats):
         logger.info("")
         print_status(playlist_status)
 
-    collections_ran = any("Library Collection Files" in library.status for library in config.libraries)
     if collections_ran:
         report_duplicate_collections(config)
 
@@ -982,6 +982,8 @@ def run_libraries(config):
             # Pre-populate collection_names before the run_order loop so that operations can correctly identify unconfigured collections regardless of run_order.
             # Without this, if operations runs before collections, collection_names is empty and every Plex collection is incorrectly flagged as unconfigured. #1968
             if runs["collections"]:
+                # Only report duplicate collection titles when Kometa actually processed collections this run.
+                collections_ran = True
                 for metadata in library.collection_files:
                     if config.requested_files and metadata.get_file_name() not in config.requested_files:
                         continue

--- a/kometa.py
+++ b/kometa.py
@@ -383,6 +383,43 @@ def collection_count_after_run(beginning_count, items_added, items_removed):
     return max(0, items_added + beginning_count - items_removed)
 
 
+def summarize_duplicate_collections(collections):
+    titles = {}
+    counts = {}
+    for collection in collections:
+        title = str(getattr(collection, "title", "")).strip()
+        if not title:
+            continue
+        key = title.casefold()
+        counts[key] = counts.get(key, 0) + 1
+        titles.setdefault(key, title)
+    return sorted([(titles[key], count) for key, count in counts.items() if count > 1], key=lambda item: (-item[1], item[0].casefold()))
+
+
+def report_duplicate_collections(config):
+    duplicate_libraries = []
+    for library in config.libraries:
+        if getattr(library, "skip_library", False):
+            continue
+        try:
+            duplicate_titles = summarize_duplicate_collections(library.get_all_collections())
+        except Exception as e:
+            logger.warning(f"Plex Warning: Failed to scan duplicate collections in {library.name}: {e}")
+            continue
+        if duplicate_titles:
+            duplicate_libraries.append((library.name, duplicate_titles))
+
+    if duplicate_libraries:
+        logger.separator("Duplicate Collections", space=False, border=False)
+        logger.info("")
+        for library_name, duplicate_titles in duplicate_libraries:
+            logger.warning(f"Plex Warning: Duplicate collection titles detected in {library_name} Library")
+            for title, count in duplicate_titles:
+                logger.warning(f"  {count} instances: {title}")
+            logger.warning("If this is unexpected, consider checking Plex DBRepair.")
+            logger.warning("")
+
+
 def start(attrs):
     try:
         if run_args["validate-file"] or run_args["validate-dir"]:
@@ -803,6 +840,10 @@ def run_config(config, stats):
         logger.separator("Playlists Summary", space=False, border=False)
         logger.info("")
         print_status(playlist_status)
+
+    collections_ran = any("Library Collection Files" in library.status for library in config.libraries)
+    if collections_ran:
+        report_duplicate_collections(config)
 
     stats["added"] += amount_added
     for library in config.libraries:

--- a/kometa.py
+++ b/kometa.py
@@ -721,7 +721,7 @@ def start(attrs):
 
 
 def run_config(config, stats):
-    library_status = run_libraries(config)
+    library_status, collections_ran = run_libraries(config)
 
     playlist_status = {}
     playlist_stats = {}
@@ -750,7 +750,6 @@ def run_config(config, stats):
         # logger.remove_playlists_handler()
 
     amount_added = 0
-    collections_ran = False
     if not run_args["operations-only"] and not run_args["overlays-only"] and not run_args["playlists-only"]:
         has_run_again = False
         for library in config.libraries:
@@ -871,6 +870,7 @@ def run_config(config, stats):
 
 def run_libraries(config):
     library_status = {}
+    collections_ran = False
     for library in config.libraries:
         if library.skip_library:
             logger.info("")
@@ -1058,7 +1058,7 @@ def run_libraries(config):
         except Exception as e:
             library.notify(get_critical_error_message(e))
             log_critical_exception(e)
-    return library_status
+    return library_status, collections_ran
 
 
 def run_collection(config, library, metadata, requested_collections):

--- a/kometa.py
+++ b/kometa.py
@@ -9,6 +9,7 @@ import uuid
 from collections import Counter
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
+from typing import TypeAlias
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.version import parse
@@ -78,6 +79,8 @@ system_versions = {
     "tenacity": None,
     "tmdbapis": tmdbapis.__version__,
 }
+
+LibraryRunStatus: TypeAlias = dict[str, dict[str, str]]
 
 default_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config")
 load_dotenv(os.path.join(default_dir, ".env"))
@@ -868,8 +871,8 @@ def run_config(config, stats):
     return stats
 
 
-def run_libraries(config):
-    library_status = {}
+def run_libraries(config) -> tuple[LibraryRunStatus, bool]:
+    library_status: LibraryRunStatus = {}
     collections_ran = False
     for library in config.libraries:
         if library.skip_library:

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1542,7 +1542,7 @@ class Plex(Library):
             cols = self.search(title=title, libtype="collection")
             exact_matches = [d for d in cols if str(d.title).casefold() == title.casefold()]
             if not exact_matches and force_search:
-                exact_matches = [d for d in self.get_all_collections() if str(d.title).casefold() == title.casefold()]
+                exact_matches = [d for d in self.get_all_collections() if d is not None and str(d.title).casefold() == title.casefold()]
             if exact_matches:
                 if len(exact_matches) > 1:
                     logger.warning(f"Plex Warning: Multiple collections found with title '{title}', using the first exact match")

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1362,13 +1362,27 @@ class Plex(Library):
         if len(test_items) < 1:
             raise Failed(f"Plex Error: No items for smart filter: {uri_args}")
 
+    def _collection_by_title(self, title):
+        try:
+            return self.get_collection(title, force_search=True, debug=False)
+        except Failed:
+            return None
+
     def create_smart_collection(self, title, smart_type, uri_args, ignore_blank_results):
+        existing_collection = self._collection_by_title(title)
+        if existing_collection:
+            logger.warning(f"Plex Warning: Collection '{title}' already exists; skipping creation")
+            return existing_collection
         if not ignore_blank_results:
             self.test_smart_filter(uri_args)
         args = {"type": smart_type, "title": title, "smart": 1, "sectionId": self.Plex.key, "uri": self.build_smart_filter(uri_args)}
         self._query(f"/library/collections{utils.joinArgs(args)}", post=True)
 
     def create_blank_collection(self, title):
+        existing_collection = self._collection_by_title(title)
+        if existing_collection:
+            logger.warning(f"Plex Warning: Collection '{title}' already exists; skipping creation")
+            return existing_collection
         args = {"type": 1 if self.is_movie else 2 if self.is_show else 8, "title": title, "smart": 0, "sectionId": self.Plex.key, "uri": f"{self.PlexServer._uriRoot()}/library/metadata"}
         self._query(f"/library/collections{utils.joinArgs(args)}", post=True)
 
@@ -1526,9 +1540,13 @@ class Plex(Library):
         else:
             title = str(data)
             cols = self.search(title=title, libtype="collection")
-            for d in cols:
-                if str(d.title).casefold() == title.casefold():
-                    return d
+            exact_matches = [d for d in cols if str(d.title).casefold() == title.casefold()]
+            if not exact_matches and force_search:
+                exact_matches = [d for d in self.get_all_collections() if str(d.title).casefold() == title.casefold()]
+            if exact_matches:
+                if len(exact_matches) > 1:
+                    logger.warning(f"Plex Warning: Multiple collections found with title '{title}', using the first exact match")
+                return exact_matches[0]
             if debug:
                 logger.debug("")
                 for d in cols:

--- a/tests/test_duplicate_collections.py
+++ b/tests/test_duplicate_collections.py
@@ -1,0 +1,36 @@
+import ast
+from pathlib import Path
+
+
+def _load_duplicate_summarizer():
+    source = Path(__file__).resolve().parents[1].joinpath("kometa.py").read_text(encoding="utf-8")
+    module = ast.parse(source)
+    helper_nodes = []
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "summarize_duplicate_collections":
+            helper_nodes.append(node)
+            break
+    helper_module = ast.Module(body=helper_nodes, type_ignores=[])
+    code = compile(helper_module, str(Path(__file__).resolve().parents[1] / "kometa.py"), "exec")
+    namespace = {}
+    exec(code, namespace)
+    return namespace["summarize_duplicate_collections"]
+
+
+def test_summarize_duplicate_collections_groups_case_insensitive_titles():
+    summarize_duplicate_collections = _load_duplicate_summarizer()
+
+    class Collection:
+        def __init__(self, title):
+            self.title = title
+
+    collections = [
+        Collection("Top 250 Movies"),
+        Collection("Top 250 Movies"),
+        Collection("top 250 movies"),
+        Collection("Awards"),
+        Collection("Unique"),
+        Collection("Awards"),
+    ]
+
+    assert summarize_duplicate_collections(collections) == [("Top 250 Movies", 3), ("Awards", 2)]

--- a/tests/test_plex_collection_lookup.py
+++ b/tests/test_plex_collection_lookup.py
@@ -1,0 +1,154 @@
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+
+class FakeLogger:
+    def __init__(self):
+        self.warning_messages = []
+
+    def warning(self, message):
+        self.warning_messages.append(str(message))
+
+    def __getattr__(self, name):
+        return lambda *args, **kwargs: None
+
+
+def _load_plex(monkeypatch):
+    monkeypatch.delitem(sys.modules, "modules.plex", raising=False)
+    monkeypatch.delitem(sys.modules, "modules.builder", raising=False)
+    monkeypatch.delitem(sys.modules, "modules.util", raising=False)
+    monkeypatch.delitem(sys.modules, "modules.library", raising=False)
+    monkeypatch.delitem(sys.modules, "modules.poster", raising=False)
+    monkeypatch.delitem(sys.modules, "modules.request", raising=False)
+
+    fake_builder = types.ModuleType("modules.builder")
+    fake_builder.date_attributes = set()
+    fake_builder.date_filters = set()
+    fake_builder.string_filters = set()
+    fake_builder.boolean_filters = set()
+    fake_builder.number_filters = set()
+    monkeypatch.setitem(sys.modules, "modules.builder", fake_builder)
+
+    fake_util = types.ModuleType("modules.util")
+    fake_util.logger = FakeLogger()
+    fake_util.Failed = Exception
+    monkeypatch.setitem(sys.modules, "modules.util", fake_util)
+
+    fake_library = types.ModuleType("modules.library")
+    fake_library.Library = type("Library", (), {})
+    monkeypatch.setitem(sys.modules, "modules.library", fake_library)
+
+    fake_poster = types.ModuleType("modules.poster")
+    fake_poster.ImageData = object
+    monkeypatch.setitem(sys.modules, "modules.poster", fake_poster)
+
+    fake_request = types.ModuleType("modules.request")
+    from urllib.parse import parse_qs, quote_plus, urlparse
+
+    fake_request.parse_qs = parse_qs
+    fake_request.quote_plus = quote_plus
+    fake_request.urlparse = urlparse
+    monkeypatch.setitem(sys.modules, "modules.request", fake_request)
+
+    fake_tenacity = types.ModuleType("tenacity")
+
+    def _identity(value=None, **_kwargs):
+        return value
+
+    def retry(*_args, **_kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    fake_tenacity.retry = retry
+    fake_tenacity.retry_if_not_exception_type = _identity
+    fake_tenacity.stop_after_attempt = _identity
+    fake_tenacity.wait_fixed = _identity
+    monkeypatch.setitem(sys.modules, "tenacity", fake_tenacity)
+
+    plex_module = importlib.import_module("modules.plex")
+    return plex_module
+
+
+def test_get_collection_falls_back_to_full_collection_inventory_when_search_misses(monkeypatch):
+    plex_module = _load_plex(monkeypatch)
+    logger = FakeLogger()
+    monkeypatch.setattr(plex_module, "logger", logger)
+    plex = plex_module.Plex.__new__(plex_module.Plex)
+    hidden_collection = SimpleNamespace(title="Hidden Collection")
+    search_calls = []
+    inventory_calls = []
+
+    def search(*args, **kwargs):
+        search_calls.append((args, kwargs))
+        return []
+
+    def get_all_collections(label=None):
+        inventory_calls.append(label)
+        return [hidden_collection, SimpleNamespace(title="Other Collection")]
+
+    plex.search = search
+    plex.get_all_collections = get_all_collections
+
+    assert plex.get_collection("Hidden Collection", force_search=True) is hidden_collection
+    assert len(search_calls) == 1
+    assert inventory_calls == [None]
+
+
+def test_get_collection_warns_when_inventory_has_duplicate_exact_matches(monkeypatch):
+    plex_module = _load_plex(monkeypatch)
+    logger = FakeLogger()
+    monkeypatch.setattr(plex_module, "logger", logger)
+    plex = plex_module.Plex.__new__(plex_module.Plex)
+    first = SimpleNamespace(title="Duplicate Collection")
+    second = SimpleNamespace(title="Duplicate Collection")
+
+    plex.search = lambda *args, **kwargs: []
+    plex.get_all_collections = lambda label=None: [first, second]
+
+    assert plex.get_collection("Duplicate Collection", force_search=True) is first
+    assert any("Multiple collections found with title 'Duplicate Collection'" in msg for msg in logger.warning_messages)
+
+
+def test_create_blank_collection_skips_create_when_collection_already_exists(monkeypatch):
+    plex_module = _load_plex(monkeypatch)
+    logger = FakeLogger()
+    monkeypatch.setattr(plex_module, "logger", logger)
+    plex = plex_module.Plex.__new__(plex_module.Plex)
+    existing_collection = SimpleNamespace(title="Existing Collection")
+    query_calls = []
+
+    plex.get_collection = lambda *args, **kwargs: existing_collection
+    plex._query = lambda *args, **kwargs: query_calls.append((args, kwargs))
+    plex.is_movie = True
+    plex.is_show = False
+    plex.Plex = SimpleNamespace(key=1)
+    plex.PlexServer = SimpleNamespace(_uriRoot=lambda: "http://plex")
+
+    assert plex.create_blank_collection("Existing Collection") is existing_collection
+    assert query_calls == []
+    assert any("already exists; skipping creation" in msg for msg in logger.warning_messages)
+
+
+def test_create_smart_collection_skips_create_when_collection_already_exists(monkeypatch):
+    plex_module = _load_plex(monkeypatch)
+    logger = FakeLogger()
+    monkeypatch.setattr(plex_module, "logger", logger)
+    plex = plex_module.Plex.__new__(plex_module.Plex)
+    existing_collection = SimpleNamespace(title="Existing Collection")
+    query_calls = []
+    test_calls = []
+
+    plex.get_collection = lambda *args, **kwargs: existing_collection
+    plex._query = lambda *args, **kwargs: query_calls.append((args, kwargs))
+    plex.test_smart_filter = lambda uri_args: test_calls.append(uri_args)
+    plex.build_smart_filter = lambda uri_args: f"smart://{uri_args}"
+    plex.Plex = SimpleNamespace(key=1)
+
+    assert plex.create_smart_collection("Existing Collection", 1, "key=value", ignore_blank_results=False) is existing_collection
+    assert query_calls == []
+    assert test_calls == []
+    assert any("already exists; skipping creation" in msg for msg in logger.warning_messages)

--- a/tests/test_plex_collection_lookup.py
+++ b/tests/test_plex_collection_lookup.py
@@ -34,6 +34,10 @@ def _load_plex(monkeypatch):
     fake_util = types.ModuleType("modules.util")
     fake_util.logger = FakeLogger()
     fake_util.Failed = Exception
+    fake_util.LimitReached = Exception
+    fake_util.MappingConvertError = Exception
+    fake_util.OverlayError = Exception
+    fake_util.ServiceError = Exception
     monkeypatch.setitem(sys.modules, "modules.util", fake_util)
 
     fake_library = types.ModuleType("modules.library")

--- a/tests/test_plex_collection_lookup.py
+++ b/tests/test_plex_collection_lookup.py
@@ -58,8 +58,8 @@ def _load_plex(monkeypatch):
 
     fake_tenacity = types.ModuleType("tenacity")
 
-    def _identity(value=None, **_kwargs):
-        return value
+    def _identity(*args, **_kwargs):
+        return args[0] if args else None
 
     def retry(*_args, **_kwargs):
         def decorator(func):

--- a/tests/test_plex_collection_lookup.py
+++ b/tests/test_plex_collection_lookup.py
@@ -64,8 +64,10 @@ def _load_plex(monkeypatch):
         return decorator
 
     fake_tenacity.retry = retry
+    fake_tenacity.retry_if_exception_type = _identity
     fake_tenacity.retry_if_not_exception_type = _identity
     fake_tenacity.stop_after_attempt = _identity
+    fake_tenacity.wait_chain = _identity
     fake_tenacity.wait_fixed = _identity
     monkeypatch.setitem(sys.modules, "tenacity", fake_tenacity)
 

--- a/tests/test_plex_collection_lookup.py
+++ b/tests/test_plex_collection_lookup.py
@@ -113,6 +113,19 @@ def test_get_collection_warns_when_inventory_has_duplicate_exact_matches(monkeyp
     assert any("Multiple collections found with title 'Duplicate Collection'" in msg for msg in logger.warning_messages)
 
 
+def test_get_collection_ignores_none_entries_in_full_collection_inventory(monkeypatch):
+    plex_module = _load_plex(monkeypatch)
+    logger = FakeLogger()
+    monkeypatch.setattr(plex_module, "logger", logger)
+    plex = plex_module.Plex.__new__(plex_module.Plex)
+    hidden_collection = SimpleNamespace(title="Hidden Collection")
+
+    plex.search = lambda *args, **kwargs: []
+    plex.get_all_collections = lambda label=None: [None, hidden_collection]
+
+    assert plex.get_collection("Hidden Collection", force_search=True) is hidden_collection
+
+
 def test_create_blank_collection_skips_create_when_collection_already_exists(monkeypatch):
     plex_module = _load_plex(monkeypatch)
     logger = FakeLogger()


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG.md and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Prevents Kometa from creating duplicate collections when Plex search misses an existing same-named collection.

The collection creation path now performs a pre-create existence check against the full Plex collection inventory, so an existing collection can still be detected even if the initial search lookup fails. If more than one exact match exists, Kometa warns and skips creation rather than guessing.

Also added a regression test covering:
- fallback to the full collection inventory when search misses
- skipping create when the collection already exists
- warning on duplicate exact matches

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, GitHub will automatically close the issue.
-->
- Related Issue #3233
- Closes #3233 

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

<!--
    This is optional and only necessary when your PR changes supported attributes,
    accepted values, or structure for Configuration Files, Collection Files,
    Metadata Files, Overlay Files, Playlist Files, or Defaults template variables.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG.md entry.
    We may ask you to update the CHANGELOG.md if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No

***NOTE*** Cannot fully test this, as the symptom is generally a corrupt DB, Kometa now checks Plex’s full collection inventory before creating a collection, so if Plex search misses an existing same-named collection, Kometa reuses it instead of creating a duplicate.