### PR TITLE
ci: matrix test/imports/smoke jobs across Linux + Windows, regression test for #3244

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -3,6 +3,7 @@ accessmodes
 ACL
 addon
 addons
+AST
 adlib
 afi's
 Ahsoka

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,22 @@
-# ──────────────────────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────────
 # Testing & Quality Gates
 #
 # Runs on every PR targeting nightly + on push to nightly.
 #
 # Checks (in order of speed):
-#   1. lint       — black, isort, flake8, mypy, bandit
-#   2. test       — full pytest suite + coverage threshold
-#   3. regression — issue-specific regression test suite
-#   4. schema     — validate all shipped defaults against JSON schemas
-#   5. imports    — detect NEW circular imports
-#   6. perf       — flag slow tests with --durations=10
-#   7. coverage   — diff-coverage on changed files (if available)
-# ──────────────────────────────────────────────────────────────────────────────
+#   1. lint       — black, isort, flake8, mypy, bandit                 (ubuntu)
+#   2. test       — full pytest suite + coverage threshold     (ubuntu+windows)
+#   3. regression — issue-specific regression test suite                (ubuntu)
+#   4. schema     — validate all shipped defaults against JSON schemas  (ubuntu)
+#   5. imports    — detect NEW circular imports + POSIX-only leaks (ubuntu+windows)
+#   6. perf       — flag slow tests with --durations=10                 (ubuntu)
+#   7. smoke      — `kometa.py --help` + minimal-config dry-run (ubuntu+windows)
+#
+# The three matrix jobs (test/imports/smoke) catch OS-specific regressions
+# like #3244, where #3235's unconditional `import resource` crashed every
+# Windows user. The other jobs stay ubuntu-only because their inputs (Python
+# source, JSON schemas, lint config) are platform-independent.
+# ─────────────────────────────────────────────────────────────────────────────
 name: Tests
 
 on:
@@ -65,10 +70,17 @@ jobs:
         continue-on-error: true
 
   # ── 2. Full Test Suite + Coverage Gate ─────────────────────────────────────
+  # Matrix: ubuntu + windows. Coverage gate only enforced on ubuntu — Windows
+  # leg exists to catch OS-specific test failures (path handling, FD APIs,
+  # subprocess differences), not to ratchet coverage twice.
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     # Fail-fast: don't bother running other jobs if lint failed
     needs: [lint]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v7
 
@@ -91,20 +103,17 @@ jobs:
 
       - name: Run pytest with coverage
         run: |
-          python -m pytest tests/ \
-            --cov=modules \
-            --cov-report=term-missing \
-            --cov-report=xml:coverage.xml \
-            --tb=short \
-            -v
+          python -m pytest tests/ --cov=modules --cov-report=term-missing --cov-report=xml:coverage.xml --tb=short -v
 
       - name: Upload coverage report
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.xml
 
       - name: Enforce minimum coverage
+        if: matrix.os == 'ubuntu-latest'
         run: |
           python -c "
           import xml.etree.ElementTree as ET
@@ -207,12 +216,20 @@ jobs:
         run: |
           python -m pytest tests/test_schema_validation.py tests/test_collection_schema.py tests/test_validator.py -v --tb=short
 
-  # ── 5. Import Cycle Detection ────────────────────────────────────────────────
+  # ── 5. Import Cycle Detection ────────────────────────────────────────
   # Auto-discovers every modules/*.py and tries to import it. Catches new
   # circular imports, missing dependencies, and lazy import bugs that wouldn't
   # show up in unit tests. See tests/test_imports.py for the logic.
+  #
+  # Matrix: ubuntu + windows. Windows leg catches POSIX-only imports leaking
+  # into module-level code (e.g. `import resource`, `import fcntl`, `import
+  # pwd`) — the exact class of bug that crashed every Windows user after #3235.
   imports:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v7
 
@@ -260,10 +277,24 @@ jobs:
             --tb=short \
             -q
 
-  # ── 7. Smoke Test (minimal end-to-end) ─────────────────────────────────────
+  # ── 7. Smoke Test (minimal end-to-end) ─────────────────────────
+  # Matrix: ubuntu + windows. The windows leg is the gate against future
+  # POSIX-only regressions like #3244 — `python kometa.py --help` is the
+  # literal command that crashed on Windows when #3235 added an unconditional
+  # `import resource` at module scope.
+  #
+  # `shell: bash` is set explicitly so the heredoc and `|| true` syntax work
+  # identically on both runners (Windows runners ship git-bash by default).
   smoke:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: [lint]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v7
 
@@ -278,8 +309,8 @@ jobs:
 
       - name: Create minimal config
         run: |
-          mkdir -p /tmp/kometa-smoke
-          cat > /tmp/kometa-smoke/config.yml << 'EOF'
+          mkdir -p "${RUNNER_TEMP}/kometa-smoke"
+          cat > "${RUNNER_TEMP}/kometa-smoke/config.yml" << 'EOF'
           settings:
             cache: false
           libraries: {}
@@ -296,4 +327,4 @@ jobs:
 
       - name: "Run Kometa with minimal config (expected: clean failure)"
         run: |
-          python kometa.py --run --config /tmp/kometa-smoke/config.yml 2>&1 || true
+          python kometa.py --run --config "${RUNNER_TEMP}/kometa-smoke/config.yml" 2>&1 || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-lint-${{ hashFiles('requirements.txt', 'dev-requirements.txt') }}
@@ -90,7 +90,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-test-${{ hashFiles('requirements.txt', 'dev-requirements.txt') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Internal: add a comprehensive pytest test suite (580 tests, up from 203) covering most of `modules/`, plus a regression-test convention (`test_issue_NNNN_*`) for documented bugs. (#3232)
 - Internal: add a GitHub Actions test workflow with separate jobs for `lint` (black + isort + flake8), `test` (pytest with 20% coverage gate), `regression` (regression-only suite), `schema` (JSON Schema validation of `json-schema/*.json` + kitchen-sink config), `imports` (auto-discovered import smoke check across all 40 modules), `perf` (slow-test reporting via `pytest --durations-min`), and `smoke` (`kometa.py --help` + minimal-config dry-run). (#3232)
+- Internal: extend the `test`, `imports`, and `smoke` CI jobs to a Linux + Windows OS matrix so POSIX-only regressions (the class of bug that produced #3244) get caught before merge instead of at user launch. Adds an AST-based regression test (`test_issue_3244_*`) that statically pins the `try/except ImportError` guard around `import resource` in `kometa.py` and asserts every `resource.<attr>` reference at module scope sits inside an `if resource is not None:` block.
 
 ## [v2.4.3] - 2026-06-22
 

--- a/tests/test_collection_schema.py
+++ b/tests/test_collection_schema.py
@@ -10,7 +10,7 @@ SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "..", "json-schema", "coll
 
 @pytest.fixture(scope="module")
 def collection_schema():
-    with open(SCHEMA_PATH) as f:
+    with open(SCHEMA_PATH, encoding="utf-8") as f:
         return json.load(f)
 
 

--- a/tests/test_kometa.py
+++ b/tests/test_kometa.py
@@ -1,0 +1,110 @@
+"""Tests for ``kometa.py`` (the top-level entry script).
+
+The script itself is mostly argparse + scheduling + a thin orchestration
+loop, so most behaviour is covered by the per-module suites. This file
+exists for regression checks that pin invariants of the entry script
+itself — things that, if broken, would crash users at launch before any
+other test had a chance to fire.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+KOMETA_PY = REPO_ROOT / "kometa.py"
+
+
+def _module_ast() -> ast.Module:
+    """Parse kometa.py once and return its AST."""
+    return ast.parse(KOMETA_PY.read_text(encoding="utf-8"))
+
+
+def test_issue_3244_resource_import_is_guarded() -> None:
+    """Regression for #3244: ``import resource`` must be wrapped in try/except.
+
+    The ``resource`` module is POSIX-only. PR #3235 added a bare
+    ``import resource`` at module scope in ``kometa.py`` to bump
+    ``RLIMIT_NOFILE`` from 256 to 4096 on macOS. That import crashed
+    every Windows user at launch with::
+
+        ModuleNotFoundError: No module named 'resource'
+
+    The fix (PR #3244) wraps the import in ``try: import resource /
+    except ImportError: resource = None`` and guards every subsequent
+    use with ``if resource is not None:``.
+
+    This test enforces the guard *statically* — it does not execute
+    ``kometa.py``, so it catches the regression on every platform
+    (including the Linux CI runner where ``import resource`` would
+    succeed and hide the bug).
+    """
+    tree = _module_ast()
+
+    # Walk top-level statements only. A nested ``import resource`` inside
+    # a function body is fine; the bug is specifically a module-scope
+    # unconditional import.
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name != "resource", (
+                    "Found unconditional `import resource` at module scope in kometa.py. " "This crashes on Windows (POSIX-only module). " "Wrap it in `try: import resource / except ImportError: resource = None` instead. " "See PR #3244."
+                )
+
+    # Belt-and-braces: confirm the *guarded* form is still present, so a
+    # well-meaning refactor that removes the try/except (e.g. while
+    # cleaning up "dead code") gets caught here too.
+    guarded_import_found = False
+    for node in tree.body:
+        if isinstance(node, ast.Try):
+            for sub in node.body:
+                if isinstance(sub, ast.Import):
+                    for alias in sub.names:
+                        if alias.name == "resource":
+                            guarded_import_found = True
+                            break
+    assert guarded_import_found, (
+        "Expected a `try: import resource / except ImportError: ...` block at module scope "
+        "in kometa.py. Either the guard was removed, or the file layout changed in a way "
+        "this test doesn't recognise. If the guard is genuinely no longer needed (e.g. the "
+        "code was moved into a function), update this test."
+    )
+
+
+def test_issue_3244_resource_uses_are_guarded() -> None:
+    """Regression for #3244: every ``resource.<attr>`` access must be guarded.
+
+    A guarded import is necessary but not sufficient — if ``resource`` is
+    ``None`` on Windows, calls like ``resource.getrlimit(...)`` will
+    raise ``AttributeError``. This test asserts that every reference to
+    ``resource.<something>`` at module scope lives inside an ``if
+    resource is not None:`` block (or another guard that proves
+    ``resource`` is truthy).
+    """
+    tree = _module_ast()
+
+    # Collect every ``resource.X`` Attribute reference and the line it's on.
+    resource_uses: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id == "resource":
+            resource_uses.append(node.lineno)
+
+    if not resource_uses:
+        return  # No uses at all is fine — the import is also a no-op.
+
+    # Find the line range of every ``if resource is not None:`` block at
+    # module scope so we can confirm each use sits inside one.
+    guarded_ranges: list[tuple[int, int]] = []
+    for node in tree.body:
+        if isinstance(node, ast.If) and isinstance(node.test, ast.Compare):
+            # Match `resource is not None` exactly
+            left = node.test.left
+            ops = node.test.ops
+            comparators = node.test.comparators
+            if isinstance(left, ast.Name) and left.id == "resource" and len(ops) == 1 and isinstance(ops[0], ast.IsNot) and len(comparators) == 1 and isinstance(comparators[0], ast.Constant) and comparators[0].value is None:
+                guarded_ranges.append((node.lineno, node.end_lineno or node.lineno))
+
+    for use_line in resource_uses:
+        inside_guard = any(start <= use_line <= end for start, end in guarded_ranges)
+        assert inside_guard, f"`resource.<attr>` at kometa.py:{use_line} is not inside an `if resource is not None:` block. " f"On Windows `resource` is `None`, so this will raise AttributeError. See PR #3244."

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -45,7 +45,7 @@ DEFAULT_YAML_FILES = sorted(list(DEFAULTS_DIR.rglob("*.yml")) + list(DEFAULTS_DI
 @pytest.mark.parametrize("schema_path", SCHEMA_FILES, ids=lambda p: p.name)
 def test_schema_file_is_valid_jsonschema(schema_path: Path) -> None:
     """Each *-schema.json file must be loadable AND a valid Draft-7 schema."""
-    with schema_path.open() as fh:
+    with schema_path.open(encoding="utf-8") as fh:
         schema = json.load(fh)
 
     # check_schema() raises SchemaError on a malformed schema definition.
@@ -66,7 +66,7 @@ def test_at_least_one_schema_exists() -> None:
 @pytest.mark.parametrize("yaml_path", DEFAULT_YAML_FILES, ids=lambda p: str(p.relative_to(REPO_ROOT)))
 def test_default_file_is_valid_yaml(yaml_path: Path) -> None:
     """Each YAML file under defaults/ must parse without errors."""
-    with yaml_path.open() as fh:
+    with yaml_path.open(encoding="utf-8") as fh:
         try:
             doc = yaml.safe_load(fh)
         except yaml.YAMLError as e:


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [X] Chore (maintenance, dependency bumps, housekeeping - no functional change)

## Description

Extends the test workflow's three highest-OS-signal jobs (`test`, `imports`, `smoke`) to run on `windows-latest` in addition to `ubuntu-latest`, adds an AST-based regression test for PR #3244, and fixes the real Windows bug the new matrix immediately uncovered.

### Why

PR #3235 ("[Errno 24] Too many open files" fix) added an unconditional `import resource` at module scope in `kometa.py`. The `resource` module is POSIX-only, so this crashed every Windows user at launch:

```
ModuleNotFoundError: No module named 'resource'
```

PR #3244 fixed that. But CI didn't catch the regression in the first place — every job ran on `ubuntu-latest`, where `import resource` succeeds. This PR closes that gap.

### What changes

**1. `.github/workflows/test.yml`** — matrix on three jobs:

| Job | Was | Now |
|---|---|---|
| `test` (pytest + coverage) | `ubuntu-latest` | `ubuntu-latest` + `windows-latest`; coverage gate only on Linux |
| `imports` (per-module import walk) | `ubuntu-latest` | `ubuntu-latest` + `windows-latest`; catches POSIX-only imports leaking into module scope |
| `smoke` (`kometa.py --help` + minimal-config dry-run) | `ubuntu-latest` | `ubuntu-latest` + `windows-latest`; literal command that crashed Windows users after #3235 |

The other four jobs (`lint`, `regression`, `schema`, `perf`) stay Linux-only because their inputs are platform-independent — there's no value in doubling CI minutes for the same signal. Also bumped `actions/cache` v5 → v6 in `test.yml` to match #3242's bump of `lint.yml`.

**2. `tests/test_kometa.py`** (new) — two AST-based regression tests for #3244:

- `test_issue_3244_resource_import_is_guarded` — asserts there is no unconditional `import resource` at module scope, and that a `try: import resource / except ImportError` block IS present
- `test_issue_3244_resource_uses_are_guarded` — asserts every `resource.<attr>` reference at module scope sits inside an `if resource is not None:` block

Static AST analysis catches the regression on every platform — even on the Linux runner where `import resource` succeeds and would otherwise hide the bug.

**3. `tests/test_schema_validation.py` + `tests/test_collection_schema.py`** — real Windows bug, caught by this PR's own matrix:

The first run of the new `test (windows-latest)` job failed with:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 7378
FAILED tests/test_schema_validation.py::test_default_file_is_valid_yaml[defaults\\both\\genre.yml]
FAILED tests/test_schema_validation.py::test_default_file_is_valid_yaml[defaults\\movie\\seasonal.yml]
```

The tests opened YAML/JSON files without specifying an encoding. On Windows the default is `cp1252` (charmap), which can't decode the non-ASCII bytes in some defaults files. On Linux the default is `utf-8`, so the bug was invisible. Fix: pin `encoding="utf-8"` on the three offending `open()` calls. Audited `modules/` — all runtime `open()` calls are either `Image.open()` (binary) or already pass `encoding=` where text matters, so no production code is affected.

The CI matrix found a real cross-platform bug on the very first run. 

### Verification

- 660/660 tests pass locally on macOS 14 / Python 3.14
- All seven CI jobs pass after the encoding fix (ubuntu + windows where applicable). The previous run showed everything green except `test (windows-latest)`, which then surfaced the encoding bug; the fix commit clears it.
- Mutation-tested the AST regression: injecting a bare `import resource` at the top of `kometa.py` reliably fails `test_issue_3244_resource_import_is_guarded` with a clear error message pointing at PR #3244. Restoring the file makes both tests pass.
- YAML schema validated (`yaml.safe_load` round-trip succeeds; matrix lands on the right three jobs).

### Implementation notes

- `fail-fast: false` on each matrix so a Linux failure doesn't kill the Windows leg and vice versa — we want both signals.
- `smoke` job pins `defaults.run.shell: bash` explicitly so its heredoc and `|| true` syntax work identically on both runners (Windows GitHub-hosted runners ship git-bash by default). Path swapped from `/tmp/kometa-smoke` to `${RUNNER_TEMP}/kometa-smoke` so it resolves to `C:\Users\runneradmin\AppData\Local\Temp` on Windows.
- The `pytest` command in the `test` job was collapsed to a single line because PowerShell doesn't understand bash-style `\` continuations.
- `pywin32==312; sys_platform == 'win32'` is already in `requirements.txt`, so no requirements changes are needed for Windows.

### What's NOT in this PR

- No new tests for `modules/*` — this is strictly a CI matrix expansion + one regression test + one encoding fix. Broader coverage growth (the `builder.py` / `meta.py` / `operations.py` cluster at 3-7%) is queued as a follow-up.
- No mypy/bandit OS matrix. Those are static analysers, OS-independent.
- No Python version matrix (3.12 / 3.13 / 3.14). Out of scope; deserves its own PR.

## Related Issues [optional]

- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
