### PR TITLE
fix: duplicate step name in docker-develop.yml

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -44,7 +44,6 @@ jobs:
           # Thin Dockerfile — just FROM base + COPY, only cache final layer
           cache-to: type=gha,mode=min
       - name: Discord Success Notification
-      - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master
         if: success()
         with:


### PR DESCRIPTION
Hotfix for YAML error introduced in #3292. Duplicated `- name: Discord Success Notification` step causing validation failures.