### PR TITLE
fix: use cache-to type=inline in raw buildx

### DIFF
--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -162,7 +162,7 @@ jobs:
             --file ./Dockerfile \
             --platform linux/amd64,linux/arm64 \
             --tag ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly \
-            --cache-to type=gha,mode=min \
+            --cache-to type=inline \
             --push \
             .
       - name: Discord Success Notification


### PR DESCRIPTION
## Problem

`type=gha` requires the BuildKit container (docker-container driver) to authenticate with the GHA cache API. In `pull_request_target` events, the token can't write to cache even with `actions:write` permission.

## Fix

Use `--cache-to type=inline` — embeds cache metadata in the image manifest and pushes it to Docker Hub with the image. No GHA cache API calls at all.