### PR TITLE
bump: trigger nightly Increment Build (BuildKit v0.20.0 pinned)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 ARG BASE_TAG=base
 FROM kometateam/kometa:${BASE_TAG}
-# Bump 10: registry cache, trigger nightly rebuild
+# Bump: BuildKit v0.20.0 pinned, trigger nightly rebuild
 
 ARG BRANCH_NAME=master
 ENV BRANCH_NAME=${BRANCH_NAME}


### PR DESCRIPTION
Trigger Increment Build now that #3307 (BuildKit v0.20.0 pin for GHA Cache Service v2) is merged.