### PR TITLE
Fixed: Asset folder shows `None` when `asset_folders: false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Show the configured assets directory in missing-asset warnings instead of `'None'` when no matching flat asset file is found.
 - Create the per-library `_backgrounds` and `_logos` image-map tables unconditionally so caches created before those tables existed self-heal on the next run, instead of raising `no such table: image_map_<n>_logos` and failing every collection that sets a logo.
 - Report transient TMDb network failures as a warning and a timeout-style error instead of dumping the raw connection traceback into the run summary.
+- Asset folder would be reported as `None` when `asset_folders` was set to false
 
 ### Changed
 

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1898,6 +1898,7 @@ class Plex(Library):
     def find_and_upload_assets(self, item, current_labels, asset_directory=None):
         item_dir = None
         name = None
+        configured_asset_directories = self.asset_directory if asset_directory is None else asset_directory
         try:
             poster, background, logo, square_art, item_dir, name = self.find_item_assets(item, asset_directory=asset_directory)
             has_overlay = "Overlay" in current_labels
@@ -1907,7 +1908,8 @@ class Plex(Library):
             if has_overlay:
                 logger.info(f"Item: {name} has an Overlay and will be updated when overlays are run")
             elif not poster and not background and not logo and not square_art and self.show_missing_assets:
-                logger.warning(f"Asset Warning: No poster or background found in the assets folder '{item_dir}'")
+                searched_directory = item_dir or "', '".join(os.path.abspath(ad) for ad in configured_asset_directories)
+                logger.warning(f"Asset Warning: No poster or background found in the assets folder '{searched_directory}'")
         except Failed as e:
             if self.show_missing_assets:
                 logger.warning(e)


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG.md and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Fixed an issue where logging would show the assets folder as "None" when `asset_folders: false`.

before:
```YAML
| (2/51) Ad Vitam                                                                                    |
| Asset Warning: No poster or background found in the assets folder 'None'                           |
| No Item Edits                                                                                      |
```

after:
```yaml
| (7/51) Bullet Train                                                                                |
| Asset Warning: No poster or background found in the assets folder 'D:\Repositories\Kometa\config\assets' |
| No Item Edits                                                                                      |
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, GitHub will automatically close the issue.
-->
- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

<!--
    This is optional and only necessary when your PR changes supported attributes,
    accepted values, or structure for Configuration Files, Collection Files,
    Metadata Files, Overlay Files, Playlist Files, or Defaults template variables.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG.md entry.
    We may ask you to update the CHANGELOG.md if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
