### PR TITLE
bump: trigger nightly Increment Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.7
 ARG BASE_TAG=base
 FROM kometateam/kometa:${BASE_TAG}
+# This is a tiny bump to trigger Increment Build
 
 ARG BRANCH_NAME=master
 ENV BRANCH_NAME=${BRANCH_NAME}


### PR DESCRIPTION
Minimal change to Dockerfile to trigger `Increment Build` workflow, which will:\n1. Bump the build number\n2. Build and push `kometateam/kometa:nightly` with the thin Dockerfile\n\nMerge and done.