### PR TITLE
bump: verify master fix (PR #3309) unblocks Docker nightly build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 ARG BASE_TAG=base
 FROM kometateam/kometa:${BASE_TAG}
-# Bump: BuildKit v0.20.0 pinned, trigger nightly rebuild
+# Bump: verify master's increment-build.yml fix (PR #3309) unblocks nightly Docker builds
 
 ARG BRANCH_NAME=master
 ENV BRANCH_NAME=${BRANCH_NAME}


### PR DESCRIPTION
## Verification Bump

Trivial Dockerfile comment change to trigger the Increment Build workflow now that PR #3309 has landed on `master`.

With master's `increment-build.yml` now:
- Pinning BuildKit to v0.20.0 via `driver-opts`
- Using `type=registry` cache (Docker Hub `:buildcache-nightly`) instead of `type=gha`

...the "failed to reserve cache" error should be gone and `kometateam/kometa:nightly` should finally push successfully.

## What to Watch

After merge:
1. Increment Build fires on `pull_request_target`
2. Buildx setup step should now show `driver-opts: image=moby/buildkit:v0.20.0`
3. Build command should use `--cache-from type=registry,...` instead of `type=gha`
4. Cache export step should succeed instead of failing with `failed to reserve cache`
5. `:nightly` tag gets pushed to Docker Hub

If this succeeds, the ~7-hour saga of PRs #3277-#3309 is finally over.
