### PR TITLE
fix(flake8): wrap long cords tuple in overlay.py under 256-char limit…

### DIFF
--- a/modules/overlay.py
+++ b/modules/overlay.py
@@ -432,7 +432,12 @@ class Overlay:
             overlay_image = Image.new("RGBA", canvas_box, (255, 255, 255, 0))
             drawing = ImageDraw.Draw(overlay_image)
             if self.has_back:
-                cords = (start_x - self.back_padding, start_y - self.back_padding, start_x + (back_width if self.back_box else box_width) + self.back_padding, start_y + (back_height if self.back_box else box_height) + self.back_padding)  # type: ignore[operator]
+                cords = (  # type: ignore[operator]
+                    start_x - self.back_padding,
+                    start_y - self.back_padding,
+                    start_x + (back_width if self.back_box else box_width) + self.back_padding,
+                    start_y + (back_height if self.back_box else box_height) + self.back_padding,
+                )
                 if self.back_radius:
                     drawing.rounded_rectangle(cords, fill=self.back_color, outline=self.back_line_color, width=self.back_line_width, radius=self.back_radius)  # type: ignore[arg-type]
                 else:

--- a/modules/overlay.py
+++ b/modules/overlay.py
@@ -432,11 +432,11 @@ class Overlay:
             overlay_image = Image.new("RGBA", canvas_box, (255, 255, 255, 0))
             drawing = ImageDraw.Draw(overlay_image)
             if self.has_back:
-                cords = (  # type: ignore[operator]
+                cords = (
                     start_x - self.back_padding,
                     start_y - self.back_padding,
-                    start_x + (back_width if self.back_box else box_width) + self.back_padding,
-                    start_y + (back_height if self.back_box else box_height) + self.back_padding,
+                    start_x + (back_width if self.back_box else box_width) + self.back_padding,  # type: ignore[operator]
+                    start_y + (back_height if self.back_box else box_height) + self.back_padding,  # type: ignore[operator]
                 )
                 if self.back_radius:
                     drawing.rounded_rectangle(cords, fill=self.back_color, outline=self.back_line_color, width=self.back_line_width, radius=self.back_radius)  # type: ignore[arg-type]


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG.md and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [X] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

The cords tuple in modules/overlay.py:435 was 262 chars — 6 over the 256-char flake8 limit. The # type: ignore[operator] comment added in #3272 pushed it over.

Fix: split the tuple across lines, keep the ignore. Zero behaviour change.

Unblocks #3274.

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

<!--
    This is optional and only necessary when your PR changes supported attributes,
    accepted values, or structure for Configuration Files, Collection Files,
    Metadata Files, Overlay Files, Playlist Files, or Defaults template variables.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG.md entry.
    We may ask you to update the CHANGELOG.md if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [X] No
