### PR TITLE
ci: reduce Docker build cache size and prevent cache-full build failures

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -42,7 +42,7 @@ jobs:
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:develop
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min,ignore-error=true
 
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -62,7 +62,7 @@ jobs:
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly-${{ matrix.tag-suffix }}
           cache-from: type=gha,scope=${{ matrix.cache-scope }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.cache-scope }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.cache-scope }},ignore-error=true
 
   docker-publish-nightly:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -63,4 +63,4 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: false
           cache-from: type=gha,scope=${{ matrix.cache-scope }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.cache-scope }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.cache-scope }},ignore-error=true


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [X] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

The `docker-nightly`, `docker-test`, and `docker-develop` workflows were using `cache-to: type=gha,mode=max`, which exports all intermediate build layers to the GitHub Actions cache. With 3 platforms (amd64, arm64, armv7) and multiple workflows running regularly, this causes the 10 GB repository cache limit to be reached quickly, resulting in `error writing layer blob: failed to reserve cache` failures that abort builds entirely.

Changes:
- `mode=max` -> `mode=min`: exports only the final image layers rather than all intermediate build stages, significantly reducing cache consumption
- Added `ignore-error=true`: prevents a full cache from failing the entire build - the image still builds and pushes successfully, it just won't warm the cache for next time

`docker-latest` and `docker-version` (master/release builds) are left unchanged.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [ ] Yes
- [X] No