### PR TITLE
ci: sync validate-pull.yml from nightly to fix tester Docker cache reserve error

### DIFF
--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -79,6 +79,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ validate-pull ]
     if: needs.validate-pull.outputs.build == 'true' && (contains(github.event.pull_request.labels.*.name, 'docker') || contains(github.event.pull_request.labels.*.name, 'tester'))
+    permissions:
+      contents: read
+      packages: write
+      actions: write
     outputs:
       commit-msg: ${{ steps.update-version.outputs.commit-msg }}
       part_value: ${{ steps.update-version.outputs.part_value }}
@@ -155,20 +159,20 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.20.0
 
       - name: Build and Push
         id: docker_build
-        uses: docker/build-push-action@v7
-        with:
-          context: ./
-          file: ./Dockerfile
-          build-args: |
-            "BRANCH_NAME=${{ steps.update-version.outputs.tag-name }}"
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: kometateam/kometa:${{ steps.update-version.outputs.tag-name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        run: |
+          docker buildx build \
+            --build-arg BRANCH_NAME=${{ steps.update-version.outputs.tag-name }} \
+            --file ./Dockerfile \
+            --platform linux/amd64,linux/arm64 \
+            --tag kometateam/kometa:${{ steps.update-version.outputs.tag-name }} \
+            --push \
+            .
 
       - name: Discord Success Notification
         uses: Kometa-Team/discord-notifications@master


### PR DESCRIPTION
## Same Problem as PR #3309, Different File

`validate-pull.yml` is also triggered by `pull_request_target`, so the workflow file is read from **master (default branch)**, not from the PR's base branch. Every fix we landed on nightly (PRs #3278, #3279, #3282, #3286, #3288, #3290, #3292, #3297, #3307) has been invisible to actually-running validate-pull jobs, because those jobs read master's stale copy.

Symptom: tester Docker builds on labeled PRs fail with `failed to reserve cache`.

## The Fix

Forward the known-good version from `nightly` to `master`:

1. **Add `permissions` block** — `contents:read`, `packages:write`, `actions:write` (needed for GHA cache access).
2. **Pin BuildKit to v0.20.0** via `driver-opts` on `setup-buildx-action` (belt-and-suspenders for GHA Cache Service v2 support).
3. **Replace `docker/build-push-action@v7` with raw `docker buildx build`** — drops `cache-from`/`cache-to` entirely. Tester Docker builds are one-off per-PR and don't benefit meaningfully from layer caching. Removing cache export eliminates the `failed to reserve cache` failure mode completely.

## Why Master

Same rationale as PR #3309 — a `pull_request_target` workflow can only be fixed by editing the default branch. This is a legitimate exception to the "all PRs target nightly" rule.

## Diff

`.github/workflows/validate-pull.yml` — 15 insertions, 11 deletions. Identical to what's already running successfully on `nightly`.
