### PR TITLE
Assets now accept Plex supported asset filenames and filetypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rework `defaults/overlays/ratings.yml` to fetch ratings directly during the overlay run; Mass Rating Update operations are no longer required for fetched sources. Adds auto image-pick, Fresh/Rotten filtering via `value_filter`, a `Direct` image level for tomatoes/tomatoesaudience, and new image assets under `defaults/overlays/images/rating/`.
 - Accept HTTP(S) URLs anywhere a `text_file` builder used to require a local file path. Kometa first tries to parse the response as JSON (matching today's behaviour) and falls back to a plain-text line-by-line parse on parse failure. Gzip-compressed responses are auto-decompressed. Mixed local/URL lists in a single `text_file` builder are supported.
 - Add `logo` and `square`/`square_art` asset detection and setting via `url_` and `file_` methods for Collection builders, as well as Defaults via `url_*_<<key>>` template variables.
+- Add Plex-compatible local asset names for posters, backgrounds, logos, and square art, including `.tbn` files and numbered variants such as `poster-2.png`; exact filenames such as `poster.jpg` take priority over numbered variants.
 
 ### Changed
 
 - `modules/request.py`: every outbound HTTP request now sends a 30-second per-socket timeout (`DEFAULT_TIMEOUT`), so a stalled external server can no longer hang a run indefinitely. Retries on `Requests.get`/`post` switch from a fixed 10-second wait (up to 50s of sleeping per failing URL) to exponential backoff capped at 10 seconds (~25s worst case, much less for transient blips).
 - `modules/request.py`: `get_stream` throttles its download-progress log updates to ~4 per second (plus a final 100% line) instead of logging once per 8 KB chunk.
 - `modules/cache.py`: the cache now holds one shared SQLite connection (WAL journal mode) for the life of the run instead of opening a new connection for every query — previously each of the ~60 cache methods opened a connection per call and never closed it, which added measurable overhead on large overlay runs. Transaction-per-block commit behaviour is unchanged.
+- Updated assets to accept all filenames and filetype extensions that Plex allows as per https://support.plex.tv/articles/200220677-local-media-assets-movies/
 
 ### Security
 

--- a/docs/config/settings.md
+++ b/docs/config/settings.md
@@ -32,7 +32,7 @@ The available setting attributes which can be set at each level are outlined bel
 
     <div id="asset-depth" />Specify how many folder levels to scan for an item within the asset directory.
 
-    At each asset level, Kometa will look for either `medianame.ext` [such as Star Wars.png] or a dedicated folder containing `poster.ext`.
+    At each asset level, Kometa will look for either `medianame.ext` [such as `Star Wars.png`] or a dedicated folder containing supported asset names such as `poster.ext`, `background.ext`, `logo.ext`, and `square.ext`.
 
     For example, if your asset directory is `/path/to/assets/`, and your `asset_depth` is 2, then Kometa will look for an asset match in any of these locations:
 
@@ -118,6 +118,8 @@ The available setting attributes which can be set at each level are outlined bel
     <div id="asset-folders" />While `true`, Kometa will search the `asset_directory` for a dedicated folder per item vs while false will look for an image.
 
     i.e. When `true` the example path would be `<asset_directory_path>/Star Wars/poster.png` instead of `<asset_directory_path>/Star Wars.png`.
+
+    See the [Image Asset Directory Guide](../kometa/guides/assets.md#asset-naming) for the full list of accepted poster, background, logo, and square art names, including Plex-compatible names such as `cover.ext`, `fanart.ext`, `clearlogo.ext`, and `backgroundSquare.ext`.
 
     <hr style="margin: 0px;">
 

--- a/docs/files/updates.md
+++ b/docs/files/updates.md
@@ -85,8 +85,8 @@ All the following attributes update the poster of the collection/playlist from v
 **All of these details work with Playlists.**
 
 If no poster is specified the script will look in the library's [Image Asset Directories](../kometa/guides/assets.md) for a
-folder named either the collection/playlist name or the `name_mapping` if specified and look for a `poster.ext` file in 
-that folder (replacing .ext with the image extension).
+folder named either the collection/playlist name or the `name_mapping` if specified and look for a supported poster asset
+such as `poster.ext`, `cover.ext`, `default.ext`, `folder.ext`, or `movie.ext` in that folder.
 
 | Attribute          | Description & Values                                                                                                                                                            |
 |:-------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -126,7 +126,7 @@ All the following attributes update the background of the collection/playlist fr
 
 If no background is specified the script will look in the library's [Image Asset Directories](../kometa/guides/assets.md) 
 for a folder named either the collection/playlist name or the `name_mapping` if specified and look for a 
-`background.ext` file in that folder (replacing .ext with the image extension).
+supported background asset such as `background.ext`, `art.ext`, `backdrop.ext`, or `fanart.ext` in that folder.
 
 | Attribute         | Description & Values                                                                                                                                                                        |
 |:------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -155,7 +155,7 @@ All the following attributes update the logo of the collection from various sour
 
 If no logo is specified the script will look in the library's [Image Asset Directories](../kometa/guides/assets.md)
 for a folder named either the collection name or the `name_mapping` if specified and look for a
-`logo.ext` file in that folder (replacing .ext with the image extension).
+supported logo asset such as `logo.ext` or `clearlogo.ext` in that folder.
 
 | Attribute   | Description & Values                                                                                           |
 |:------------|:---------------------------------------------------------------------------------------------------------------|
@@ -179,8 +179,8 @@ All the following attributes update the square art (used by some Plex clients) o
 **All of these details work with Playlists.**
 
 If no square art is specified the script will look in the library's [Image Asset Directories](../kometa/guides/assets.md) for a
-folder named either the collection/playlist name or the `name_mapping` if specified and look for a `square.ext` or
-`square_art.ext` file in that folder (replacing .ext with the image extension).
+folder named either the collection/playlist name or the `name_mapping` if specified and look for a supported square art asset
+such as `square.ext`, `square_art.ext`, `squareArt.ext`, or `backgroundSquare.ext` in that folder.
 
 | Attribute         | Description & Values                                                                                                   |
 |:------------------|:-----------------------------------------------------------------------------------------------------------------------|

--- a/docs/kometa/guides/assets.md
+++ b/docs/kometa/guides/assets.md
@@ -132,6 +132,10 @@ the [`asset_folders` Setting Attribute](../../config/settings.md). Note that `as
 
 Assets can be stored anywhere on the host system that Kometa has visibility of (i.e. if using docker, the directory must be mounted/visible to the docker container).
 
+Replace `.ext` with a supported image extension: `.jpg`, `.jpeg`, `.png`, `.webp`, or `.tbn`.
+
+Numbered variants such as `poster-2.png` or `fanart-2.tbn` are accepted for the same base asset names listed below. When both an exact asset name and a numbered variant exist, the exact asset name takes priority. For example, `poster.jpg` is used before `poster-2.png`.
+
 ???+ important
 
     In this table, `<path_to_assets>` is an asset directory OR some directory below an asset directory, depending on your setting for `asset_depth`.
@@ -151,10 +155,10 @@ Assets can be stored anywhere on the host system that Kometa has visibility of (
 
     | Image Type                       | Asset Folders Image Paths<br>`asset_folders: true`         |
     |:---------------------------------|:-----------------------------------------------------------|
-    | Collection/Movie/Show poster     | `<path_to_assets>/ASSET_NAME/poster.ext`                   |
-    | Collection/Movie/Show background | `<path_to_assets>/ASSET_NAME/background.ext`               |
-    | Collection/Movie/Show logo       | `<path_to_assets>/ASSET_NAME/logo.ext`                     |
-    | Collection/Movie/Show square art | `<path_to_assets>/ASSET_NAME/square.ext` or `<path_to_assets>/ASSET_NAME/square_art.ext` |
+    | Collection/Movie/Show poster     | `<path_to_assets>/ASSET_NAME/poster.ext`, `cover.ext`, `default.ext`, `folder.ext`, or `movie.ext` |
+    | Collection/Movie/Show background | `<path_to_assets>/ASSET_NAME/background.ext`, `art.ext`, `backdrop.ext`, or `fanart.ext` |
+    | Collection/Movie/Show logo       | `<path_to_assets>/ASSET_NAME/logo.ext` or `clearlogo.ext` |
+    | Collection/Movie/Show square art | `<path_to_assets>/ASSET_NAME/square.ext`, `square_art.ext`, `squareArt.ext`, or `backgroundSquare.ext` |
     | Season poster                    | `<path_to_assets>/ASSET_NAME/Season##.ext`                 |
     | Season background                | `<path_to_assets>/ASSET_NAME/Season##_background.ext`      |
     | Episode poster                   | `<path_to_assets>/ASSET_NAME/S##E##.ext`                   |
@@ -165,13 +169,62 @@ Assets can be stored anywhere on the host system that Kometa has visibility of (
     | Image Type                       | Flat Assets Image Paths<br>`asset_folders: false`          |
     |:---------------------------------|:-----------------------------------------------------------|
     | Collection/Movie/Show poster     | `<path_to_assets>/ASSET_NAME.ext`                         |
-    | Collection/Movie/Show background | `<path_to_assets>/ASSET_NAME_background.ext`               |
-    | Collection/Movie/Show logo       | `<path_to_assets>/ASSET_NAME_logo.ext`                     |
-    | Collection/Movie/Show square art | `<path_to_assets>/ASSET_NAME_square.ext` or `<path_to_assets>/ASSET_NAME_square_art.ext` |
+    | Collection/Movie/Show background | `<path_to_assets>/ASSET_NAME_background.ext`, `ASSET_NAME-art.ext`, `ASSET_NAME-backdrop.ext`, `ASSET_NAME-background.ext`, or `ASSET_NAME-fanart.ext` |
+    | Collection/Movie/Show logo       | `<path_to_assets>/ASSET_NAME_logo.ext`, `ASSET_NAME-clearlogo.ext`, or `ASSET_NAME-logo.ext` |
+    | Collection/Movie/Show square art | `<path_to_assets>/ASSET_NAME_square.ext`, `ASSET_NAME_square_art.ext`, `ASSET_NAME-square.ext`, `ASSET_NAME-squareArt.ext`, or `ASSET_NAME-backgroundSquare.ext` |
     | Season poster                    | `<path_to_assets>/ASSET_NAME_Season##.ext`                 |
     | Season background                | `<path_to_assets>/ASSET_NAME_Season##_background.ext`      |
     | Episode poster                   | `<path_to_assets>/ASSET_NAME_S##E##.ext`                   |
     | Episode background               | `<path_to_assets>/ASSET_NAME_S##E##_background.ext`        |
+
+For example, if the asset name is `Toy Story (1995)`, Kometa accepts the following item-level filenames:
+
+=== "ASSET_FOLDERS=True"
+
+    ```txt
+    config/assets/Toy Story (1995)/poster.jpg
+    config/assets/Toy Story (1995)/poster-2.png
+    config/assets/Toy Story (1995)/cover.jpg
+    config/assets/Toy Story (1995)/default.png
+    config/assets/Toy Story (1995)/folder.tbn
+    config/assets/Toy Story (1995)/movie.jpg
+
+    config/assets/Toy Story (1995)/background.jpg
+    config/assets/Toy Story (1995)/fanart.png
+    config/assets/Toy Story (1995)/backdrop.tbn
+    config/assets/Toy Story (1995)/art.jpg
+
+    config/assets/Toy Story (1995)/logo.png
+    config/assets/Toy Story (1995)/clearlogo.png
+
+    config/assets/Toy Story (1995)/square.jpg
+    config/assets/Toy Story (1995)/square_art.png
+    config/assets/Toy Story (1995)/squareArt.jpg
+    config/assets/Toy Story (1995)/backgroundSquare.png
+    ```
+
+=== "ASSET_FOLDERS=False"
+
+    ```txt
+    config/assets/Toy Story (1995).jpg
+    config/assets/Toy Story (1995)-2.png
+
+    config/assets/Toy Story (1995)_background.jpg
+    config/assets/Toy Story (1995)-background.jpg
+    config/assets/Toy Story (1995)-fanart.png
+    config/assets/Toy Story (1995)-backdrop.tbn
+    config/assets/Toy Story (1995)-art.jpg
+
+    config/assets/Toy Story (1995)_logo.png
+    config/assets/Toy Story (1995)-logo.png
+    config/assets/Toy Story (1995)-clearlogo.png
+
+    config/assets/Toy Story (1995)_square.jpg
+    config/assets/Toy Story (1995)_square_art.png
+    config/assets/Toy Story (1995)-square.jpg
+    config/assets/Toy Story (1995)-squareArt.png
+    config/assets/Toy Story (1995)-backgroundSquare.png
+    ```
 
 ## Determining the "Asset Name"
 
@@ -306,7 +359,7 @@ Assets can be stored anywhere on the host system that Kometa has visibility of (
         config/assets/The Expanse (2015) {tvdb-280619}_S01E01_background.ext
         ```
 
-* Replace `.ext` with the image extension
+* Replace `.ext` with a supported image extension: `.jpg`, `.jpeg`, `.png`, `.webp`, or `.tbn`.
 
 * When `asset_folders` is set to `true` movie/show folders can be nested inside other folders, but you must specify how deep you want to search because the more levels to search the longer it takes.
 

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -27,7 +27,7 @@ logger = util.logger
 
 builders = ["plex_all", "plex_watchlist", "plex_pilots", "plex_collectionless", "plex_search"]
 library_types = ["movie", "show", "artist"]
-asset_image_extensions = (".jpg", ".jpeg", ".png", ".webp")
+asset_image_extensions = (".jpg", ".jpeg", ".png", ".webp", ".tbn")
 search_translation = {
     "episode_actor": "episode.actor",
     "episode_title": "episode.title",
@@ -111,8 +111,16 @@ search_translation = {
 
 def get_asset_image_matches(file_filter, file_name):
     matches = [m for m in util.glob_filter(file_filter) if os.path.isfile(m) and os.path.splitext(m)[1].lower() in asset_image_extensions]
-    exact_matches = [m for m in matches if os.path.splitext(os.path.basename(m))[0].lower() == file_name.lower()]
-    return exact_matches or matches
+    exact_matches = []
+    numbered_matches = []
+    for match in matches:
+        file_stem = os.path.splitext(os.path.basename(match))[0].lower()
+        target_name = file_name.lower()
+        if file_stem == target_name:
+            exact_matches.append(match)
+        elif re.match(rf"{re.escape(target_name)}-\d+$", file_stem):
+            numbered_matches.append(match)
+    return exact_matches or numbered_matches
 
 
 show_translation = {
@@ -1912,7 +1920,7 @@ class Plex(Library):
                                 item_asset_directory = os.path.abspath(matches[0])
                                 break
                 else:
-                    matches = get_asset_image_matches(os.path.join(ad, f"{file_name}.*"), file_name)
+                    matches = get_asset_image_matches(os.path.join(ad, f"{file_name}*.*"), file_name)
                     if len(matches) > 0:
                         item_asset_directory = ad
                 if item_asset_directory:
@@ -1927,28 +1935,44 @@ class Plex(Library):
                         raise Failed(f"Asset Warning: Unable to find asset folder: '{folder_name}'")
                 return None, None, None, None, item_asset_directory, folder_name
 
-        poster_filter = os.path.join(item_asset_directory, f"{file_name}.*")
-        background_filter = os.path.join(item_asset_directory, "background.*" if file_name == "poster" else f"{file_name}_background.*")
-        logo_filter = os.path.join(item_asset_directory, "logo.*" if file_name == "poster" else f"{file_name}_logo.*")
-        square_art_names = ["square", "square_art"] if file_name == "poster" else [f"{file_name}_square", f"{file_name}_square_art"]
+        if file_name == "poster":
+            poster_names = ["poster", "cover", "default", "folder", "movie"]
+            background_names = ["background", "art", "backdrop", "fanart"]
+            logo_names = ["logo", "clearlogo"]
+            square_art_names = ["square", "square_art", "squareArt", "backgroundSquare"]
+        else:
+            poster_names = [file_name]
+            background_names = [f"{file_name}_background", f"{file_name}-art", f"{file_name}-backdrop", f"{file_name}-background", f"{file_name}-fanart"]
+            logo_names = [f"{file_name}_logo", f"{file_name}-clearlogo", f"{file_name}-logo"]
+            square_art_names = [
+                f"{file_name}_square",
+                f"{file_name}_square_art",
+                f"{file_name}-square",
+                f"{file_name}-squareArt",
+                f"{file_name}-backgroundSquare",
+            ]
 
-        poster_matches = get_asset_image_matches(poster_filter, file_name)
-        if len(poster_matches) > 0:
-            poster = ImageData("asset_directory", os.path.abspath(poster_matches[0]), prefix=prefix, is_url=False)
+        for poster_name in poster_names:
+            poster_matches = get_asset_image_matches(os.path.join(item_asset_directory, f"{poster_name}*.*"), poster_name)
+            if len(poster_matches) > 0:
+                poster = ImageData("asset_directory", os.path.abspath(poster_matches[0]), prefix=prefix, is_url=False)
+                break
 
-        background_name = "background" if file_name == "poster" else f"{file_name}_background"
-        background_matches = get_asset_image_matches(background_filter, background_name)
-        if len(background_matches) > 0:
-            background = ImageData("asset_directory", os.path.abspath(background_matches[0]), prefix=prefix, image_type="background", is_url=False)
+        for background_name in background_names:
+            background_matches = get_asset_image_matches(os.path.join(item_asset_directory, f"{background_name}*.*"), background_name)
+            if len(background_matches) > 0:
+                background = ImageData("asset_directory", os.path.abspath(background_matches[0]), prefix=prefix, image_type="background", is_url=False)
+                break
 
         if not isinstance(item, (Episode, Season)):
-            logo_name = "logo" if file_name == "poster" else f"{file_name}_logo"
-            logo_matches = get_asset_image_matches(logo_filter, logo_name)
-            if len(logo_matches) > 0:
-                logo = ImageData("asset_directory", os.path.abspath(logo_matches[0]), prefix=prefix, image_type="logo", is_url=False)
+            for logo_name in logo_names:
+                logo_matches = get_asset_image_matches(os.path.join(item_asset_directory, f"{logo_name}*.*"), logo_name)
+                if len(logo_matches) > 0:
+                    logo = ImageData("asset_directory", os.path.abspath(logo_matches[0]), prefix=prefix, image_type="logo", is_url=False)
+                    break
 
             for square_art_name in square_art_names:
-                square_art_matches = get_asset_image_matches(os.path.join(item_asset_directory, f"{square_art_name}.*"), square_art_name)
+                square_art_matches = get_asset_image_matches(os.path.join(item_asset_directory, f"{square_art_name}*.*"), square_art_name)
                 if len(square_art_matches) > 0:
                     square_art = ImageData("asset_directory", os.path.abspath(square_art_matches[0]), prefix=prefix, image_type="square_art", is_url=False)
                     break


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG.md and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

## Summary

Adds broader Plex-compatible local asset filename support for movie assets.

This updates asset discovery to accept Plex’s documented movie artwork names in addition to the Kometa names already supported. It also adds support for `.tbn` image files and Plex-style numbered variants such as `poster-2.png`.

Exact asset filenames take priority over numbered variants, so if both exist:

```text
poster.jpg
poster-2.png
```

Kometa uses `poster.jpg`.

## Changes

- Added `.tbn` as a supported asset image extension.
- Added Plex-compatible poster aliases:
  - `poster`
  - `cover`
  - `default`
  - `folder`
  - `movie`
- Added Plex-compatible background aliases:
  - `background`
  - `art`
  - `backdrop`
  - `fanart`
- Added Plex-compatible logo aliases:
  - `logo`
  - `clearlogo`
- Added Plex-compatible square art aliases:
  - `square`
  - `square_art`
  - `squareArt`
  - `backgroundSquare`
- Added support for numbered variants like `poster-2.png`.

## Examples

### `asset_folders: true`

For `Toy Story (1995)`, accepted filenames inside the asset folder include:

```text
assets/
  Toy Story (1995)/
    poster.jpg
    poster-2.png
    cover.jpg
    default.png
    folder.tbn
    movie.jpg

    background.jpg
    fanart.png
    backdrop.tbn
    art.jpg

    logo.png
    clearlogo.png

    square.jpg
    square_art.png
    squareArt.jpg
    backgroundSquare.png
```

### `asset_folders: false`

For flat assets, accepted filenames include:

```text
assets/
  Toy Story (1995).jpg

  Toy Story (1995)_background.jpg
  Toy Story (1995)-background.jpg
  Toy Story (1995)-fanart.png
  Toy Story (1995)-backdrop.tbn
  Toy Story (1995)-art.jpg

  Toy Story (1995)_logo.png
  Toy Story (1995)-logo.png
  Toy Story (1995)-clearlogo.png

  Toy Story (1995)_square.jpg
  Toy Story (1995)_square_art.png
  Toy Story (1995)-square.jpg
  Toy Story (1995)-squareArt.png
  Toy Story (1995)-backgroundSquare.png
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, GitHub will automatically close the issue.
-->
- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

<!--
    This is optional and only necessary when your PR changes supported attributes,
    accepted values, or structure for Configuration Files, Collection Files,
    Metadata Files, Overlay Files, Playlist Files, or Defaults template variables.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG.md entry.
    We may ask you to update the CHANGELOG.md if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
