### PR TITLE
Fix Plex multi-edit retry state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Skip episode rating operations for movie libraries.
 - Show the configured assets directory in missing-asset warnings instead of `'None'` when no matching flat asset file is found.
+- Preserve Plex batch multi-edit state across timeout retries so a transient `saveMultiEdits()` timeout no longer raises `Batch multi-editing mode not enabled` on retry.
 - Create the per-library `_backgrounds` and `_logos` image-map tables unconditionally so caches created before those tables existed self-heal on the next run, instead of raising `no such table: image_map_<n>_logos` and failing every collection that sets a logo.
 - Report transient TMDb network failures as a warning and a timeout-style error instead of dumping the raw connection traceback into the run summary.
 - Asset folder would be reported as `None` when `asset_folders` was set to false

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1307,7 +1307,15 @@ class Plex(Library):
         sleep=_plex_timeout_sleep,
     )
     def _save_multi_edits_with_retry(self):
-        self.Plex.saveMultiEdits()
+        edits = dict(self.Plex._edits) if isinstance(getattr(self.Plex, "_edits", None), dict) else None
+        try:
+            self.Plex.saveMultiEdits()
+        except (ConnectTimeout, ReadTimeout):
+            # PlexAPI clears its internal batch state before the request is sent.
+            # If the save times out, restore the pending edits so a retry can reuse them.
+            if edits is not None:
+                self.Plex._edits = edits
+            raise
 
     def alter_collection(self, items, collection, smart_label_collection=False, add=True):
         maintain_status = True

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1307,7 +1307,8 @@ class Plex(Library):
         sleep=_plex_timeout_sleep,
     )
     def _save_multi_edits_with_retry(self):
-        edits = dict(self.Plex._edits) if isinstance(getattr(self.Plex, "_edits", None), dict) else None
+        pending_edits = getattr(self.Plex, "_edits", None)
+        edits = pending_edits.copy() if isinstance(pending_edits, dict) else None
         try:
             self.Plex.saveMultiEdits()
         except (ConnectTimeout, ReadTimeout):

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from plexapi.exceptions import BadRequest
 from requests.exceptions import ReadTimeout
 
 import modules.builder  # noqa: F401 — pre-import to break circular deps
@@ -291,6 +292,31 @@ class TestSaveMultiEditsRetry:
         sleep_mock.assert_any_call(5)
         assert any("attempt 1 timed out" in message for message in plex_module.logger.info_messages)
         assert any("attempt 2 timed out" in message for message in plex_module.logger.info_messages)
+
+    def test_restores_batch_state_between_timeouts(self, monkeypatch):
+        import modules.plex as plex_module
+
+        plex = make_plex()
+        plex.Plex._edits = {"items": [MagicMock()], "title.value": "New Title"}
+        call_count = 0
+
+        def save_multi_edits():
+            nonlocal call_count
+            call_count += 1
+            if plex.Plex._edits is None:
+                raise BadRequest("Batch multi-editing mode not enabled. Must call `batchMultiEdits()` first.")
+            plex.Plex._edits = None
+            if call_count == 1:
+                raise ReadTimeout("timeout-1")
+
+        plex.Plex.saveMultiEdits.side_effect = save_multi_edits
+        sleep_mock = MagicMock()
+        monkeypatch.setattr(plex_module.time, "sleep", sleep_mock)
+
+        plex._save_multi_edits_with_retry()
+
+        assert call_count == 2
+        assert plex.Plex._edits is None
 
     def test_raises_after_third_timeout(self, monkeypatch):
         import modules.plex as plex_module


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Preserve Plex batch multi-edit state across timeout retries so a transient `saveMultiEdits()` timeout can be retried without losing the pending batch payload.

| Area | Details |
| --- | --- |
| Retry flow | Snapshot and restore `Plex._edits` around `saveMultiEdits()` timeout retries |
| Regression coverage | Added a test that simulates PlexAPI clearing batch state before the retry |
| Changelog | Added an `Unreleased -> Fixed` entry |

## Related Issues [optional]

- Related Issue #3344
- Closes #3344

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No

## Verification

| Check | Result |
| --- | --- |
| `python3 -m py_compile modules/plex.py tests/test_plex.py` | Passed |
| `pytest tests/test_plex.py -q` | Blocked locally: missing `arrapi` during test collection |

## Scope

| File | Purpose |
| --- | --- |
| `modules/plex.py` | Restore batch state across retries |
| `tests/test_plex.py` | Regression coverage for timeout retry behavior |
| `CHANGELOG.md` | Document the fix under Unreleased |

## Review Notes

| Note | Detail |
| --- | --- |
| User-visible impact | Prevents a retry timeout from turning into `Batch multi-editing mode not enabled` |
| Risk | Low; the change only affects the timeout retry path for Plex batch edits |
