### PR TITLE
Fix/ci checkout v7 to v6

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -22,7 +22,7 @@ jobs:
           private-key: ${{ secrets.APP_TOKEN }}
 
       - name: Check Out Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: nightly

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           ref: develop
 

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           ref: nightly
 

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         if: ${{ github.event_name == 'pull_request' || github.event.inputs.platform == 'all' || github.event.inputs.platform == matrix.platform }}

--- a/.github/workflows/docker-version.yml
+++ b/.github/workflows/docker-version.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -76,7 +76,7 @@ jobs:
           author_icon_url: ${{ vars.DOCKER_IMAGE }}
 
       - name: Checkout Configs Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           repository: Kometa-Team/Community-Configs
           token: ${{ secrets.PAT }}

--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: nightly
@@ -57,7 +57,7 @@ jobs:
           private-key: ${{ secrets.APP_TOKEN }}
 
       - name: Check Out Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: nightly
@@ -131,7 +131,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           ref: nightly
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v6
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -20,7 +20,7 @@ jobs:
           private-key: ${{ secrets.APP_TOKEN }}
 
       - name: Check Out Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: develop

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -25,7 +25,7 @@ jobs:
           private-key: ${{ secrets.APP_TOKEN }}
 
       - name: Check Out Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: nightly

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # The checkout step
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v6
     - uses: rojopolis/spellcheck-github-actions@0.62.0
       name: Spellcheck 

--- a/.github/workflows/tag-new-version.yml
+++ b/.github/workflows/tag-new-version.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT }}
           fetch-depth: 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -82,7 +82,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -200,7 +200,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -231,7 +231,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -256,7 +256,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -296,7 +296,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -26,12 +26,11 @@ jobs:
           exit 1
 
       - name: Checkout Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          allow-unsafe-pr-checkout: true
 
       - name: Get changes
         id: get-changes
@@ -95,7 +94,7 @@ jobs:
           private-key: ${{ secrets.APP_TOKEN }}
 
       - name: Check Out Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT }}
           ref: ${{ github.event.pull_request.head.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed CI: downgrade `actions/checkout` from `v7` to `v6` across all workflows to restore PR validation for fork pull requests (still an upgrade over Kometa 2.3.1)
 - Downgrade "Skipping `<name>`: Item not found" log message from `ERROR` to `WARNING` in metadata file processing when a mapped item cannot be found in the Plex library.
 - Allow `builder_level` to work with playlists. Fixes #2267
 - Consolidate repeated asset warning messages in the warning summary into shared count buckets so the same warning is reported once instead of one row per affected folder or item.


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [X] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

`actions/checkout@v7` introduced a breaking security change that blocks checking out fork PRs under `pull_request_target` and `workflow_run` triggers by default. The `validate-pull` workflow uses `pull_request_target` and checks out the contributor's fork branch in two places — the second checkout (in `docker-build-pull`) was missing the `allow-unsafe-pr-checkout: true` opt-in, causing the job to fail for all fork PRs and blocking PR validation entirely.

This PR downgrades `actions/checkout` from `v7` to `v6` across all 14 workflow files. `v6` does not have this restriction, restoring the existing behaviour without requiring structural changes to the workflow. The `allow-unsafe-pr-checkout: true` input (a `v7`-only addition) has also been removed from `validate-pull.yml` as it has no effect in `v6`.

`actions/cache` is already at `v6` throughout (landed via #3242) — no change required there.

Tested by merging the fix to a fork's nightly branch and opening a test PR against it. The `validate-pull` job ran with `actions/checkout@v6`, successfully checked out the fork branch, and passed all checks including spellcheck.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No