### PR TITLE
fix: replace build-push-action with raw docker buildx, no cache

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -32,17 +32,14 @@ jobs:
 
       - name: Build and Push
         id: docker_build
-        uses: docker/build-push-action@v7
-        with:
-          context: ./
-          file: ./Dockerfile
-          build-args: |
-            "BRANCH_NAME=develop"
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
-          tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:develop
-          # Thin Dockerfile — just FROM base + COPY, only cache final layer
-          cache-to: type=gha,mode=min
+        run: |
+          docker buildx build \
+            --build-arg BRANCH_NAME=develop \
+            --file ./Dockerfile \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --tag ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:develop \
+            --push \
+            .
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master
         if: success()

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -30,15 +30,13 @@ jobs:
 
       - name: Build and Push
         id: docker_build
-        uses: docker/build-push-action@v7
-        with:
-          context: ./
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
-          tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:latest
-          # Thin Dockerfile — just FROM base + COPY, only cache final layer
-          cache-to: type=gha,mode=min
+        run: |
+          docker buildx build \
+            --file ./Dockerfile \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --tag ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:latest \
+            --push \
+            .
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master
         if: success()

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -52,17 +52,14 @@ jobs:
 
       - name: Build and Push
         id: docker_build
-        uses: docker/build-push-action@v7
-        with:
-          context: ./
-          file: ./Dockerfile
-          build-args: |
-            "BRANCH_NAME=nightly"
-          platforms: ${{ matrix.platform }}
-          push: true
-          tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly-${{ matrix.tag-suffix }}
-          # Thin Dockerfile — just FROM base + COPY, only cache final layer
-          cache-to: type=gha,mode=min
+        run: |
+          docker buildx build \
+            --build-arg BRANCH_NAME=nightly \
+            --file ./Dockerfile \
+            --platform ${{ matrix.platform }} \
+            --tag ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly-${{ matrix.tag-suffix }} \
+            --push \
+            .
 
   docker-publish-nightly:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -61,13 +61,10 @@ jobs:
       - name: Build Docker Image
         if: ${{ github.event_name == 'pull_request' || github.event.inputs.platform == 'all' || github.event.inputs.platform == matrix.platform }}
         id: docker_build
-        uses: docker/build-push-action@v7
-        with:
-          context: ./
-          file: ./Dockerfile
-          build-args: |
-            "BRANCH_NAME=${{ github.ref_name }}"
-          platforms: ${{ matrix.platform }}
-          push: false
-          # Thin Dockerfile — just FROM base + COPY, only cache final layer
-          cache-to: type=gha,mode=min
+        run: |
+          docker buildx build \
+            --build-arg BRANCH_NAME=${{ github.ref_name }} \
+            --file ./Dockerfile \
+            --platform ${{ matrix.platform }} \
+            --load \
+            .

--- a/.github/workflows/docker-version.yml
+++ b/.github/workflows/docker-version.yml
@@ -38,15 +38,13 @@ jobs:
 
       - name: Build and Push
         id: docker_build
-        uses: docker/build-push-action@v7
-        with:
-          context: ./
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
-          tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:${{ steps.get_version.outputs.VERSION }}
-          # Thin Dockerfile — just FROM base + COPY, only cache final layer
-          cache-to: type=gha,mode=min
+        run: |
+          docker buildx build \
+            --file ./Dockerfile \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --tag ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:${{ steps.get_version.outputs.VERSION }} \
+            --push \
+            .
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master
         if: success()

--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -156,17 +156,14 @@ jobs:
 
       - name: Build and Push
         id: docker_build
-        uses: docker/build-push-action@v7
-        with:
-          context: ./
-          file: ./Dockerfile
-          build-args: |
-            "BRANCH_NAME=nightly"
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly
-          # Thin Dockerfile — just FROM base + COPY, only cache final layer
-          cache-to: type=gha,mode=min
+        run: |
+          docker buildx build \
+            --build-arg BRANCH_NAME=nightly \
+            --file ./Dockerfile \
+            --platform linux/amd64,linux/arm64 \
+            --tag ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly \
+            --push \
+            .
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master
         if: success()

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -162,17 +162,14 @@ jobs:
 
       - name: Build and Push
         id: docker_build
-        uses: docker/build-push-action@v7
-        with:
-          context: ./
-          file: ./Dockerfile
-          build-args: |
-            "BRANCH_NAME=${{ steps.update-version.outputs.tag-name }}"
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: kometateam/kometa:${{ steps.update-version.outputs.tag-name }}
-          # Thin Dockerfile — just FROM base + COPY, only cache final layer
-          cache-to: type=gha,mode=min
+        run: |
+          docker buildx build \
+            --build-arg BRANCH_NAME=${{ steps.update-version.outputs.tag-name }} \
+            --file ./Dockerfile \
+            --platform linux/amd64,linux/arm64 \
+            --tag kometateam/kometa:${{ steps.update-version.outputs.tag-name }} \
+            --push \
+            .
 
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master


### PR DESCRIPTION
## Root Cause

`docker/build-push-action@v7` always adds `--cache-to type=gha,mode=max` regardless of explicit inputs — empty strings fall back to defaults, `mode=min` is not respected. GHA cache writes then fail in `pull_request_target` events due to token permission restrictions.

## Fix

Replace the composite action with raw `docker buildx build` commands in all 7 app build workflows. No `--cache-to` or `--cache-from` at all. The thin Dockerfile (`FROM base + COPY . /`) doesn't benefit from layer caching — the base image is pulled from Docker Hub and the COPY layer is a single fast step.