### PR TITLE
fix: append release year to Movies Added report entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extend the `--run-collections` Recommendation Hub sort skip to also cover `--run-files`, which has the same partial-run limitation.
 - Warn and skip `item_edition` edits when Plex Pass is unavailable instead of attempting the edit and surfacing a Plex 403 Forbidden error.
 - Fix the default AU content-rating overlay so the MA15+ badge matches both Plex rating spellings: canonical `au/MA 15+` from explicit TMDb Australian certifications and Plex-derived `au/MA15+` for titles without an AU certification.
+- Fix "Movies Added" report entries missing release year; titles now match the "Movies Missing"/"Movies Removed" format e.g. `The Grapes of Wrath (1939)`.
 
 ### Changed
 

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -4355,7 +4355,7 @@ class CollectionBuilder:
         if self.do_report and items_added:
             self.library.add_additions(
                 self.name,
-                [(i.title, self.library.get_id_from_maps(i.ratingKey)) for i in items_added],
+                [(f"{i.title} ({i.year})" if i.year else i.title, self.library.get_id_from_maps(i.ratingKey)) for i in items_added],
                 self.library.is_movie,
             )
         logger.exorcise()


### PR DESCRIPTION
Fixes #2028.

#2028 reported that the "Movies Added" and "Movies Removed" report
sections list titles without the release year, unlike "Movies Missing".
The "Removed" side was already fixed; the "Added" side still emits bare
titles.

This appends `(year)` when present, matching the other sections, e.g.
`The Grapes of Wrath (1939)`. Falls back to the bare title when `year`
is unset.