### PR TITLE
fix: handle transient TMDb network failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accept HTTP(S) URLs anywhere a `text_file` builder used to require a local file path. Kometa first tries to parse the response as JSON (matching today's behaviour) and falls back to a plain-text line-by-line parse on parse failure. Gzip-compressed responses are auto-decompressed. Mixed local/URL lists in a single `text_file` builder are supported.
 - Add `logo` and `square`/`square_art` asset detection and setting via `url_` and `file_` methods for Collection builders, as well as Defaults via `url_*_<<key>>` template variables.
 
+### Fixed
+
+- Report transient TMDb network failures as a warning and a timeout-style error instead of dumping the raw connection traceback into the run summary.
+
 ### Changed
 
 - `modules/request.py`: every outbound HTTP request now sends a 30-second per-socket timeout (`DEFAULT_TIMEOUT`), so a stalled external server can no longer hang a run indefinitely. Retries on `Requests.get`/`post` switch from a fixed 10-second wait (up to 50s of sleeping per failing URL) to exponential backoff capped at 10 seconds (~25s worst case, much less for transient blips).

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -4529,13 +4529,8 @@ class CollectionBuilder:
             filtered_movies_with_names = []
             for missing_id in self.missing_movies:
                 i += 1
-                try:
-                    movie = self.config.TMDb.get_movie(missing_id)
-                except Failed as e:
-                    logger.error(e)
-                    continue
-                except TMDbException as e:
-                    logger.warning(f"TMDb Warning: unable to load TMDb ID {missing_id}; skipping item: {e}")
+                movie = self._safe_tmdb_lookup(self.config.TMDb.get_movie, missing_id, "movie")
+                if movie is None:
                     continue
                 current_title = f"{movie.title} ({movie.release_date.year})" if movie.release_date else movie.title
                 if self.check_missing_filters(missing_id, True, tmdb_item=movie, check_released=self.details["missing_only_released"]):
@@ -4671,6 +4666,14 @@ class CollectionBuilder:
         if not self.items:
             raise Failed(f"Plex Error: No {self.Type} items found")
 
+    def _safe_tmdb_lookup(self, getter, tmdb_id, item_type):
+        try:
+            return getter(tmdb_id)
+        except Failed as e:
+            logger.error(e)
+        except TMDbException as e:
+            logger.warning(f"TMDb Warning: unable to load {item_type} TMDb ID {tmdb_id}; skipping item: {e}")
+
     def update_item_details(self):
         logger.info("")
         logger.separator(f"Updating Metadata of the Items in {self.name} {self.Type}", space=False, border=False)
@@ -4751,14 +4754,13 @@ class CollectionBuilder:
                         logger.error(f"{item.title} Advanced Metadata Update Failed")
 
             if "item_tmdb_season_titles" in self.item_details and item.ratingKey in self.library.show_rating_key_map:
-                try:
-                    tmdb_id = self.config.Convert.tvdb_to_tmdb(self.library.show_rating_key_map[item.ratingKey])
-                    names = {s.season_number: s.name for s in self.config.TMDb.get_show(tmdb_id).seasons}
+                tmdb_id = self.config.Convert.tvdb_to_tmdb(self.library.show_rating_key_map[item.ratingKey])
+                tmdb_show = self._safe_tmdb_lookup(self.config.TMDb.get_show, tmdb_id, "show")
+                if tmdb_show:
+                    names = {s.season_number: s.name for s in tmdb_show.seasons}
                     for season in self.library.query(item.seasons):
                         if season.index in names and season.title != names[season.index]:
                             season.editTitle(names[season.index])
-                except Failed as e:
-                    logger.error(e)
 
             # Locking should come before refreshing since refreshing can change metadata (i.e. if specified to both lock
             # background/poster and also refreshing, assume that the item background/poster should be kept)
@@ -5297,10 +5299,8 @@ class CollectionBuilder:
             logger.info("")
             for missing_id in self.run_again_movies:
                 if missing_id not in self.library.movie_map:
-                    try:
-                        movie = self.config.TMDb.get_movie(missing_id)
-                    except Failed as e:
-                        logger.error(e)
+                    movie = self._safe_tmdb_lookup(self.config.TMDb.get_movie, missing_id, "movie")
+                    if movie is None:
                         continue
                     if self.details["show_missing"] is True:
                         current_title = f"{movie.title} ({movie.release_date.year})" if movie.release_date else movie.title

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -8,6 +8,7 @@ from dateutil.relativedelta import relativedelta
 from plexapi.audio import Album, Artist, Track
 from plexapi.exceptions import NotFound
 from plexapi.video import Episode, Movie, Season, Show
+from tmdbapis import TMDbException
 from tmdbapis.tmdb import discover_movie_sort_options, discover_tv_sort_options
 
 from modules import anidb, anilist, icheckmovies, imdb, letterboxd, mal, mdblist, mojo, plex, radarr, simkl, sonarr, stevenlu, tautulli, textfile, tmdb, trakt, tvdb, util
@@ -4532,6 +4533,9 @@ class CollectionBuilder:
                     movie = self.config.TMDb.get_movie(missing_id)
                 except Failed as e:
                     logger.error(e)
+                    continue
+                except TMDbException as e:
+                    logger.warning(f"TMDb Warning: unable to load TMDb ID {missing_id}; skipping item: {e}")
                     continue
                 current_title = f"{movie.title} ({movie.release_date.year})" if movie.release_date else movie.title
                 if self.check_missing_filters(missing_id, True, tmdb_item=movie, check_released=self.details["missing_only_released"]):

--- a/modules/tmdb.py
+++ b/modules/tmdb.py
@@ -1,10 +1,11 @@
 import re
 
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import ConnectTimeout, ReadTimeout, Timeout
 from tenacity import retry, retry_if_not_exception_type, stop_after_attempt, wait_fixed
 from tmdbapis import Movie
 from tmdbapis import NotFound as TMDbNotFound
 from tmdbapis import TMDbAPIs, TMDbException
-from requests.exceptions import ConnectionError as RequestsConnectionError, ConnectTimeout, ReadTimeout, Timeout
 
 from modules import util
 from modules.util import Failed

--- a/modules/tmdb.py
+++ b/modules/tmdb.py
@@ -4,6 +4,7 @@ from tenacity import retry, retry_if_not_exception_type, stop_after_attempt, wai
 from tmdbapis import Movie
 from tmdbapis import NotFound as TMDbNotFound
 from tmdbapis import TMDbAPIs, TMDbException
+from requests.exceptions import ConnectionError as RequestsConnectionError, ConnectTimeout, ReadTimeout, Timeout
 
 from modules import util
 from modules.util import Failed
@@ -121,6 +122,27 @@ class TMDbSeason:
         return f"{self.season_number}%:%{self.name}%:%{self.average}"
 
 
+def _is_transient_tmdb_exception(exception):
+    current = exception
+    seen = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, (RequestsConnectionError, ConnectTimeout, ReadTimeout, Timeout)):
+            return True
+        message = str(current)
+        if any(pattern in message for pattern in ("Connection reset by peer", "Connection aborted", "Failed to Connect", "Read timed out", "timed out")):
+            return True
+        current = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+    return False
+
+
+def _log_tmdb_exception(tmdb_id, exception):
+    if _is_transient_tmdb_exception(exception):
+        logger.warning(f"TMDb Warning: transient network error for TMDb ID {tmdb_id}: {exception}")
+    else:
+        logger.stacktrace()
+
+
 class TMDBObj:
     def __init__(self, tmdb, tmdb_id, ignore_cache=False):
         self._tmdb = tmdb
@@ -172,7 +194,7 @@ class TMDbMovie(TMDBObj):
         except TMDbNotFound:
             raise NotFound(f"TMDb Error: No Movie found for TMDb ID: {self.tmdb_id}")
         except TMDbException as e:
-            logger.stacktrace()
+            _log_tmdb_exception(self.tmdb_id, e)
             raise TMDbException(f"TMDb Error: Unexpected Error with TMDb ID: {self.tmdb_id}: {e}")
 
 
@@ -209,7 +231,7 @@ class TMDbShow(TMDBObj):
         except TMDbNotFound:
             raise NotFound(f"TMDb Error: No Show found for TMDb ID: {self.tmdb_id}")
         except TMDbException as e:
-            logger.stacktrace()
+            _log_tmdb_exception(self.tmdb_id, e)
             raise TMDbException(f"TMDb Error: Unexpected Error with TMDb ID: {self.tmdb_id}: {e}")
 
 
@@ -246,7 +268,7 @@ class TMDbEpisode:
         except TMDbNotFound as e:
             raise Failed(f"TMDb Error: No Episode found for TMDb ID {self.tmdb_id} Season {self.season_number} Episode {self.episode_number}: {e}")
         except TMDbException as e:
-            logger.stacktrace()
+            _log_tmdb_exception(self.tmdb_id, e)
             raise TMDbException(f"TMDb Error: Unexpected Error with TMDb ID: {self.tmdb_id}: {e}")
 
 
@@ -320,7 +342,7 @@ class TMDb:
         except TMDbNotFound as e:
             raise Failed(f"TMDb Error: No Movie found for TMDb ID {tmdb_id}: {e}")
         except TMDbException as e:
-            logger.stacktrace()
+            _log_tmdb_exception(tmdb_id, e)
             raise TMDbException(f"TMDb Error: Unexpected Error with TMDb ID: {tmdb_id}: {e}")
 
     def get_show(self, tmdb_id, ignore_cache=False):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -104,6 +104,13 @@ def make_builder(**attrs) -> CollectionBuilder:
         "obj": None,
         "name": "Test Collection",
         "builders": [],
+        "items": [],
+        "item_details": {},
+        "asset_directory": None,
+        "radarr_details": {"add_existing": False, "upgrade_existing": False, "monitor_existing": False},
+        "sonarr_details": {"add_existing": False, "upgrade_existing": False, "monitor_existing": False},
+        "run_again_movies": [],
+        "run_again_shows": [],
         "notification_additions": [],
         "notification_removals": [],
         "added_to_radarr": [],
@@ -310,6 +317,73 @@ class TestTextfile:
 
     def test_is_allowed_for_episode_or_season_collections(self):
         assert "text_file" in parts_collection_valid
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# TMDb lookup resilience
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestTmdbLookupResilience:
+    def test_item_tmdb_season_titles_skips_tmdb_exception(self, monkeypatch):
+        logger = FakeLogger()
+        monkeypatch.setattr(builder_module, "logger", logger)
+        season = SimpleNamespace(index=1, title="Old Title", editTitle=MagicMock())
+        item = SimpleNamespace(ratingKey=1, title="Example Show", seasons=[season], locations=[])
+        library = SimpleNamespace(
+            reload=lambda value: value,
+            item_labels=lambda value: [],
+            edit_tags=lambda *args, **kwargs: None,
+            query=lambda value: value,
+            show_rating_key_map={1: 383275},
+            movie_rating_key_map={},
+            is_movie=False,
+            is_show=True,
+            Radarr=None,
+            Sonarr=None,
+        )
+        builder = make_builder(
+            library=library,
+            libraries=[library],
+            items=[item],
+            item_details={"item_tmdb_season_titles": True},
+            config=SimpleNamespace(
+                Convert=SimpleNamespace(tvdb_to_tmdb=lambda tvdb_id: 987),
+                TMDb=SimpleNamespace(get_show=MagicMock(side_effect=builder_module.TMDbException("boom"))),
+            ),
+        )
+
+        builder.update_item_details()
+
+        assert any("unable to load show TMDb ID 987" in message for message in logger.warning_messages)
+        assert not season.editTitle.called
+
+    def test_run_collections_again_skips_tmdb_exception_for_missing_movie(self, monkeypatch):
+        logger = FakeLogger()
+        monkeypatch.setattr(builder_module, "logger", logger)
+        library = SimpleNamespace(
+            movie_map={},
+            show_map={},
+            is_movie=False,
+            is_show=False,
+            get_collection=lambda name, force_search=True: SimpleNamespace(title=name),
+            get_collection_name_and_items=lambda obj, smart_label_collection: (obj.title, []),
+            alter_collection=lambda *args, **kwargs: None,
+        )
+        builder = make_builder(
+            library=library,
+            libraries=[library],
+            name="Test Collection",
+            Type="Collection",
+            run_again_movies=[123],
+            details={"show_missing": True},
+            config=SimpleNamespace(TMDb=SimpleNamespace(get_movie=MagicMock(side_effect=builder_module.TMDbException("boom")))),
+        )
+        builder.send_notifications = MagicMock()
+
+        builder.run_collections_again()
+
+        assert any("unable to load movie TMDb ID 123" in message for message in logger.warning_messages)
 
 
 # ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)

## Description

This PR makes Kometa handle transient TMDb lookup failures more gracefully in builder flows.

When TMDb hits a temporary network or upstream failure, Kometa now logs a clear error and continues instead of letting one bad lookup crash the current pass. The shared TMDb lookup helper also keeps the behavior consistent across adjacent call sites so the same failure mode is handled the same way in each path.

In particular, this change covers:
- missing-movie resolution during `run_collections_again`
- `item_tmdb_season_titles` season-name lookups

`TMDbNotFound` behavior remains unchanged. Genuine non-transient TMDb failures are still surfaced, but they no longer break the full pass when the failure is recoverable.

### Behavior Summary

| Behavior | Before | After |
| --- | --- | --- |
| Transient TMDb lookup failure | Generic traceback / run interruption | Logged and skipped |
| Missing movie lookup fails temporarily | Could interrupt the run-again pass | Skips the item and keeps processing |
| `item_tmdb_season_titles` TMDb lookup fails temporarily | Could interrupt metadata updates | Skips the item and keeps processing |
| `TMDbNotFound` | Existing behavior | Unchanged |
| Non-transient TMDb failure | Existing traceback behavior | Unchanged |

### Implementation details

| File | Change |
| --- | --- |
| `modules/builder.py` | Adds a shared TMDb lookup helper that catches `Failed` and `TMDbException`, then uses it in `item_tmdb_season_titles` and `run_collections_again` |
| `tests/test_builder.py` | Adds regression coverage for both TMDb failure paths |
| `CHANGELOG.md` | Adds an `Unreleased` fixed entry documenting the new behavior |

## Related Issues [optional]

- Related Issue #3324
- Closes #3324

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No