### PR TITLE
ci: pin BuildKit to v0.20.0 for GHA Cache Service v2 support

### DIFF
--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.20.0
 
       - name: Build and Push Base Image
         id: docker_build

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.20.0
 
       - name: Build and Push
         id: docker_build

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.20.0
 
       - name: Build and Push
         id: docker_build

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.20.0
 
       - name: Build and Push
         id: docker_build
@@ -75,6 +78,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.20.0
 
       - name: Publish Multi-Arch Tag
         run: |

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -57,6 +57,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' || github.event.inputs.platform == 'all' || github.event.inputs.platform == matrix.platform }}
         id: buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.20.0
 
       - name: Build Docker Image
         if: ${{ github.event_name == 'pull_request' || github.event.inputs.platform == 'all' || github.event.inputs.platform == matrix.platform }}

--- a/.github/workflows/docker-version.yml
+++ b/.github/workflows/docker-version.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.20.0
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -149,6 +149,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.20.0
 
       - name: Build and Push
         id: docker_build

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -159,6 +159,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.20.0
 
       - name: Build and Push
         id: docker_build


### PR DESCRIPTION
## Root Cause

GitHub sunset the Actions Cache Service v1 in early 2025 (announced with `actions/cache@v5` rollout on Feb 1, 2025). The new v2 requires BuildKit >= 0.20 which supports `url_v2` and `ACTIONS_CACHE_SERVICE_V2`.

`docker/setup-buildx-action@v4` by default pulls `moby/buildkit:buildx-stable-1` which lagged behind and still speaks the sunset v1 API. When it tries to reserve a cache blob, the endpoint 404s and BuildKit reports `failed to reserve cache` — which looks like a cache-full error but is actually API deprecation.

**Timeline matches**: PRs #3277, #3278, #3279 (all June 30) were attempts to work around `cache-full build failures` that were actually this v1→v2 migration.

**Reference**: [moby/buildkit#5754 — "buildctl: set fallback url for gha cache"](https://github.com/moby/buildkit/pull/5754):
> We should always set `url` attr (if possible) when gha cache is used otherwise it will fail on **BuildKit < 0.20** that doesn't support `url_v2`.

## Fix

Pin BuildKit to v0.20.0 via `driver-opts` in all 9 `setup-buildx-action` usages (8 files). Once BuildKit speaks the v2 API, existing `cache-to: type=gha,mode=max` config works again.