### PR TITLE
fix: use no-cache instead of cache-to in app builds

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -42,7 +42,7 @@ jobs:
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:develop
           # Thin Dockerfile — just FROM base + COPY, no build cache needed
-          cache-to: ""
+          no-cache: true
 
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -38,7 +38,7 @@ jobs:
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:latest
           # Thin Dockerfile — just FROM base + COPY, no build cache needed
-          cache-to: ""
+          no-cache: true
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master
         if: success()

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -62,7 +62,7 @@ jobs:
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly-${{ matrix.tag-suffix }}
           # Thin Dockerfile — just FROM base + COPY, no build cache needed
-          cache-to: ""
+          no-cache: true
 
   docker-publish-nightly:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -66,4 +66,4 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: false
           # Thin Dockerfile — just FROM base + COPY, no build cache needed
-          cache-to: ""
+          no-cache: true

--- a/.github/workflows/docker-version.yml
+++ b/.github/workflows/docker-version.yml
@@ -46,7 +46,7 @@ jobs:
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:${{ steps.get_version.outputs.VERSION }}
           # Thin Dockerfile — just FROM base + COPY, no build cache needed
-          cache-to: ""
+          no-cache: true
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master
         if: success()

--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -162,7 +162,7 @@ jobs:
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly
           # Thin Dockerfile — just FROM base + COPY, no build cache needed
-          cache-to: ""
+          no-cache: true
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master
         if: success()

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -168,7 +168,7 @@ jobs:
           push: true
           tags: kometateam/kometa:${{ steps.update-version.outputs.tag-name }}
           # Thin Dockerfile — just FROM base + COPY, no build cache needed
-          cache-to: ""
+          no-cache: true
 
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master


### PR DESCRIPTION
## Fix: GHA cache exhaustion (take 2)

`cache-to: ""` doesn't actually override `docker/build-push-action@v7`'s default — empty string falls through to `type=gha,mode=max`, so builds still fail with:

```
ERROR: failed to build: error writing layer blob: failed to reserve cache
```

**Fix:** `no-cache: true` — prevents both cache read and write. Since the thin Dockerfile (`FROM base + COPY . /`) produces no cachable layers, there's zero performance impact.

### Files changed

All 7 app build workflows: `cache-to: ""` → `no-cache: true`

The base image workflow (`docker-base.yml`) is unchanged — it uses `type=registry` cache and benefits from it.