### PR TITLE
fix: get_image() accepts validate_only, doing a HEAD check instead of crashing on url_poster/url_background/url_logo/url_square_art

### DIFF
--- a/modules/request.py
+++ b/modules/request.py
@@ -134,8 +134,13 @@ class Requests:
             raise Failed(f"URL Error: {response.status_code} on {url}")
         return YAML(input_data=response.content, check_empty=check_empty)
 
-    def get_image(self, url, session=None):
-        response = self.get(url, header=True) if session is None else session.get(url, headers=get_header(None, True, None), timeout=DEFAULT_TIMEOUT)
+    def get_image(self, url, session=None, validate_only=False):
+        active_session = session if session is not None else self.session
+        request_headers = get_header(None, True, None)
+        if validate_only:
+            response = active_session.head(url, headers=request_headers, timeout=DEFAULT_TIMEOUT, allow_redirects=True)
+        else:
+            response = active_session.get(url, headers=request_headers, timeout=DEFAULT_TIMEOUT)
         if response.status_code == 404:
             raise Failed(f"Image Error: Not Found on Image URL: {url}")
         if response.status_code >= 400:


### PR DESCRIPTION
# Fix get_image() TypeError on url_poster, url_background, url_logo, and url_square_art

## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Any collection using `url_poster`, `url_background`, `url_logo`, or `url_square_art` was crashing with:

`TypeError: Requests.get_image() got an unexpected keyword argument validate_only`

The four validation call sites in `modules/builder.py` already called `self.config.Requests.get_image(method_data, validate_only=True)`, but `get_image()` in `modules/request.py` never had a `validate_only` parameter, so every call raised a TypeError instead of validating the URL.

This PR adds `validate_only` to `get_image()`. When set, it performs a HEAD request instead of a full GET, checking the status code and content type without downloading the image body. This matches what the four callers were written to expect, since they only need to confirm the URL resolves to a valid image, not use the image data itself. Callers that need the actual bytes, such as `download_image`, are unaffected and still perform a full GET.

Tested locally against a config using `url_poster` and confirmed the collection now builds instead of failing with an Unknown Error.

## Related Issues [optional]

- In addition to #3356, which this builds on

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No
