### PR TITLE
ci: replace GHA Docker layer cache with registry cache

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -41,8 +41,8 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:develop
-          cache-from: type=gha
-          cache-to: type=gha,mode=min,ignore-error=true
+          cache-from: type=registry,ref=${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:buildcache-develop
+          cache-to: type=registry,ref=${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:buildcache-develop,mode=max
 
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -61,8 +61,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly-${{ matrix.tag-suffix }}
-          cache-from: type=gha,scope=${{ matrix.cache-scope }}
-          cache-to: type=gha,mode=min,scope=${{ matrix.cache-scope }},ignore-error=true
+          cache-from: type=registry,ref=${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:buildcache-${{ matrix.cache-scope }}
+          cache-to: type=registry,ref=${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:buildcache-${{ matrix.cache-scope }},mode=max
 
   docker-publish-nightly:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -31,10 +31,13 @@ jobs:
         include:
           - platform: linux/amd64
             cache-scope: docker-test-amd64
+            nightly-cache-scope: docker-nightly-amd64
           - platform: linux/arm64
             cache-scope: docker-test-arm64
+            nightly-cache-scope: docker-nightly-arm64
           - platform: linux/arm/v7
             cache-scope: docker-test-armv7
+            nightly-cache-scope: docker-nightly-armv7
     steps:
 
       - name: Check Out Repo
@@ -62,5 +65,4 @@ jobs:
             "BRANCH_NAME=${{ github.ref_name }}"
           platforms: ${{ matrix.platform }}
           push: false
-          cache-from: type=gha,scope=${{ matrix.cache-scope }}
-          cache-to: type=gha,mode=min,scope=${{ matrix.cache-scope }},ignore-error=true
+          cache-from: type=registry,ref=${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:buildcache-${{ matrix.nightly-cache-scope }}

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -167,8 +167,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: kometateam/kometa:${{ steps.update-version.outputs.tag-name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min,ignore-error=true
+          cache-from: |
+            type=registry,ref=${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:buildcache-docker-nightly-amd64
+            type=registry,ref=${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:buildcache-docker-nightly-arm64
 
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [X] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

The approach taken in those PRs (`mode=min,ignore-error=true` on the GHA cache backend) was insufficient. When the GitHub Actions cache hits its 10GB repo limit, the reservation failure surfaces as `failed to build: failed to solve: error writing layer blob: failed to reserve cache` - at the buildx solve level, above where `ignore-error` intercepts. The build fails regardless.

This PR replaces GHA Docker layer caching with Docker Hub registry cache across all affected workflows:

- **docker-nightly**: `type=registry` per-platform scope, `mode=max` - no 10GB limit, intermediate layers cached
- **docker-develop**: `type=registry`, `mode=max`
- **docker-test**: `type=registry` cache-from only, reading from nightly's registry cache - no write needed since `push: false` and no Docker Hub auth in this workflow
- **validate-pull**: `type=registry` cache-from only, reading from nightly's amd64 and arm64 registry caches - PR builds should never write to shared cache, and this was the root cause of the reservation failures on #3253

Because #3278 was already merged into nightly, this PR also reverts that change as part of the merge. This is intentional.

## Related Issues [optional]

- Supersedes #3277
- Supersedes #3278

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [ ] Yes
- [X] No