### PR TITLE
Update Sight & Sound Letterboxd default owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update the Sight & Sound Letterboxd default collection to use the correct `sightsoundmag` owner for the list.
 - Fix mixed-library playlist `plex_search` by building the Plex search per library type while logging the criteria once.
 - Fix asset-directory logos being ignored during metadata image updates.
 - Skip episode rating operations for movie libraries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Remove the broken Sight & Sound Letterboxd default collection so the shipped chart defaults no longer try to load an unsupported list URL.
 - Fix mixed-library playlist `plex_search` by building the Plex search per library type while logging the criteria once.
 - Fix asset-directory logos being ignored during metadata image updates.
 - Skip episode rating operations for movie libraries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Remove the broken Sight & Sound Letterboxd default collection so the shipped chart defaults no longer try to load an unsupported list URL.
 - Fix mixed-library playlist `plex_search` by building the Plex search per library type while logging the criteria once.
 - Fix asset-directory logos being ignored during metadata image updates.
 - Skip episode rating operations for movie libraries.

--- a/defaults/chart/letterboxd.yml
+++ b/defaults/chart/letterboxd.yml
@@ -65,21 +65,6 @@ collections:
       - name: arr
       - name: custom
 
-  "Sight & Sound Greatest Films":
-    variables:
-      style: color
-      key: sight_sound
-    template:
-      - name: letterboxd_list
-        user: bfi
-        list: sight-and-sounds-greatest-films-of-all-time
-      - name: shared
-        translation_key: sight_and_sound_greatest_films
-        url_logo: https://raw.githubusercontent.com/Kometa-Team/Default-Images/master/chart/logos/Letterboxd.png
-        summary: <<summary_<<key>>>>
-      - name: arr
-      - name: custom
-
   "1,001 To See Before You Die":
     variables:
       style: color

--- a/defaults/chart/letterboxd.yml
+++ b/defaults/chart/letterboxd.yml
@@ -65,6 +65,21 @@ collections:
       - name: arr
       - name: custom
 
+  "Sight & Sound Greatest Films":
+    variables:
+      style: color
+      key: sight_sound
+    template:
+      - name: letterboxd_list
+        user: sightsoundmag
+        list: sight-and-sounds-greatest-films-of-all-time
+      - name: shared
+        translation_key: sight_and_sound_greatest_films
+        url_logo: https://raw.githubusercontent.com/Kometa-Team/Default-Images/master/chart/logos/Letterboxd.png
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
   "1,001 To See Before You Die":
     variables:
       style: color


### PR DESCRIPTION
## Description
Update the Sight & Sound Letterboxd default collection to use the correct `sightsoundmag` owner for the list.

This keeps the shipped Letterboxd chart default pointed at the working list URL while preserving the collection in the defaults. A changelog entry was also added to document the correction.

## Related Issues [optional]
- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?
- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?
- [ ] Yes
- [X] No
- [ ] Not Applicable

## Have you updated the CHANGELOG.md?
- [X] Yes
- [ ] No