### PR TITLE
Fix logo asset metadata updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix asset-directory logos being ignored during metadata image updates.
 - Skip episode rating operations for movie libraries.
 - Show the configured assets directory in missing-asset warnings instead of `'None'` when no matching flat asset file is found.
 - Suppress full stack traces for a small set of known, non-critical logger patterns so expected Plex not-found noise prints as a warning instead of a stack trace.

--- a/docs/files/updates.md
+++ b/docs/files/updates.md
@@ -149,13 +149,15 @@ Standard priority is as follows [lower numbers take precedence]:
 
 You can use the `prioritize_assets` setting to push the asset_directory to the top of this priority list.
 
-## Logo Collection Metadata Updates
+## Logo Collection/Playlist Metadata Updates
 
-All the following attributes update the logo of the collection from various sources.
+All the following attributes update the logo of the collection/playlist from various sources.
+
+**All of these details work with Playlists.**
 
 If no logo is specified the script will look in the library's [Image Asset Directories](../kometa/guides/assets.md)
-for a folder named either the collection name or the `name_mapping` if specified and look for a
-supported logo asset such as `logo.ext` or `clearlogo.ext` in that folder.
+for a folder named either the collection/playlist name or the `name_mapping` if specified and look for a supported
+logo asset such as `logo.ext` or `clearlogo.ext` in that folder.
 
 | Attribute   | Description & Values                                                                                           |
 |:------------|:---------------------------------------------------------------------------------------------------------------|

--- a/docs/kometa/guides/assets.md
+++ b/docs/kometa/guides/assets.md
@@ -157,8 +157,8 @@ Numbered variants such as `poster-2.png` or `fanart-2.tbn` are accepted for the 
     |:---------------------------------|:-----------------------------------------------------------|
     | Collection/Movie/Show poster     | `<path_to_assets>/ASSET_NAME/poster.ext`, `cover.ext`, `default.ext`, `folder.ext`, or `movie.ext` |
     | Collection/Movie/Show background | `<path_to_assets>/ASSET_NAME/background.ext`, `art.ext`, `backdrop.ext`, or `fanart.ext` |
-    | Collection/Movie/Show logo       | `<path_to_assets>/ASSET_NAME/logo.ext` or `clearlogo.ext` |
-    | Collection/Movie/Show square art | `<path_to_assets>/ASSET_NAME/square.ext`, `square_art.ext`, `squareArt.ext`, or `backgroundSquare.ext` |
+    | Collection/Playlist/Movie/Show logo       | `<path_to_assets>/ASSET_NAME/logo.ext` or `clearlogo.ext` |
+    | Collection/Playlist/Movie/Show square art | `<path_to_assets>/ASSET_NAME/square.ext`, `square_art.ext`, `squareArt.ext`, or `backgroundSquare.ext` |
     | Season poster                    | `<path_to_assets>/ASSET_NAME/Season##.ext`                 |
     | Season background                | `<path_to_assets>/ASSET_NAME/Season##_background.ext`      |
     | Episode poster                   | `<path_to_assets>/ASSET_NAME/S##E##.ext`                   |
@@ -170,8 +170,8 @@ Numbered variants such as `poster-2.png` or `fanart-2.tbn` are accepted for the 
     |:---------------------------------|:-----------------------------------------------------------|
     | Collection/Movie/Show poster     | `<path_to_assets>/ASSET_NAME.ext`                         |
     | Collection/Movie/Show background | `<path_to_assets>/ASSET_NAME_background.ext`, `ASSET_NAME-art.ext`, `ASSET_NAME-backdrop.ext`, `ASSET_NAME-background.ext`, or `ASSET_NAME-fanart.ext` |
-    | Collection/Movie/Show logo       | `<path_to_assets>/ASSET_NAME_logo.ext`, `ASSET_NAME-clearlogo.ext`, or `ASSET_NAME-logo.ext` |
-    | Collection/Movie/Show square art | `<path_to_assets>/ASSET_NAME_square.ext`, `ASSET_NAME_square_art.ext`, `ASSET_NAME-square.ext`, `ASSET_NAME-squareArt.ext`, or `ASSET_NAME-backgroundSquare.ext` |
+    | Collection/Playlist/Movie/Show logo       | `<path_to_assets>/ASSET_NAME_logo.ext`, `ASSET_NAME-clearlogo.ext`, or `ASSET_NAME-logo.ext` |
+    | Collection/Playlist/Movie/Show square art | `<path_to_assets>/ASSET_NAME_square.ext`, `ASSET_NAME_square_art.ext`, `ASSET_NAME-square.ext`, `ASSET_NAME-squareArt.ext`, or `ASSET_NAME-backgroundSquare.ext` |
     | Season poster                    | `<path_to_assets>/ASSET_NAME_Season##.ext`                 |
     | Season background                | `<path_to_assets>/ASSET_NAME_Season##_background.ext`      |
     | Episode poster                   | `<path_to_assets>/ASSET_NAME_S##E##.ext`                   |

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1887,6 +1887,8 @@ class Plex(Library):
                 posters["asset_directory"] = asset_poster
             if asset_background:
                 backgrounds["asset_directory"] = asset_background
+            if asset_logo:
+                logos["asset_directory"] = asset_logo
             if asset_square_art:
                 square_arts["asset_directory"] = asset_square_art
             if asset_location is None or initial:
@@ -1918,7 +1920,7 @@ class Plex(Library):
                 logger.info(f"Item: {name} has an Overlay and will be updated when overlays are run")
             elif not poster and not background and not logo and not square_art and self.show_missing_assets:
                 searched_directory = item_dir or "', '".join(os.path.abspath(ad) for ad in configured_asset_directories)
-                logger.warning(f"Asset Warning: No poster or background found in the assets folder '{searched_directory}'")
+                logger.warning(f"Asset Warning: No supported artwork found in the assets folder '{searched_directory}'")
         except Failed as e:
             if self.show_missing_assets:
                 logger.warning(e)


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [X] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Metadata image updates could find a logo in the asset directory but skip it during image selection. Posters, backgrounds, and square art already passed their asset-directory matches into the same selection step.

This wires asset-directory logos into that path as well, so metadata image updates handle local logos consistently with the other artwork types.

Also updates nearby docs/log wording for playlist logo and square-art asset support.

## Related Issues [optional]

N/A

## Have you updated the Documentation to reflect changes (if necessary)?

- [X] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No
