### PR TITLE
bump v6: trigger nightly Increment Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 ARG BASE_TAG=base
 FROM kometateam/kometa:${BASE_TAG}
-# Bump v5: YAML fix is in, trigger nightly rebuild
+# Bump v6: cache cleared, trigger nightly rebuild
 
 ARG BRANCH_NAME=master
 ENV BRANCH_NAME=${BRANCH_NAME}


### PR DESCRIPTION
Trigger Increment Build after clearing GHA cache (was full from previous failed builds).