### PR TITLE
Fix missing _logos/_backgrounds tables for pre-existing image caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Create the per-library `_backgrounds` and `_logos` image-map tables unconditionally so caches created before those tables existed self-heal on the next run, instead of raising `no such table: image_map_<n>_logos` and failing every collection that sets a logo.
 - Report transient TMDb network failures as a warning and a timeout-style error instead of dumping the raw connection traceback into the run summary.
 
 ### Changed

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -1041,19 +1041,20 @@ class Cache:
                             overlay TEXT,
                             compare TEXT,
                             location TEXT)""")
-                        cursor.execute(f"""CREATE TABLE IF NOT EXISTS {table_name}_backgrounds (
-                            key INTEGER PRIMARY KEY,
-                            rating_key TEXT UNIQUE,
-                            overlay TEXT,
-                            compare TEXT,
-                            location TEXT)""")
-                        cursor.execute(f"""CREATE TABLE IF NOT EXISTS {table_name}_logos (
-                            key INTEGER PRIMARY KEY,
-                            rating_key TEXT UNIQUE,
-                            overlay TEXT,
-                            compare TEXT,
-                            location TEXT)""")
                 if table_name:
+                    # Created unconditionally so caches predating these tables self-heal on next run
+                    cursor.execute(f"""CREATE TABLE IF NOT EXISTS {table_name}_backgrounds (
+                        key INTEGER PRIMARY KEY,
+                        rating_key TEXT UNIQUE,
+                        overlay TEXT,
+                        compare TEXT,
+                        location TEXT)""")
+                    cursor.execute(f"""CREATE TABLE IF NOT EXISTS {table_name}_logos (
+                        key INTEGER PRIMARY KEY,
+                        rating_key TEXT UNIQUE,
+                        overlay TEXT,
+                        compare TEXT,
+                        location TEXT)""")
                     cursor.execute("SELECT count(name) FROM sqlite_master WHERE type='table' AND name=?", (f"{table_name}_overlays",))
                     if cursor.fetchone()[0] > 0:
                         cursor.execute(f"PRAGMA table_info({table_name}_overlays)")


### PR DESCRIPTION
## Description

`Cache.get_image_table_name()` creates the per-library `_backgrounds` and `_logos` image-map tables **only inside the first-registration `else` branch** — the path that runs the first time a library is inserted into `image_maps`. Any cache whose `image_map_<n>` row already existed before those tables were introduced takes the `if row and row["key"]:` branch on every subsequent run and never gets them created.

The result is that `query_image_map(item.ratingKey, f"{self.image_table_name}_logos")` in `library.upload_images()` raises:

```
sqlite3.OperationalError: no such table: image_map_<n>_logos
```

which surfaces as a critical error on **every collection that sets a logo**, firing a failure webhook per collection.

This is the same root cause as the (stale-closed, never code-fixed) #2708.

## Fix

Move the `_backgrounds` and `_logos` `CREATE TABLE IF NOT EXISTS` statements out of the `else` branch into the unconditional `if table_name:` block, exactly matching how `_square_arts`, `_overlays`, `_overlay_state`, and `_overlay_images` are already created. `CREATE TABLE IF NOT EXISTS` is idempotent, so new caches are unaffected and pre-existing caches self-heal on the next run — no cache deletion required.

## Testing

- Reproduced on a live nightly cache (`2.4.4-build41`) whose `image_map_{1,2,3}` tables predated the logo feature: no `*_logos` tables existed and every logo-setting collection threw the error.
- After the fix, the missing tables are created on the next run and the collections build cleanly.

Closes #2708