### PR TITLE
ci: add ignore-error=true to validate-pull docker cache to prevent cache-full build failures

### DIFF
--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -168,7 +168,7 @@ jobs:
           push: true
           tags: kometateam/kometa:${{ steps.update-version.outputs.tag-name }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min,ignore-error=true
 
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [X] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Follow-up to #3277. The `validate-pull` workflow has its own `docker-build-pull` job with `cache-to: type=gha,mode=max` that was missed in the previous cache fix. This was causing the same `error writing layer blob: failed to reserve cache` failure on PR builds when the 10 GB cache limit is reached.

Changes:
- `mode=max` -> `mode=min` and added `ignore-error=true` to the `docker-build-pull` step in `validate-pull.yml`

## Related Issues [optional]

- Related to #3277

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [ ] Yes
- [X] No