### PR TITLE
chore: chip 9 pyright errors out of modules/letterboxd.py (baseline 1205 -> 1196)

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -177,6 +177,7 @@ integrations
 ints
 io
 isort
+iterable
 iteratively
 itvx
 ja

--- a/.pyright-baseline.json
+++ b/.pyright-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Ratcheting pyright baseline. DO NOT hand-edit unless you know what you're doing. Regenerate with: python scripts/pyright_baseline.py --regenerate",
-  "total_errors": 1205,
+  "total_errors": 1196,
   "per_file_errors": {
     "kometa.py": 20,
     "modules/anidb.py": 1,
@@ -11,7 +11,6 @@
     "modules/ergast.py": 2,
     "modules/icheckmovies.py": 3,
     "modules/imdb.py": 7,
-    "modules/letterboxd.py": 9,
     "modules/library.py": 7,
     "modules/logs.py": 5,
     "modules/mdblist.py": 2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `modules/poster.py`: fix 18 Optional-member-access errors flagged by pyright. The `ImageData.__init__` triple-nested-ternary is unwound into an explicit `if`/`elif`/`else` (also skips a redundant `os.stat()` call when `compare=` is provided explicitly). `apply_vars` and `adjust_text_width` early-return on `self.text is None` (matches the callers' existing `if component.text:` guard). `get_generated_layer` raises `Failed` with a descriptive message instead of crashing with `'NoneType' object is not subscriptable` when `Image.load()` or text-dimension computation returns unexpectedly. Baseline drops 1223 → 1205.
+- `modules/letterboxd.py`: fix 9 Optional-call/iterable errors flagged by pyright by removing dead defensive code. `letterboxdpy` is a pinned hard dependency in `requirements.txt`, so the speculative `try/except ImportError` (and the runtime `_require_library()` guard it required) was never reachable in any supported install. Imports are now unconditional, matching every other integration module (`plex.py`, `tmdb.py`, etc.). The two `util.get_list(...)` for-loops in `validate_letterboxd_lists` / `validate_letterboxd_user_pages` now pass `return_none=False` and fall back to `[]`, so they never try to iterate `None`. Net diff: -19 lines, no behavioural change for any real install. Baseline drops 1205 → 1196 (and `modules/letterboxd.py` falls out of the per-file table entirely).
 
 ## [v2.4.4] - 2026-06-25
 

--- a/modules/letterboxd.py
+++ b/modules/letterboxd.py
@@ -3,27 +3,18 @@ from datetime import datetime, timezone
 from urllib.parse import urlparse, urlunparse
 from urllib.request import Request, urlopen
 
+from letterboxdpy.core.scraper import Scraper
+from letterboxdpy.films import Films
+from letterboxdpy.list import List as LetterboxdList
+from letterboxdpy.movie import Movie
+from letterboxdpy.user import User
+from letterboxdpy.watchlist import Watchlist
 from lxml import html as lxml_html
 
 from modules import util
 from modules.util import Failed
 
 logger = util.logger
-
-try:
-    from letterboxdpy.core.scraper import Scraper
-    from letterboxdpy.films import Films
-    from letterboxdpy.list import List as LetterboxdList
-    from letterboxdpy.movie import Movie
-    from letterboxdpy.user import User
-    from letterboxdpy.watchlist import Watchlist
-except ImportError:
-    Films = None
-    LetterboxdList = None
-    Movie = None
-    Scraper = None
-    User = None
-    Watchlist = None
 
 sort_options = {
     "name": "by/name/",
@@ -73,10 +64,6 @@ class Letterboxd:
         self._scraper_cls = Scraper
         self._user_cls = User
         self._watchlist_cls = Watchlist
-
-    def _require_library(self):
-        if not all([self._films_cls, self._list_cls, self._movie_cls, self._scraper_cls, self._user_cls, self._watchlist_cls]):
-            raise Failed("Letterboxd Error: letterboxdpy is required. Install the pinned project dependency and try again.")
 
     def _info_once(self, key, message):
         if key not in self._warned:
@@ -178,7 +165,6 @@ class Letterboxd:
         return bool(title and "just a moment" in title.lower() or body_text and "enable javascript and cookies to continue" in body_text.lower())
 
     def _request_html_with_scraper(self, url):
-        self._require_library()
         try:
             soup = self._scraper_cls.get_page(url)
         except Exception as e:
@@ -462,7 +448,6 @@ class Letterboxd:
         return items
 
     def _tmdb(self, slug_path, language):
-        self._require_library()
         try:
             movie = self._movie_cls(self._slug_path(slug_path).strip("/").split("/")[1])
         except Exception as e:
@@ -524,7 +509,6 @@ class Letterboxd:
         return bool(note_value and note_filter in note_value)
 
     def _get_list_object(self, list_url):
-        self._require_library()
         list_url = self._normalize_url(list_url)
         if self._url_type(list_url) == "watchlist":
             username = self._parse_watchlist_url(list_url)
@@ -539,7 +523,6 @@ class Letterboxd:
             raise Failed(f"Letterboxd Error: Failed to load list {list_url}: {e}") from e
 
     def _get_list_items(self, list_url, limit, language):
-        self._require_library()
         list_url = self._normalize_url(list_url)
         items = []
         if self._url_type(list_url) == "films":
@@ -592,7 +575,6 @@ class Letterboxd:
         return items[:limit] if limit else items
 
     def _get_user_entries(self, username, page_type, language="en"):
-        self._require_library()
         try:
             user = self._user_cls(username)
         except Exception as e:
@@ -692,7 +674,6 @@ class Letterboxd:
         return entries
 
     def get_user_lists(self, username, sort, language):
-        self._require_library()
         try:
             user = self._user_cls(username)
             raw_lists = user.get_lists()
@@ -710,7 +691,7 @@ class Letterboxd:
 
     def validate_letterboxd_lists(self, err_type, letterboxd_lists, language):
         valid_lists = []
-        for letterboxd_dict in util.get_list(letterboxd_lists, split=False):
+        for letterboxd_dict in util.get_list(letterboxd_lists, split=False, return_none=False) or []:
             if not isinstance(letterboxd_dict, dict):
                 letterboxd_dict = {"url": letterboxd_dict}
             dict_methods = {dm.lower(): dm for dm in letterboxd_dict}
@@ -767,7 +748,7 @@ class Letterboxd:
                     letterboxd_dict.update(shared_params)
                     valid_pages.append(self._validate_single_user_page(err_type, letterboxd_dict, page_type, language))
         else:
-            for letterboxd_dict in util.get_list(letterboxd_user_pages, split=False):
+            for letterboxd_dict in util.get_list(letterboxd_user_pages, split=False, return_none=False) or []:
                 if not isinstance(letterboxd_dict, dict):
                     letterboxd_dict = {"username": letterboxd_dict}
                 valid_pages.append(self._validate_single_user_page(err_type, letterboxd_dict, page_type, language))


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [X] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Next swing at the pyright Optional-cluster baseline established in #3239. Target: `modules/letterboxd.py`, which had 9 pyright errors — all `reportOptional*` — that turned out to share a single root cause: dead defensive code that pyright (correctly) couldn't prove was unreachable.

### Root cause

`modules/letterboxd.py` was the only file in `modules/` that wrapped its third-party imports in `try: ... except ImportError: <each name> = None`, then re-checked them at the start of every public method via a `_require_library()` helper. Pyright sees those `_xxx_cls` attributes as `type[Foo] | None` and can't narrow through the runtime helper-method call, so every `self._xxx_cls(...)` invocation lit up as "Object of type None cannot be called."

But that defensive layer is unreachable in any supported install:

- `letterboxdpy==6.5.7` is a pinned **hard** requirement in `requirements.txt`.
- Every other integration module (`plex.py`, `tmdb.py`, `sonarr.py`, `radarr.py`, ...) imports its third-party dependency unconditionally with no guard.

So the right fix isn't to type-narrow the dead code, it's to delete it.

### Changes

| Change | Effect |
|---|---|
| Replace `try: from letterboxdpy ... except ImportError: ... = None` with plain top-level imports | Matches the established codebase pattern; 7 of 9 pyright errors disappear |
| Remove `_require_library()` and its 6 callers | The runtime guard is now provably dead; removing it lets pyright see the non-Optional types directly |
| In `validate_letterboxd_lists()` and the user-pages branch of `validate_letterboxd_user_pages()`, pass `return_none=False` to `util.get_list(...)` AND fall back to `or []` | Fixes the remaining 2 `reportOptionalIterable` errors. `util.get_list` has no return-type annotation so pyright still infers `list \| None` even with `return_none=False`; the `or []` is belt-and-suspenders that narrows cleanly without depending on the helper's internals |

Net diff: **4 files, +11/-29**. Only `modules/letterboxd.py` carries the substantive change (-19 lines); the rest is the baseline update, a CHANGELOG entry, and adding `iterable` to the spellcheck wordlist.

### Behavioural impact

For **any supported install** (i.e. one where `pip install -r requirements.txt` actually ran): zero behavioural change. The deleted helper layer was idempotent at runtime — the same imports succeed, the same code paths run.

For an **unsupported install** (someone has somehow run Kometa without `letterboxdpy`): previously, Kometa would import fine and only blow up with a polite `Failed("Letterboxd Error: letterboxdpy is required...")` the first time someone used a Letterboxd builder. Now it raises `ImportError` at module load. I think this is strictly an improvement — a missing pinned dependency is a setup bug worth surfacing loudly rather than papering over.

### Verification

Run locally on Python 3.12 (matching CI), in a clean venv built per `scripts/README.md`:

```
pytest tests/                                          → 664 passed, 0 failed
pytest tests/test_letterboxd.py                        → 20 passed, 0 failed
python scripts/pyright_baseline.py --check             → -9 (1205 → 1196)
black --check modules/letterboxd.py                    → clean
flake8 modules/letterboxd.py                           → clean
isort --check --profile black modules/letterboxd.py    → clean
pre-commit (isort + flake8 + pyspelling) on commit     → all passed
```

The test suite is the strongest signal: `tests/test_letterboxd.py` has 20 tests that monkeypatch the module-level `Films`/`Movie`/`Scraper`/etc. names, then construct `Letterboxd(...)` and exercise its public API end-to-end. Those names still exist (they're just real imports now instead of conditional ones), so the monkeypatching continues to work. All 20 pass without modification.

### Baseline

```
Before:  1205 errors across 29 files  (modules/letterboxd.py: 9)
After:   1196 errors across 28 files  (modules/letterboxd.py: dropped)
```

`modules/letterboxd.py` falls off the per-file table entirely. 

## Related Issues [optional]

- Related Issue #
- Closes #

Follow-up to #3239 (pyright infra) and #3258 (poster.py cleanup, same author's chip-at-the-baseline series).

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No
