### PR TITLE
Group missing TMDb collection summary errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix custom `rating<n>_file` (and `git`/`repo`/`url`) overlay images being silently replaced by a built-in `default`/`pmm` asset.
 - Prevent Kometa from creating duplicate collections when Plex search misses an existing same-named collection by falling back to the full collection inventory before creating.
 - Refine the run summary output: group repeated overlay, Letterboxd/TMDb, Plex resolution-regex, Trakt TVDb-miss, and missing local artwork/theme path messages; update the supported-artwork summary wording; normalize asset-directory and logo warning summaries; print overlay and convert summaries in the same `Count | Message` format as warning/error summaries; add a visual divider before the summary intro text; rename the overlay section to `Overlay Summary`; and keep the run-status table hidden when there is no status data to show.
+- Group missing TMDb collection errors into a single end-of-run summary row while preserving each collection ID in the main log.
 - Fix overlay cache poisoning where application state was written for unresolved overlays (e.g. no IMDb rating), causing the item to be permanently skipped even after a rating became available.
 - Fix duplicate rows accumulating in `overlay_special_text2` on every run due to a missing `UNIQUE(rating_key, type)` constraint.
 - Ignore episode logo and square-art files during asset-directory discovery because Plex episodes only support poster and background artwork.

--- a/kometa.py
+++ b/kometa.py
@@ -675,6 +675,10 @@ def start(attrs):
                 (r"Mojo Error: No List Items found in .+", "Mojo Error: No List Items found"),
                 (r"Text File Error: No IDs found at .+", "Text File Error: No IDs found"),
                 (r"Text File Error: No supported IDs found in .+", "Text File Error: No supported IDs found"),
+                (
+                    r"TMDb Error: Collection ID \d+ missing on TMDb; add '\d+' to the franchise exclude list if this is auto-built\.",
+                    "TMDb Error: Collection ID missing on TMDb; add it to the franchise exclude list if this is auto-built",
+                ),
                 (r"TMDb Error: No valid TMDb IDs in .+", "TMDb Error: No valid TMDb IDs"),
                 (r"Trakt Error: No TVDb ID found for .+", "Trakt Error: No TVDb ID found"),
                 (r"Trakt Error: No valid Trakt Lists in .+", "Trakt Error: No valid Trakt Lists"),

--- a/tests/test_kometa.py
+++ b/tests/test_kometa.py
@@ -181,6 +181,13 @@ def test_asset_paths_and_warnings_are_summarized() -> None:
         assert _summarize_log_message(message) == expected
 
 
+def test_missing_tmdb_collections_are_summarized() -> None:
+    """Variable collection IDs should collapse into one summary row."""
+    message = "TMDb Error: Collection ID 1698578 missing on TMDb; add '1698578' to the franchise exclude list if this is auto-built."
+    expected = "TMDb Error: Collection ID missing on TMDb; add it to the franchise exclude list if this is auto-built"
+    assert _summarize_log_message(message) == expected
+
+
 def test_status_summary_skips_empty_tables() -> None:
     """Regression for the run-status table header.
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Groups repeated TMDb missing-collection errors into a single end-of-run summary row by normalizing the variable collection ID. The original messages, including each collection ID, remain available in the main log.

Added a regression test using the reported log message and updated the changelog.
***Screenshot (highlight is what this covers)***
<img width="1358" height="202" alt="Screenshot 2026-07-16 at 12 39 19 PM" src="https://github.com/user-attachments/assets/dc228ea9-44fd-4c8c-8e9e-27ed8785bb5e" />


Validation:
- `black --check kometa.py tests/test_kometa.py` passes.
- `git diff --check` passes.
- A dependency-free execution of the summary grouping helper passes.
- `pytest -q tests/test_kometa.py` could not run in the local environment because the runtime dependency `num2words` is not installed; collection failed before tests executed.

## Related Issues [optional]

Not applicable.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No
