### PR TITLE
feat: accept HTTP(S) URLs in text_file builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Accept HTTP(S) URLs anywhere a `text_file` builder used to require a local file path. Kometa first tries to parse the response as JSON (matching today's behaviour) and falls back to a plain-text line-by-line parse on parse failure. Gzip-compressed responses are auto-decompressed. Mixed local/URL lists in a single `text_file` builder are supported.
+
 ## [v2.4.4] - 2026-06-25
 
 ### Fixed

--- a/docs/files/builders/overview.md
+++ b/docs/files/builders/overview.md
@@ -245,10 +245,10 @@ Builders use third-party services to source items to be added to the collection.
 
     ![Text File logo](../../assets/images/files/builders/text.png){ align=right }
 
-    **[Text File](textfile/overview.md)** builders read items from a manually maintained local text file.
+    **[Text File](textfile/overview.md)** builders read items from a manually maintained local or remote text file.
 
     [:octicons-home-16: View Builder](textfile/overview.md){ .md-button .md-button--primary }
 
     ??? quicklink "Popular Builders"
 
-        - [:material-file-document-outline: Text File](textfile/text-file.md) - Reads supported IDs and URLs from a local text file while preserving file order.
+        - [:material-file-document-outline: Text File](textfile/text-file.md) - Reads supported IDs and URLs from a local or remote text file while preserving source order.

--- a/docs/files/builders/textfile/overview.md
+++ b/docs/files/builders/textfile/overview.md
@@ -4,10 +4,10 @@ hide:
 ---
 # Text File Builders
 
-You can find items using a simple manually maintained text file stored locally.
+You can find items using a simple manually maintained text file stored locally or available by URL.
 
 No external service configuration is required for this Builder.
 
 | Builder                          | Description                                                                  |             Works with Movies              |             Works with Shows             |    Works with Playlists and Custom Sort    |
 |:---------------------------------|:-----------------------------------------------------------------------------|:------------------------------------------:|:----------------------------------------:|:------------------------------------------:|
-| [`text_file`](text-file.md) | Reads supported IDs and URLs from a local text file while preserving file order. | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |
+| [`text_file`](text-file.md) | Reads supported IDs and URLs from a local or remote text file while preserving source order. | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |

--- a/docs/files/builders/textfile/text-file.md
+++ b/docs/files/builders/textfile/text-file.md
@@ -4,9 +4,9 @@ hide:
 ---
 # Text File
 
-Finds items using a manually created local text file.
+Finds items using a manually created local or remote text file.
 
-The expected input is a path to a text file or a list of text file paths.
+The expected input is a path or URL to a text file, or a list of text file paths and URLs.
 
 Each non-empty line can contain one of the following. Lines beginning with `#` are ignored, and you can also add trailing inline comments using ` # comment` after a value:
 
@@ -26,7 +26,9 @@ Numeric lines are interpreted by library type:
 - Show libraries: TVDb IDs
 - Playlists or mixed/unknown contexts: generic numeric IDs matched against available movie/show libraries
 
-The `sync_mode: sync` and `collection_order: custom` settings are recommended when you want the collection order to match the file exactly. If a line expands into multiple items from a JSON list URL, those items keep the order returned by that JSON list. If you provide multiple files, they are concatenated in the order listed and treated as a single `text_file` builder.
+The `sync_mode: sync` and `collection_order: custom` settings are recommended when you want the collection order to match the source exactly. If a line expands into multiple items from a JSON list URL, those items keep the order returned by that JSON list. If you provide multiple files or URLs, they are concatenated in the order listed and treated as a single `text_file` builder.
+
+A URL used directly as the `text_file` value can return either plain text content using the same line syntax as a local file, or a JSON list using the JSON list format shown below.
 
 On show libraries, `text_file` can also be used with `builder_level: season` or `builder_level: episode` collections. In those cases, `tvdb_season` and `tvdb_episode` entries can target specific show parts directly.
 
@@ -88,6 +90,14 @@ collections:
 
 ```yaml
 collections:
+  My Remote Hand Curated List:
+    text_file: https://example.com/hand-curated.txt
+    collection_order: custom
+    sync_mode: sync
+```
+
+```yaml
+collections:
   Tracker Episodes:
     builder_level: episode
     text_file: config/lists/tracker-episodes.txt
@@ -100,12 +110,12 @@ collections:
   My Combined Text Files:
     text_file:
       - config/lists/priority.txt
-      - config/lists/overflow.txt
+      - https://example.com/overflow.txt
     collection_order: custom
     sync_mode: sync
 ```
 
-When multiple files are listed, Kometa reads them as one `text_file` builder input in the order shown above. The file boundaries are not kept as separate builder groups; only the combined item order is preserved.
+When multiple files or URLs are listed, Kometa reads them as one `text_file` builder input in the order shown above. The source boundaries are not kept as separate builder groups; only the combined item order is preserved.
 
 ### Example Text File Contents
 

--- a/modules/textfile.py
+++ b/modules/textfile.py
@@ -42,6 +42,9 @@ class TextFile:
     def __init__(self, requests):
         self.requests = requests
 
+    def _is_url(self, value):
+        return str(value).startswith(("http://", "https://"))
+
     def _clean_line(self, line):
         entry = str(line).strip()
         if not entry or entry.startswith("#"):
@@ -71,6 +74,24 @@ class TextFile:
                 return json.loads(raw)
             except (TypeError, json.JSONDecodeError, UnicodeDecodeError):
                 raise Failed(f"{name} Error: JSON not found at {url}")
+
+    def _request_text(self, url, name="Text File"):
+        response = self.requests.get(url)
+        if response.status_code >= 400:
+            raise Failed(f"{name} Error: Text File not found at {url}")
+        content = getattr(response, "content", None)
+        if content is None:
+            raise Failed(f"{name} Error: Text File not found at {url}")
+        raw = content.encode("utf-8") if isinstance(content, str) else bytes(content)
+        if raw.startswith(b"\x1f\x8b"):
+            try:
+                raw = gzip.decompress(raw)
+            except OSError:
+                raise Failed(f"{name} Error: Text File not found at {url}")
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError:
+            raise Failed(f"{name} Error: Text File not found at {url}")
 
     def _request_list(self, url, name="Text File"):
         data = self._request(url, name=name)
@@ -167,6 +188,17 @@ class TextFile:
             raise Failed(f"Text File Error: No IDs found at {url}")
         return ids
 
+    def _parse_text_url(self, url, is_movie=None):
+        try:
+            return self._parse_json_url(url, is_movie=is_movie)
+        except Failed:
+            ids = []
+            for line_number, line in enumerate(self._request_text(url).splitlines(), 1):
+                ids.extend(self._parse_line(line, f"{url}:{line_number}", is_movie=is_movie))
+            if not ids:
+                raise Failed(f"Text File Error: No IDs found at {url}")
+            return ids
+
     def _parse_line(self, line, source, is_movie=None):
         entry = self._clean_line(line)
         if not entry:
@@ -194,10 +226,14 @@ class TextFile:
     def validate_file(self, data):
         valid_files = []
         for text_file in util.get_list(data, split=False, return_none=False):
-            file_path = os.path.abspath(str(text_file))
-            if not os.path.isfile(file_path):
-                raise Failed(f"Text File Error: File not found at {file_path}")
-            valid_files.append(file_path)
+            text_file = str(text_file).strip()
+            if self._is_url(text_file):
+                valid_files.append(text_file)
+            else:
+                file_path = os.path.abspath(text_file)
+                if not os.path.isfile(file_path):
+                    raise Failed(f"Text File Error: File not found at {file_path}")
+                valid_files.append(file_path)
         return valid_files
 
     def get_ids(self, data, is_movie=None):
@@ -205,9 +241,12 @@ class TextFile:
         for file_path in util.get_list(data, split=False, return_none=False):
             if util.logger:
                 util.logger.info(f"Processing Text File: {file_path}")
-            with open(file_path, encoding="utf-8") as handle:
-                for line_number, line in enumerate(handle, 1):
-                    ids.extend(self._parse_line(line, f"{file_path}:{line_number}", is_movie=is_movie))
+            if self._is_url(file_path):
+                ids.extend(self._parse_text_url(file_path, is_movie=is_movie))
+            else:
+                with open(file_path, encoding="utf-8") as handle:
+                    for line_number, line in enumerate(handle, 1):
+                        ids.extend(self._parse_line(line, f"{file_path}:{line_number}", is_movie=is_movie))
         if not ids:
             raise Failed("Text File Error: No IDs found.")
         return ids

--- a/tests/test_textfile.py
+++ b/tests/test_textfile.py
@@ -157,6 +157,56 @@ def test_text_file_concatenates_multiple_files_in_order():
         os.unlink(second_path)
 
 
+def test_text_file_validate_accepts_url():
+    text_builder = TextFile(FakeRequests({}))
+
+    assert text_builder.validate_file("https://example.com/list.txt") == ["https://example.com/list.txt"]
+
+
+def test_text_file_accepts_plain_text_url():
+    text_builder = TextFile(
+        FakeRequests(
+            {
+                "https://example.com/list.txt": FakeResponse(
+                    content="# remote list\n" "tt1234567\n" "12345 # tmdb\n" "plex://movie/5d7768244de0ee001fcc7ff0\n",
+                    json_error=ValueError("not json"),
+                )
+            }
+        )
+    )
+
+    assert text_builder.get_ids("https://example.com/list.txt", is_movie=True) == [
+        ("tt1234567", "imdb"),
+        (12345, "tmdb"),
+        ("plex://movie/5d7768244de0ee001fcc7ff0", "plex"),
+    ]
+
+
+def test_text_file_accepts_json_url_as_builder_input():
+    text_builder = TextFile(FakeRequests({"https://example.com/list.json": ["tt1234567", {"tmdb_id": 67890}]}))
+
+    assert text_builder.get_ids("https://example.com/list.json", is_movie=True) == [("tt1234567", "imdb"), (67890, "tmdb")]
+
+
+def test_text_file_concatenates_file_and_url_in_order():
+    path = _write_temp_file("tt1234567\n")
+    try:
+        text_builder = TextFile(
+            FakeRequests(
+                {
+                    "https://example.com/list.txt": FakeResponse(
+                        content="67890\n",
+                        json_error=ValueError("not json"),
+                    )
+                }
+            )
+        )
+
+        assert text_builder.get_ids([path, "https://example.com/list.txt"], is_movie=True) == [("tt1234567", "imdb"), (67890, "tmdb")]
+    finally:
+        os.unlink(path)
+
+
 def test_text_file_uses_tvdb_for_numeric_show_entries():
     path = _write_temp_file("12345\n")
     try:


### PR DESCRIPTION
## What type of PR is this?

- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)

## Description

Makes the `text_file` builder accept HTTP(S) URLs anywhere it currently accepts a local file path.

### Why

The existing `text_file` builder accepts only local file paths. If a user points it at a URL today, validation fails with `File not found at <url>`. URLs that return JSON could already be handled via the existing internal `_request()` / `_parse_json_url()` path (added for list-style URLs), but nothing in the codebase lets a user feed a remote **plain-text** file directly to `text_file` — even though that's the most common case (curated lists, shared lists from blog posts, etc.).

This means today the only way to use a remote list is to:
1. `curl` the file down to a local path manually, then point `text_file` at the local copy
2. Set up a cron job to keep that local copy in sync

Both are unnecessarily fiddly. URLs should be first-class citizens.

### What changes

| Layer | Change |
|---|---|
| `validate_file()` | If the value starts with `http://` or `https://`, accept it verbatim instead of running `os.path.abspath()` on it (which would produce nonsense like `/cwd/https:/example.com/list.txt`). |
| `get_ids()` | If the value is a URL, route to a new `_parse_text_url()`. Otherwise, the existing local-file path runs unchanged. |
| `_parse_text_url()` (new) | Try JSON first (preserving 100% of existing JSON-URL behaviour), fall back to plain-text line-by-line parse on JSON parse failure. |
| `_request_text()` (new) | Fetch URL, handle gzip-compressed responses (`\x1f\x8b` magic byte), UTF-8 decode, raise `Failed` with the standard error format on any failure. |
| `_is_url()` (new) | One-line helper: `str(value).startswith(("http://", "https://"))`. |

### Design choices

- **JSON-first fallback** — existing JSON-URL users (which is already a supported pattern via `_parse_json_url`) see *zero* behaviour change. New plain-text-URL users get the obvious behaviour.
- **No new YAML keys, no opt-in flag** — the URL detection is purely syntactic on the value itself. A `text_file:` entry just works for either case.
- **Mixed local/URL lists supported** — the validator processes each list entry independently, so this is valid:
  ```yaml
  collections:
    My Combined List:
      text_file:
        - config/lists/priority.txt
        - https://example.com/overflow.txt
  ```
- **gzip handling** — many shared lists are served behind CDNs that send `Content-Encoding: gzip`. Detecting the gzip magic bytes and decompressing in-band is more robust than relying on `requests` to handle it (which it normally does, but not in every wrapper configuration).

### What's NOT in this PR

- No new YAML configuration options (the URL is just the value).
- No new dependencies (`gzip`, `os`, `json` are all already imported in `textfile.py`).
- No changes to other builders — the existing IMDb / Trakt / etc. URL handling is in their own modules.
- No retry / caching behaviour for URLs (existing `self.requests.get()` already gives us tenacity-based retries via the shared request wrapper).

### Verification

- 664 tests pass locally on macOS (up from 660 — added 4 new tests in `tests/test_textfile.py` covering URL detection, JSON URL happy path, plain-text URL fallback, mixed-list scenario).
- `black --check`, `isort --check`, `flake8`: clean.
- `pyspelling -c .spellcheck.yml`: passes.
- Existing `_request()` path is untouched, so existing JSON-URL behaviour is unchanged (verified by the existing test suite still passing without modification).

### Provenance

This change has been sitting in a local branch (`add-url-to-text-builder`) since May 2026. It was orphaned during the test-infra + `.gitattributes` work earlier this week because its branch base diverged from nightly significantly (different CHANGELOG format, no test infra, etc.) and a plain rebase/merge would have brought along ~189 files of stale state.

Resurrected via `git apply --3way` of just the 5 substantive files (`modules/textfile.py`, the 3 docs files, `tests/test_textfile.py`) onto a fresh branch from current `nightly`. All 5 patches applied cleanly with no conflicts. The old local branch has been deleted; this PR is the canonical home for the feature.

## Related Issues [optional]

- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

- [X] Yes

## Have you updated the JSON Schema files (if necessary)?

- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
