### PR TITLE
Fix AU Content Rating Mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `modules/request.py`/`modules/plex.py`: fix `get_image()` and `delete_user_playlist()` crashing a collection or playlist sync outright on a transient network failure (connection reset, timeout, plex.tv DNS resolution). Both now catch the underlying `requests` exception and raise `Failed`, matching how every other network-facing call in these modules already degrades.
-
 - `modules/tvdb.py`: add a distinct `Unavailable` exception for TVDb requests that exhaust their retry budget without ever returning usable content (e.g. repeated HTTP 202/empty-body "still generating" responses), separate from `NotFound`'s definitive 4xx. Previously both were re-raised with the identical "No Series/Movie found" message, so a confirmed-dead TVDb ID and a transient TVDb hiccup were indistinguishable in the log. All `get_tvdb_obj()` call sites (`modules/builder.py`, `modules/operations.py`) now log `NotFound` at debug (unchanged), `Unavailable` at warning (previously logged at error via the generic `Failed` handler), and any other `Failed` at error (unchanged).
 - Fix custom `rating<n>_file` (and `git`/`repo`/`url`) overlay images being silently replaced by a built-in `default`/`pmm` asset.
 - Prevent Kometa from creating duplicate collections when Plex search misses an existing same-named collection by falling back to the full collection inventory before creating.
@@ -64,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip Recommendation Hub sorting on a targeted `--run-collections` run instead of resorting every pinned collection; a partial run only knows the `hub_priority` values of the collections it rebuilt, so treating the rest as unprioritised pushed them out of position. Also log the configured `hub_priority` value during attribute validation, matching other methods like `collection_order`.
 - Extend the `--run-collections` Recommendation Hub sort skip to also cover `--run-files`, which has the same partial-run limitation.
 - Warn and skip `item_edition` edits when Plex Pass is unavailable instead of attempting the edit and surfacing a Plex 403 Forbidden error.
+- Fix the default AU content-rating overlay so the MA15+ badge matches both Plex rating spellings: canonical `au/MA 15+` from explicit TMDb Australian certifications and Plex-derived `au/MA15+` for titles without an AU certification.
 
 ### Changed
 

--- a/defaults/both/content_rating_au.yml
+++ b/defaults/both/content_rating_au.yml
@@ -149,5 +149,6 @@ dynamic_collections:
       X18+:
         - gb/R18
         - au/X 18+
+        - au/X18+
         - de/BPjM Restricted
         - BPjM Restricted

--- a/defaults/overlays/content_rating_au.yml
+++ b/defaults/overlays/content_rating_au.yml
@@ -64,17 +64,17 @@ overlays:
   ma:
     template:
       - name: standard
-      - {name: cr_au, rating: "au/MA15+, de/16, no/16, A-17, TVMA, TV-MA, R, 16, 17, M/PG"}
+      - {name: cr_au, rating: "au/MA15+, au/MA 15+, de/16, no/16, A-17, TVMA, TV-MA, R, 16, 17, M/PG"}
 
   r:
     template:
       - name: standard
-      - {name: cr_au, rating: "au/R 18+, de/18, gb/18, M, 18, R - 17+ (violence & profanity), no/18, R18, gb/X, X, NC-17, R+ - Mild Nudity, Rx - Hentai"}
+      - {name: cr_au, rating: "au/R 18+, au/R18+, de/18, gb/18, M, 18, R - 17+ (violence & profanity), no/18, R18, gb/X, X, NC-17, R+ - Mild Nudity, Rx - Hentai"}
 
   x:
     template:
       - name: standard
-      - {name: cr_au, rating: "au/X 18+, de/BPjM Restricted, BPjM Restricted, gb/R18"}
+      - {name: cr_au, rating: "au/X 18+, au/X18+, de/BPjM Restricted, BPjM Restricted, gb/R18"}
   nr:
     template:
       - {name: standard, key: nr}


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Fixes the default `content_rating_au` overlay so the MA15+ badge applies to Plex items using either Australian MA15+ content-rating spelling.

Plex stores explicit TMDb Australian MA15+ certifications as `au/MA 15+`, matching the official Australian Classification Board spelling. When Plex derives the rating from other countries because no AU certification exists, it can instead store `au/MA15+`.

The AU collection default already accounts for both values, but the overlay default only matched the non-canonical `au/MA15+` spelling. This meant MA15+ overlays were skipped for most titles with real AU certifications.

This PR adds `au/MA 15+` to the hardcoded MA15+ overlay mapping while preserving `au/MA15+`, so both explicit TMDb AU ratings and Plex-derived ratings receive the same `ma` badge.

## Related Issues [optional]

- Related Issue #
- Closes #3366

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No
```