### PR TITLE
fix: restore cache-from/cache-to config that worked for years

### DIFF
--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -128,10 +128,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ increment-build, verify-changes ]
     if: needs.verify-changes.outputs.build == 'true'
-    permissions:
-      contents: read
-      packages: write
-      actions: write
     steps:
 
       - name: Check Out Repo
@@ -156,16 +152,17 @@ jobs:
 
       - name: Build and Push
         id: docker_build
-        run: |
-          # Unset GHA cache env vars so BuildKit doesn't auto-add --cache-to type=gha
-          unset ACTIONS_CACHE_URL ACTIONS_RUNTIME_TOKEN
-          docker buildx build \
-            --build-arg BRANCH_NAME=nightly \
-            --file ./Dockerfile \
-            --platform linux/amd64,linux/arm64 \
-            --tag ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly \
-            --push \
-            .
+        uses: docker/build-push-action@v7
+        with:
+          context: ./
+          file: ./Dockerfile
+          build-args: |
+            "BRANCH_NAME=nightly"
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly
+          cache-from: type=registry,ref=${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:buildcache-nightly
+          cache-to: type=registry,ref=${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:buildcache-nightly,mode=min
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master
         if: success()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 ARG BASE_TAG=base
 FROM kometateam/kometa:${BASE_TAG}
-# Bump v9: type=inline fix in, trigger nightly rebuild
+# Bump final: cache fixed, trigger nightly rebuild
 
 ARG BRANCH_NAME=master
 ENV BRANCH_NAME=${BRANCH_NAME}


### PR DESCRIPTION
Restores the exact `docker/build-push-action@v7` configuration used before #3282 — explicit `cache-from: type=gha` and `cache-to: type=gha,mode=max`. Removes the `permissions` block and `unset ACTIONS_CACHE` hack that were added trying to work around the issue.