### PR TITLE
fix: save multi edits retry call on Plex wrapper

### DIFF
--- a/modules/operations.py
+++ b/modules/operations.py
@@ -1145,7 +1145,7 @@ class Operations:
                             self.library.Plex.editTags(display_attr, update_value, remove=tag_type == "remove")
                         else:
                             self.library.Plex.editField(display_attr, update_value)
-                        self.library.Plex._save_multi_edits_with_retry()
+                        self.library._save_multi_edits_with_retry()
                         if evict_cache:
                             for batch_item in batch_items:
                                 cache_evictions.add(batch_item.ratingKey)


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

PR #3326 added a retry wrapper method, _save_multi_edits_with_retry, on the Plex wrapper class in modules/plex.py. That PR updated one call site correctly but left another call site in modules/operations.py pointing at the wrong object, calling self.library.Plex._save_multi_edits_with_retry() instead of self.library._save_multi_edits_with_retry()

self.library.Plex is the raw plexapi section object (for example MovieSection), which does not have this method. Only the Plex wrapper class itself has it. This caused every metadata edit batch (ratings, labels, genres, content rating, dates, and so on) to crash with:

AttributeError: 'MovieSection' object has no attribute '_save_multi_edits_with_retry'

This is a one line fix. Changed the call in modules/operations.py from self.library.Plex._save_multi_edits_with_retry() to self.library._save_multi_edits_with_retry()

Tested locally: reproduced the exact AttributeError with a minimal script confirming the root cause, applied the fix, and ran the full test suite (772 tests) with all tests passing, including the retry tests added in #3326

## Related Issues [optional]

- Supersedes #3326

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [X] No
- [ ] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [X] No
- [ ] Not Applicable

## Have you updated the CHANGELOG.md?

- [ ] Yes
- [X] No