### PR TITLE
Disable GHA build cache in app workflows

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -41,6 +41,8 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:develop
+          # Thin Dockerfile — just FROM base + COPY, no build cache needed
+          cache-to: ""
 
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -37,6 +37,8 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:latest
+          # Thin Dockerfile — just FROM base + COPY, no build cache needed
+          cache-to: ""
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master
         if: success()

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -61,6 +61,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly-${{ matrix.tag-suffix }}
+          # Thin Dockerfile — just FROM base + COPY, no build cache needed
+          cache-to: ""
 
   docker-publish-nightly:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -65,3 +65,5 @@ jobs:
             "BRANCH_NAME=${{ github.ref_name }}"
           platforms: ${{ matrix.platform }}
           push: false
+          # Thin Dockerfile — just FROM base + COPY, no build cache needed
+          cache-to: ""

--- a/.github/workflows/docker-version.yml
+++ b/.github/workflows/docker-version.yml
@@ -45,6 +45,8 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:${{ steps.get_version.outputs.VERSION }}
+          # Thin Dockerfile — just FROM base + COPY, no build cache needed
+          cache-to: ""
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master
         if: success()

--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -161,6 +161,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly
+          # Thin Dockerfile — just FROM base + COPY, no build cache needed
+          cache-to: ""
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master
         if: success()

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -167,6 +167,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: kometateam/kometa:${{ steps.update-version.outputs.tag-name }}
+          # Thin Dockerfile — just FROM base + COPY, no build cache needed
+          cache-to: ""
 
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,12 @@
 # syntax=docker/dockerfile:1.7
-FROM python:3.13-slim
+ARG BASE_TAG=base
+FROM kometateam/kometa:${BASE_TAG}
+
 ARG BRANCH_NAME=master
 ENV BRANCH_NAME=${BRANCH_NAME}
-ENV TINI_VERSION=v0.19.0
 ENV KOMETA_DOCKER=True
-ENV LANG=C.UTF-8
-ENV LC_ALL=C.UTF-8
-COPY requirements.txt /requirements.txt
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
-    echo "**** install system packages ****" \
- && rm -f /etc/apt/apt.conf.d/docker-clean \
- && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache \
- && apt-get update \
- && apt-get upgrade -y --no-install-recommends \
- && apt-get install -y tzdata --no-install-recommends \
- && apt-get install -y gcc g++ libffi-dev libxml2-dev libxslt-dev libz-dev libjpeg62-turbo-dev zlib1g-dev wget curl nano \
- && runtime_libffi="$(dpkg-query -W -f='${binary:Package}\n' 'libffi[0-9]*' | awk '!/-dev$/ { print; exit }')" \
- && if [ -n "$runtime_libffi" ]; then apt-mark manual "$runtime_libffi"; fi \
- && wget -O /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-"$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
- && chmod +x /tini \
- && pip3 install --upgrade --requirement /requirements.txt \
- && apt-get --purge autoremove gcc g++ libffi-dev libxml2-dev libxslt-dev libz-dev -y \
- && apt-get update \
- && apt-get check \
- && apt-get -f install \
- && rm -rf /requirements.txt /tmp/* /var/tmp/* /var/lib/apt/lists/*
- COPY . /
+
+COPY . /
+
 VOLUME /config
 ENTRYPOINT ["/tini", "-s", "python3", "kometa.py", "--"]


### PR DESCRIPTION
## Fix: GHA cache exhaustion with thin Dockerfile

The thin `Dockerfile` (`FROM kometateam/kometa:base + COPY . /`) causes the default `docker/build-push-action` cache (`type=gha,mode=max`) to try caching the pulled base image layers. With a \~1GB base image across multiple platforms, this exhausts the 10GB GitHub Actions cache limit:

```
ERROR: error writing layer blob: failed to reserve cache
```

**Fix:** Add `cache-to: ""` to all 7 app build workflows to disable cache writing. The thin Dockerfile doesn't benefit from layer caching — the base is pulled from Docker Hub and the COPY layer is a single fast step. No performance impact.

### Files changed

| Workflow | Change |
|---|---|
| `increment-build.yml` | + `cache-to: ""` |
| `docker-develop.yml` | + `cache-to: ""` |
| `docker-latest.yml` | + `cache-to: ""` |
| `docker-nightly.yml` | + `cache-to: ""` |
| `docker-test.yml` | + `cache-to: ""` |
| `docker-version.yml` | + `cache-to: ""` |
| `validate-pull.yml` | + `cache-to: ""` |

The base image workflow (`docker-base.yml`) keeps its `cache-to` with registry cache — it actually benefits from it.