### PR TITLE
fix: suppress stack trace for TMDB ID not found errors (closes #3324)

### DIFF
--- a/modules/logs.py
+++ b/modules/logs.py
@@ -29,6 +29,8 @@ SUPPRESS_STACKTRACE_PATTERNS = [
     r"Plex Error: .* not found",
     r"No matches found with regex pattern",
     r"No Items found in Plex",
+    r"tmdb.*not found",
+    r"tmdb_id.*not found",
 ]
 
 


### PR DESCRIPTION
## What
When a TMDB ID is not found, a full traceback is printed instead of a clean error message, as reported in issue #3324.

## Fix
Added patterns to `SUPPRESS_STACKTRACE_PATTERNS` in `modules/logs.py` to match TMDB 'not found' errors, ensuring that the stack trace is suppressed and only a concise message is shown. This aligns with the existing behavior for similar Plex errors.

Closes #3324