### PR TITLE
fix: skip resource.setrlimit() on Windows (regression from #3235)

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -313,6 +313,7 @@ pokémon
 popeadam
 popularplex
 portainer
+posix
 powershell
 pre
 precommit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Downgrade "Skipping `<name>`: Item not found" log message from `ERROR` to `WARNING` in metadata file processing when a mapped item cannot be found in the Plex library.
 - Allow `builder_level` to work with playlists. Fixes #2267
 - Consolidate repeated asset warning messages in the warning summary into shared count buckets so the same warning is reported once instead of one row per affected folder or item.
+- Fix `ModuleNotFoundError: No module named 'resource'` crash on Windows at startup. The file-descriptor limit fix introduced in #3235 used the POSIX-only `resource` module unconditionally. Now wrapped in a `try`/`except ImportError` so the bump is applied on POSIX systems and skipped cleanly on Windows. (#3244)
 
 ## [v2.4.3] - 2026-06-22
 

--- a/kometa.py
+++ b/kometa.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import platform
 import re
-import resource
 import sys
 import sysconfig
 import time
@@ -16,13 +15,23 @@ from packaging.version import parse
 
 from modules.logs import MyLogger
 
-# Increase file descriptor limit to prevent exhaustion with large libraries
+# Increase file descriptor limit to prevent exhaustion with large libraries.
+# The `resource` module is POSIX-only; on Windows the OS manages FD limits
+# differently (and the default 8192 stdio handle cap is already plenty), so
+# we skip this entirely there.
 try:
-    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-    if soft < 4096:
-        resource.setrlimit(resource.RLIMIT_NOFILE, (min(hard, 4096), hard))
-except (ValueError, OSError):
-    pass  # If we can't set it, continue anyway
+    import resource
+except ImportError:
+    resource = None  # type: ignore[assignment]
+
+if resource is not None:
+    try:
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if soft < 4096:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (min(hard, 4096), hard))
+    except (ValueError, OSError):
+        pass  # If we can't set it, continue anyway
+
 
 if sys.version_info[0] != 3 or sys.version_info[1] < 10:
     print("Python Version %s.%s.%s has been detected and is not supported. Kometa requires a minimum of Python 3.10.0." % (sys.version_info[0], sys.version_info[1], sys.version_info[2]))


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)

## Description

PR #3235 fixed `[Errno 24] 'Too many open files'` crashes on large Plex libraries by bumping the file-descriptor soft limit from 256 to 4096 at startup. That fix worked on POSIX. But the `resource` module is POSIX-only — `import resource` raises `ImportError` on Windows before any of the existing `try/except` ever runs.

Result: **every Windows installation of Kometa fails on launch** after #3235 with:

```
ModuleNotFoundError: No module named 'resource'
```

### The fix

Wrap `import resource` in a `try/except ImportError`, bind `resource` to `None` on Windows, and guard the `setrlimit()` block accordingly. POSIX behavior is unchanged; Windows gets a clean no-op startup.

```python
try:
    import resource
except ImportError:
    resource = None  # type: ignore[assignment]

if resource is not None:
    try:
        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
        if soft < 4096:
            resource.setrlimit(resource.RLIMIT_NOFILE, (min(hard, 4096), hard))
    except (ValueError, OSError):
        pass
```

Windows doesn't have `RLIMIT_NOFILE` in the POSIX sense anyway — Python 3.x bumps the stdio handle cap to 8192 by default, which is well above the 4096 target #3235 was raising POSIX to. So skipping the bump entirely on Windows is correct, not a workaround.

### Verified locally

**POSIX path (macOS):**

```
BEFORE: soft=256 hard=inf
AFTER:  soft=4096 hard=inf
resource module bound: True
```

**Windows path (simulated by hiding `resource` from `__import__`):**

```
OK: resource = None, setrlimit block correctly skipped
```

Both paths produce a clean module load.

### What's NOT in this PR

- No change to the underlying FD-leak fixes in `modules/overlay.py`, `modules/poster.py`, `modules/library.py` — those were the structural fixes in #3235 and they're already cross-platform.
- No new tests yet. The smoke test added in #3232 runs on `ubuntu-latest`, where `import resource` works fine. Adding a `windows-latest` leg to the matrix would catch this class of bug in the future and is worth a follow-up issue once #3232 merges.

## Related Issues [optional]

- Regression introduced by #3235
- Related to #3232 (test infrastructure that would have caught this with a Windows CI leg)

## Have you updated the Documentation to reflect changes (if necessary)?

- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
