### PR TITLE
fix: unset ACTIONS_CACHE env vars to prevent BuildKit auto-detection

### DIFF
--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -157,12 +157,13 @@ jobs:
       - name: Build and Push
         id: docker_build
         run: |
+          # Unset GHA cache env vars so BuildKit doesn't auto-add --cache-to type=gha
+          unset ACTIONS_CACHE_URL ACTIONS_RUNTIME_TOKEN
           docker buildx build \
             --build-arg BRANCH_NAME=nightly \
             --file ./Dockerfile \
             --platform linux/amd64,linux/arm64 \
             --tag ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly \
-            --cache-to type=inline \
             --push \
             .
       - name: Discord Success Notification


### PR DESCRIPTION
BuildKit's `docker-container` driver auto-detects GHA environment via `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` env vars and adds `--cache-to type=gha` even without explicit flags. This cache export fails in `pull_request_target` events.

Unset these env vars before `docker buildx build` so no GHA cache is configured. The thin Dockerfile (`FROM base + COPY . /`) doesn't benefit from layer caching anyway.