### PR TITLE
ci: sync increment-build.yml from nightly to fix Docker cache reserve error

### DIFF
--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -149,6 +149,9 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.20.0
 
       - name: Build and Push
         id: docker_build
@@ -161,9 +164,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
+          cache-from: type=registry,ref=${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:buildcache-nightly
+          cache-to: type=registry,ref=${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:buildcache-nightly,mode=min
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master
         if: success()


### PR DESCRIPTION
## The Bug We've Been Chasing All Night

`pull_request_target` uses the workflow file from the **default branch (`master`)** — NOT the PR's base branch. So every fix I've been landing on `nightly` for the "failed to reserve cache" error has been invisible to the actual failing job, which reads `increment-build.yml` from `master`.

Proof from run [28559412940](https://github.com/Kometa-Team/Kometa/actions/runs/28559412940) (the failing Increment Build for PR #3308 which itself carried the fix):

- Buildx setup step shows **no** `driver-opts` (nightly has them)
- Build step used `cache-from: type=gha` / `cache-to: type=gha,mode=max` (nightly uses `type=registry`)
- File on nightly at that SHA definitely had both fixes — GitHub just wasn't reading them

## The Fix

Forward two known-good changes from `nightly` to `master` in `.github/workflows/increment-build.yml`:

1. **Pin BuildKit to v0.20.0** via `driver-opts: image=moby/buildkit:v0.20.0` on `setup-buildx-action`. The GitHub Actions Cache Service v1 was sunset in early 2025; BuildKit < 0.20 only speaks the v1 API and fails with `failed to reserve cache` when writing `type=gha` cache. Reference: [moby/buildkit#5754](https://github.com/moby/buildkit/pull/5754).
2. **Switch from `type=gha` to `type=registry`** for the cache backend — matches what already works on `docker-nightly.yml` and `docker-latest.yml`.

## Why Master?

This is a rare, deliberate exception to the "all PRs target nightly" rule. The CI infrastructure that runs on `pull_request_target` literally cannot be repaired from `nightly` — the workflow file is only read from the default branch. The two-line diff is workflow-only, no product code touched.

## Diff

Just `.github/workflows/increment-build.yml` — 5 insertions, 3 deletions. Both changes were already validated on the `nightly` branch's copy of this same file and on `docker-nightly.yml`.

After this merges, the next PR-merge into `nightly` should trigger a green Increment Build and finally push `kometateam/kometa:nightly`.
