### PR TITLE
fix: cache confirmed tmdb_to_tvdb misses instead of re-querying every run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Plex show edition support wherever movie editions are supported, including edition filters, metadata matching/editing, overlays, dynamic collections, and `item_edition`.
 
 ### Fixed
+- Fix `tmdb_to_tvdb` re-attempting a live TMDb lookup on every run for TMDb IDs with no TVDb mapping; confirmed misses are now cached (at 3x `cache_expiration`) instead of being rechecked every time, cutting redundant network calls for tmdb_discover-driven TV overlays.
 - Fix custom `rating<n>_file` (and `git`/`repo`/`url`) overlay images being silently replaced by a built-in `default`/`pmm` asset.
 - Prevent Kometa from creating duplicate collections when Plex search misses an existing same-named collection by falling back to the full collection inventory before creating.
 - Refine the run summary output: group repeated overlay, Letterboxd/TMDb, Plex resolution-regex, and Trakt TVDb-miss messages; normalize logo warning summaries; print overlay and convert summaries in the same `Count | Message` format as warning/error summaries; add a visual divider before the summary intro text; rename the overlay section to `Overlay Summary`; and keep the run-status table hidden when there is no status data to show.

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -21,6 +21,9 @@ def sql_identifier(name):
 
 
 class Cache:
+    # Confirmed-no-mapping results (e.g. no TVDb ID exists for a given TMDb ID) get cached this many times longer than a normal hit, since a real non-match rarely resolves quickly but shouldn't be assumed permanent either.
+    NEGATIVE_MAP_TTL_MULTIPLIER = 3
+
     def __init__(self, config_path, expiration):
         self.cache_path = f"{os.path.splitext(config_path)[0]}.cache"
         self.expiration = expiration
@@ -459,8 +462,8 @@ class Cache:
         to_id = "tvdb_id" if tmdb else "tmdb_id"
         return self._query_map("tmdb_to_tvdb_map2", _id, from_id, to_id)
 
-    def update_tmdb_to_tvdb_map(self, expired, tmdb_id, tvdb_id):
-        self._update_map("tmdb_to_tvdb_map2", "tmdb_id", tmdb_id, "tvdb_id", tvdb_id, expired)
+    def update_tmdb_to_tvdb_map(self, expired, tmdb_id, tvdb_id, is_negative=False):
+        self._update_map("tmdb_to_tvdb_map2", "tmdb_id", tmdb_id, "tvdb_id", tvdb_id, expired, is_negative=is_negative)
 
     def query_letterboxd_map(self, letterboxd_id):
         return self._query_map("letterboxd_map", letterboxd_id, "letterboxd_id", "tmdb_id")
@@ -475,6 +478,7 @@ class Cache:
         self._update_map("mojo_map", "mojo_url", mojo_url, "imdb_id", imdb_id, expired)
 
     def _query_map(self, map_name, _id, from_id, to_id, media_type=None, return_type=False):
+        # A row with a NULL to_id is a cached "confirmed no mapping" result (see _update_map's is_negative), not a missing entry - it still counts as a cache hit, just on a longer TTL.
         map_name, from_id = sql_identifier(map_name), sql_identifier(from_id)
         id_to_return = None
         expired = None
@@ -486,26 +490,30 @@ class Cache:
                 else:
                     cursor.execute(f"SELECT * FROM {map_name} WHERE {from_id} = ? AND media_type = ?", (_id, media_type))  # nosec B608 - identifiers validated by sql_identifier()
                 row = cursor.fetchone()
-                if row and row[to_id]:
+                if row and row["expiration_date"]:
+                    is_negative_row = not row[to_id]
+                    ttl_days = self.expiration * self.NEGATIVE_MAP_TTL_MULTIPLIER if is_negative_row else self.expiration
                     datetime_object = datetime.strptime(row["expiration_date"], "%Y-%m-%d")
                     time_between_insertion = datetime.now() - datetime_object
-                    if "_" in row[to_id]:
-                        id_to_return = row[to_id]
-                    else:
-                        try:
-                            id_to_return = int(row[to_id])
-                        except ValueError:
+                    if not is_negative_row:
+                        if "_" in row[to_id]:
                             id_to_return = row[to_id]
-                    expired = time_between_insertion.days > self.expiration
+                        else:
+                            try:
+                                id_to_return = int(row[to_id])
+                            except ValueError:
+                                id_to_return = row[to_id]
+                    expired = time_between_insertion.days > ttl_days
                     out_type = row["media_type"] if return_type else None
         if return_type:
             return id_to_return, out_type, expired
         else:
             return id_to_return, expired
 
-    def _update_map(self, map_name, val1_name, val1, val2_name, val2, expired, media_type=None):
+    def _update_map(self, map_name, val1_name, val1, val2_name, val2, expired, media_type=None, is_negative=False):
         map_name, val1_name, val2_name = sql_identifier(map_name), sql_identifier(val1_name), sql_identifier(val2_name)
-        expiration_date = datetime.now() if expired is True else (datetime.now() - timedelta(days=random.randint(1, self.expiration)))
+        ttl_days = self.expiration * self.NEGATIVE_MAP_TTL_MULTIPLIER if is_negative else self.expiration
+        expiration_date = datetime.now() if expired is True else (datetime.now() - timedelta(days=random.randint(1, ttl_days)))
         with self.connection as connection:
             with closing(connection.cursor()) as cursor:
                 cursor.execute(f"INSERT OR IGNORE INTO {map_name}({val1_name}) VALUES(?)", (val1,))

--- a/modules/convert.py
+++ b/modules/convert.py
@@ -191,22 +191,27 @@ class Convert:
         expired = False
         if self.cache:
             cache_id, expired = self.cache.query_tmdb_to_tvdb_map(tmdb_id, tmdb=True)
-            if cache_id and not expired:
+            if expired is False:  # a cached row exists and hasn't expired, whether it's a real ID or a confirmed no-mapping result
                 return cache_id
+        tvdb_id = None
+        lookup_failed = False
         try:
             tvdb_id = self.tmdb.convert_from(tmdb_id, "tvdb_id", False)
-            if tvdb_id:
-                if self.cache:
-                    self.cache.update_tmdb_to_tvdb_map(expired, tmdb_id, tvdb_id)
-                return tvdb_id
         except Failed:
-            pass
+            lookup_failed = True  # a real API/network error, not a confirmed miss - don't cache this as "no mapping"
+        if tvdb_id:
+            if self.cache:
+                self.cache.update_tmdb_to_tvdb_map(expired, tmdb_id, tvdb_id)
+            return tvdb_id
+        if self.cache and not lookup_failed:
+            self.cache.update_tmdb_to_tvdb_map(expired, tmdb_id, None, is_negative=True)
         if fail:
             raise MappingConvertError(f"Convert Warning: No TVDb ID found for TMDb ID '{tmdb_id}'")
         else:
             return None
 
     def tvdb_to_tmdb(self, tvdb_id, fail=False):
+        # No negative-cache write here: tmdb_to_tvdb_map2 is unique-keyed on tmdb_id, and a failed lookup in this direction never produces one to key against.
         expired = False
         if self.cache:
             cache_id, expired = self.cache.query_tmdb_to_tvdb_map(tvdb_id, tmdb=False)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -169,6 +169,48 @@ class TestLetterboxdMap:
         assert expired is None
 
 
+class TestTmdbToTvdbNegativeCaching:
+    """Confirmed "no TVDb mapping for this TMDb ID" results are cached (NULL tvdb_id) on a longer TTL than normal hits."""
+
+    def test_negative_write_is_queryable_as_hit(self, tmp_path):
+        cache = make_cache(tmp_path, expiration=30)
+        cache.update_tmdb_to_tvdb_map(False, "9999", None, is_negative=True)
+        result, expired = cache.query_tmdb_to_tvdb_map("9999", tmdb=True)
+        assert result is None
+        assert expired is False
+
+    def test_negative_entry_uses_longer_ttl_than_positive(self, tmp_path):
+        cache = make_cache(tmp_path, expiration=10)
+        cache.update_tmdb_to_tvdb_map(False, "8888", None, is_negative=True)
+        # Past the normal 10-day TTL but well within the negative TTL (10 * NEGATIVE_MAP_TTL_MULTIPLIER).
+        stale_for_positive_only = (datetime.now() - timedelta(days=15)).strftime("%Y-%m-%d")
+        with sqlite3.connect(cache.cache_path) as conn:
+            conn.execute("UPDATE tmdb_to_tvdb_map2 SET expiration_date = ? WHERE tmdb_id = ?", (stale_for_positive_only, "8888"))
+        result, expired = cache.query_tmdb_to_tvdb_map("8888", tmdb=True)
+        assert result is None
+        assert expired is False
+
+    def test_negative_entry_eventually_expires(self, tmp_path):
+        cache = make_cache(tmp_path, expiration=10)
+        cache.update_tmdb_to_tvdb_map(False, "7777", None, is_negative=True)
+        long_ago = (datetime.now() - timedelta(days=999)).strftime("%Y-%m-%d")
+        with sqlite3.connect(cache.cache_path) as conn:
+            conn.execute("UPDATE tmdb_to_tvdb_map2 SET expiration_date = ? WHERE tmdb_id = ?", (long_ago, "7777"))
+        result, expired = cache.query_tmdb_to_tvdb_map("7777", tmdb=True)
+        assert result is None
+        assert expired is True
+
+    def test_positive_entry_still_uses_normal_ttl(self, tmp_path):
+        cache = make_cache(tmp_path, expiration=10)
+        cache.update_tmdb_to_tvdb_map(False, "6666", "12345")
+        stale_for_positive = (datetime.now() - timedelta(days=15)).strftime("%Y-%m-%d")
+        with sqlite3.connect(cache.cache_path) as conn:
+            conn.execute("UPDATE tmdb_to_tvdb_map2 SET expiration_date = ? WHERE tmdb_id = ?", (stale_for_positive, "6666"))
+        result, expired = cache.query_tmdb_to_tvdb_map("6666", tmdb=True)
+        assert result == 12345
+        assert expired is True
+
+
 class TestImdbToTmdbMap:
     def test_round_trip(self, tmp_path):
         cache = make_cache(tmp_path)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import modules.builder  # noqa: F401
+from modules.util import Failed
 
 
 class TestConvert:
@@ -36,6 +37,32 @@ class TestConvert:
     def test_tvdb_to_tmdb_cache_hit(self, adapter):
         adapter.cache.query_tmdb_to_tvdb_map.return_value = (550, False)
         assert adapter.tvdb_to_tmdb(368207, fail=False) == 550
+
+    def test_tmdb_to_tvdb_negative_cache_hit(self, adapter):
+        # A cached "confirmed no mapping" row (None value, not expired) must short-circuit without hitting the API.
+        adapter.cache.query_tmdb_to_tvdb_map.return_value = (None, False)
+        assert adapter.tmdb_to_tvdb(550, fail=False) is None
+        adapter.tmdb.convert_from.assert_not_called()
+
+    def test_tmdb_to_tvdb_writes_negative_cache_on_confirmed_miss(self, adapter):
+        # No cached row yet (expired=None); the API call succeeds but returns nothing, so the miss gets cached.
+        adapter.cache.query_tmdb_to_tvdb_map.return_value = (None, None)
+        adapter.tmdb.convert_from.return_value = None
+        assert adapter.tmdb_to_tvdb(550, fail=False) is None
+        adapter.cache.update_tmdb_to_tvdb_map.assert_called_once_with(None, 550, None, is_negative=True)
+
+    def test_tmdb_to_tvdb_does_not_cache_negative_on_api_error(self, adapter):
+        # A network/API error must not be mistaken for a confirmed "no mapping" result.
+        adapter.cache.query_tmdb_to_tvdb_map.return_value = (None, None)
+        adapter.tmdb.convert_from.side_effect = Failed("boom")
+        assert adapter.tmdb_to_tvdb(550, fail=False) is None
+        adapter.cache.update_tmdb_to_tvdb_map.assert_not_called()
+
+    def test_tmdb_to_tvdb_positive_result_not_cached_as_negative(self, adapter):
+        adapter.cache.query_tmdb_to_tvdb_map.return_value = (None, None)
+        adapter.tmdb.convert_from.return_value = 368207
+        assert adapter.tmdb_to_tvdb(550, fail=False) == 368207
+        adapter.cache.update_tmdb_to_tvdb_map.assert_called_once_with(None, 550, 368207)
 
     def test_hama_suffix_extracts_trailing_id(self):
         from modules.convert import Convert


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

`tmdb_to_tvdb` never cached a confirmed "no TVDb mapping" result, so every run re-hit the TMDb API for the same TMDb IDs with no match. This showed up clearly on TV libraries using `tmdb_discover`-based status overlays, where the same batch of TMDb IDs gets re-checked on every overlay pass and every run.

Confirmed misses are now cached in `tmdb_to_tvdb_map2` at 3x `cache_expiration`, long enough to stop the repeat lookups but short enough to notice if TVDb adds a mapping later. Genuine API/network errors are not cached as misses. `tvdb_to_tmdb` is intentionally left unchanged - `tmdb_to_tvdb_map2` is unique-keyed on `tmdb_id`, so a failed reverse lookup has no valid key to cache against.

Tested locally: full test suite (797 tests, including 7 new ones covering the negative-cache hit/write/error-guard/TTL behavior) passes, along with black, isort, and flake8.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No