### PR TITLE
Swap Dockerfile to thin FROM base image (Phase 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,12 @@
 # syntax=docker/dockerfile:1.7
-FROM python:3.13-slim
+ARG BASE_TAG=base
+FROM kometateam/kometa:${BASE_TAG}
+
 ARG BRANCH_NAME=master
 ENV BRANCH_NAME=${BRANCH_NAME}
-ENV TINI_VERSION=v0.19.0
 ENV KOMETA_DOCKER=True
-ENV LANG=C.UTF-8
-ENV LC_ALL=C.UTF-8
-COPY requirements.txt /requirements.txt
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
-    echo "**** install system packages ****" \
- && rm -f /etc/apt/apt.conf.d/docker-clean \
- && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache \
- && apt-get update \
- && apt-get upgrade -y --no-install-recommends \
- && apt-get install -y tzdata --no-install-recommends \
- && apt-get install -y gcc g++ libffi-dev libxml2-dev libxslt-dev libz-dev libjpeg62-turbo-dev zlib1g-dev wget curl nano \
- && runtime_libffi="$(dpkg-query -W -f='${binary:Package}\n' 'libffi[0-9]*' | awk '!/-dev$/ { print; exit }')" \
- && if [ -n "$runtime_libffi" ]; then apt-mark manual "$runtime_libffi"; fi \
- && wget -O /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-"$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
- && chmod +x /tini \
- && pip3 install --upgrade --requirement /requirements.txt \
- && apt-get --purge autoremove gcc g++ libffi-dev libxml2-dev libxslt-dev libz-dev -y \
- && apt-get update \
- && apt-get check \
- && apt-get -f install \
- && rm -rf /requirements.txt /tmp/* /var/tmp/* /var/lib/apt/lists/*
- COPY . /
+
+COPY . /
+
 VOLUME /config
 ENTRYPOINT ["/tini", "-s", "python3", "kometa.py", "--"]


### PR DESCRIPTION
## Phase 2: Swap Dockerfile to use pre-built `:base` image

**Prerequisite:** `kometateam/kometa:base` exists on Docker Hub (built and pushed by `docker-base.yml`).

### What changed

```diff
- 31 lines: python:3.13-slim + apt + pip + tini + cleanup
+ 6 lines: FROM kometateam/kometa:base + COPY . / + entrypoint
```

That's it. One file. The base image already has everything baked in — system packages, Python deps, tini, locale.

### Savings

| Before | After |
|---|---|
| apt-get update + upgrade every build | Pulls `:base` (seconds) |
| pip install lxml/pillow from source on arm/v7 | Already baked into `:base` |
| 25-60 min total for multi-arch builds | 3-8 min total for multi-arch builds |

### Cache

All `cache-from`/ `cache-to` lines were already removed from workflows in #3282 (`Test Disabling Cache`). No workflow changes needed here.

### Safety

If `:base` ever doesn't exist (fresh org, disaster recovery), run **Docker Base Image Build** workflow manually and it'll recreate it.