### PR TITLE
chore: pwn request ci hardening

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -36,6 +36,8 @@ bafta
 bambara
 bbfc
 bearlikelion
+Beetlejuice
+beetlejuice
 berlinale
 bestest
 bing
@@ -135,6 +137,7 @@ fi
 filepath
 filetype
 filmin
+filmography
 flac
 flixpatrol
 fontawesome

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -474,6 +474,7 @@ unplayed
 unprioritised
 unraid
 unresolvable
+unreviewed
 untyped
 uri
 url

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -22,7 +22,7 @@ jobs:
           private-key: ${{ secrets.APP_TOKEN }}
 
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: nightly

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: nightly
 

--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: develop
 

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: nightly
 

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         if: ${{ github.event_name == 'pull_request' || github.event.inputs.platform == 'all' || github.event.inputs.platform == matrix.platform }}

--- a/.github/workflows/docker-version.yml
+++ b/.github/workflows/docker-version.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -76,7 +76,7 @@ jobs:
           author_icon_url: ${{ vars.DOCKER_IMAGE }}
 
       - name: Checkout Configs Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: Kometa-Team/Community-Configs
           token: ${{ secrets.PAT }}

--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: nightly
@@ -57,7 +57,7 @@ jobs:
           private-key: ${{ secrets.APP_TOKEN }}
 
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: nightly
@@ -131,7 +131,7 @@ jobs:
     steps:
 
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: nightly
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Set up Python
       uses: actions/setup-python@v7

--- a/.github/workflows/promote-fork-pr.yml
+++ b/.github/workflows/promote-fork-pr.yml
@@ -1,0 +1,253 @@
+name: Promote Fork PR
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - synchronize
+      - closed
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: promote-fork-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  promote:
+    name: Create or update internal PR
+
+    # Fork PRs only, gated on the approval label; this job never checks out or executes fork code, only git fetch/push of commit objects and GitHub API calls.
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'internal-test')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # Do not use context.actor/sender here -- on synchronize that's the PR author, not the labeler -- so check the timeline for who last applied internal-test instead.
+      - name: Verify a maintainer applied the current internal-test label
+        id: permission
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const events = await github.paginate(
+              github.rest.issues.listEvents,
+              { owner, repo, issue_number, per_page: 100 }
+            );
+
+            const labelEvents = events.filter(
+              e => e.event === 'labeled' && e.label && e.label.name === 'internal-test'
+            );
+
+            if (labelEvents.length === 0) {
+              core.setFailed('No "labeled: internal-test" event found in PR timeline.');
+              return;
+            }
+
+            const lastLabelEvent = labelEvents[labelEvents.length - 1];
+            const labeler = lastLabelEvent.actor && lastLabelEvent.actor.login;
+
+            if (!labeler) {
+              core.setFailed('Could not determine who applied the internal-test label.');
+              return;
+            }
+
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner,
+              repo,
+              username: labeler
+            });
+
+            const allowed = ['admin', 'maintain', 'write'];
+
+            if (!allowed.includes(data.permission)) {
+              core.setFailed(
+                `Most recent internal-test label was applied by ${labeler}, ` +
+                `who has '${data.permission}' permission; write permission is ` +
+                `required to promote a fork PR.`
+              );
+              return;
+            }
+
+            core.notice(`internal-test label was applied by ${labeler} (${data.permission}) -- OK to promote.`);
+
+      # Use the GitHub App token, not GITHUB_TOKEN, so the created PR/push actually triggers downstream workflows.
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_TOKEN }}
+
+      # This checks out only the trusted base repository/default branch.
+      - name: Check out trusted base repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Copy fork PR commit to internal branch
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          INTERNAL_BRANCH: automation/fork-pr-${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Fetch via the base repo's own refs/pull/<N>/head -- no need to add the fork as a remote.
+          git fetch --no-tags origin \
+            "pull/${PR_NUMBER}/head:refs/remotes/origin/fork-pr-${PR_NUMBER}"
+
+          FETCHED_SHA="$(git rev-parse "refs/remotes/origin/fork-pr-${PR_NUMBER}")"
+
+          # Guard against the PR changing mid-flight: fetched SHA must match the SHA that triggered this run.
+          if [[ "${FETCHED_SHA}" != "${PR_HEAD_SHA}" ]]; then
+            echo "::error::PR changed while the promotion workflow was running."
+            echo "::error::Expected ${PR_HEAD_SHA}, fetched ${FETCHED_SHA}."
+            exit 1
+          fi
+
+          # Copy the commit object only -- never checked out or executed.
+          git push --force origin \
+            "${FETCHED_SHA}:refs/heads/${INTERNAL_BRANCH}"
+
+      - name: Create or update internal pull request
+        uses: actions/github-script@v9
+        env:
+          INTERNAL_BRANCH: automation/fork-pr-${{ github.event.pull_request.number }}
+          SOURCE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          SOURCE_PR_TITLE: ${{ github.event.pull_request.title }}
+          SOURCE_PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          SOURCE_PR_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = process.env.INTERNAL_BRANCH;
+            const sourceNumber = process.env.SOURCE_PR_NUMBER;
+
+            const title = `[Promoted #${sourceNumber}] ${process.env.SOURCE_PR_TITLE}`;
+
+            const body = [
+              `Automated internal copy of #${sourceNumber}.`,
+              ``,
+              `Original author: @${process.env.SOURCE_PR_AUTHOR}`,
+              `Copied commit: \`${process.env.SOURCE_PR_SHA}\``,
+              ``,
+              `This branch is force-updated when the original fork PR changes`,
+              `and a maintainer keeps the \`internal-test\` label applied.`,
+              ``,
+              `The \`docker\`/\`tester\` label is NOT copied automatically --`,
+              `a maintainer must re-add it here after reviewing this exact`,
+              `commit before a build with secrets will run.`,
+              ``,
+              `Do not merge this PR instead of the original contributor PR.`
+            ].join("\n");
+
+            const { data: existing } = await github.rest.pulls.list({
+              owner, repo, state: "open",
+              head: `${owner}:${head}`, base: "nightly"
+            });
+
+            if (existing.length > 0) {
+              await github.rest.pulls.update({
+                owner, repo, pull_number: existing[0].number, title, body
+              });
+              core.notice(`Updated internal PR #${existing[0].number}`);
+            } else {
+              const { data: created } = await github.rest.pulls.create({
+                owner, repo, head, base: "nightly", title, body, draft: true
+              });
+              core.notice(`Created internal PR #${created.number}`);
+            }
+
+      - name: Comment on source pull request
+        uses: actions/github-script@v9
+        env:
+          INTERNAL_BRANCH: automation/fork-pr-${{ github.event.pull_request.number }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const { data: pulls } = await github.rest.pulls.list({
+              owner, repo, state: "open",
+              head: `${owner}:${process.env.INTERNAL_BRANCH}`, base: "nightly"
+            });
+
+            if (pulls.length === 0) {
+              core.setFailed("Internal pull request could not be located.");
+              return;
+            }
+
+            const marker = "<!-- kometa-internal-test-pr -->";
+            const body = [
+              marker,
+              `Internal testing PR: #${pulls[0].number}`,
+              ``,
+              `This PR tracks commit \`${context.payload.pull_request.head.sha}\`.`
+            ].join("\n");
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: context.issue.number, per_page: 100 }
+            );
+
+            const existing = comments.find(
+              c => c.user?.type === "Bot" && c.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: context.issue.number, body });
+            }
+
+  cleanup:
+    name: Remove internal testing branch
+
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_TOKEN }}
+
+      - name: Delete internal branch
+        uses: actions/github-script@v9
+        env:
+          INTERNAL_BRANCH: automation/fork-pr-${{ github.event.pull_request.number }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${process.env.INTERNAL_BRANCH}`
+              });
+            } catch (error) {
+              if (error.status === 422 || error.status === 404) {
+                core.notice("Internal branch did not exist or was already deleted.");
+              } else {
+                throw error;
+              }
+            }

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -11,7 +11,7 @@ jobs:
     name: pyright
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -20,7 +20,7 @@ jobs:
           private-key: ${{ secrets.APP_TOKEN }}
 
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: develop

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -25,7 +25,7 @@ jobs:
           private-key: ${{ secrets.APP_TOKEN }}
 
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: nightly

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # The checkout step
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: rojopolis/spellcheck-github-actions@0.63.0
       name: Spellcheck 

--- a/.github/workflows/tag-new-version.yml
+++ b/.github/workflows/tag-new-version.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.PAT }}
           fetch-depth: 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -78,7 +78,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -151,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -227,7 +227,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -252,7 +252,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -292,7 +292,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -1,13 +1,16 @@
 name: Validate Pull Request
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, labeled]
 
 jobs:
 
   validate-pull:
     runs-on: ubuntu-latest
+    # Read-only: this job only diffs filenames and spellchecks markdown, no secrets needed.
+    permissions:
+      contents: read
     outputs:
       build: ${{ steps.list-changes.outputs.build }}
     steps:
@@ -25,17 +28,17 @@ jobs:
           echo "ERROR: Pull Requests cannot be submitted to master or develop. Please submit the Pull Request to the nightly branch"
           exit 1
 
+      # pull_request (not _target) + default merge-commit ref = no secrets, no fork-checkout trust issue.
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Get changes
         id: get-changes
-        run: | 
-            git remote add -f upstream https://github.com/Kometa-Team/${{ vars.REPO_NAME }}.git
+        # github.repository (not vars.REPO_NAME) because fork-originated pull_request runs get no vars/secrets at all, only the event payload.
+        run: |
+            git remote add -f upstream https://github.com/${{ github.repository }}.git
             git remote update
             if [[ ${{ github.event.action }} == "labeled" ]]; then
                 echo "files<<EOF" >> $GITHUB_OUTPUT
@@ -78,7 +81,11 @@ jobs:
   docker-build-pull:
     runs-on: ubuntu-latest
     needs: [ validate-pull ]
-    if: needs.validate-pull.outputs.build == 'true' && (contains(github.event.pull_request.labels.*.name, 'docker') || contains(github.event.pull_request.labels.*.name, 'tester'))
+    # Same-repo check closes the gap where a stale label let unreviewed synchronize pushes rebuild with secrets; fork PRs now go through promote-fork-pr.yml.
+    if: >-
+      needs.validate-pull.outputs.build == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (contains(github.event.pull_request.labels.*.name, 'docker') || contains(github.event.pull_request.labels.*.name, 'tester'))
     permissions:
       contents: read
       packages: write
@@ -97,12 +104,12 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_TOKEN }}
 
+      # Same-repo guaranteed by the if: above, so checkout by exact SHA is enough, no mutable ref dependency.
       - name: Check Out Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.PAT }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Update VERSION File
         id: update-version


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [X] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

CI only, no change to Kometa itself.

`validate-pull.yml` was still using `pull_request_target` combined with an explicit fork checkout, which `actions/checkout` now blocks outright since GitHub backported protection against this pattern into every released version, not just `v7` as the public changelog claims. This PR removes the exposure instead of just working around the block.

`validate-pull` now triggers on plain `pull_request`, since that job only diffs filenames and spellchecks markdown and never needed secrets. `docker-build-pull` now also requires the PR branch to actually live in `Kometa-Team/Kometa`, closing a separate pre-existing gap where labelling a fork PR once let every later push re-trigger a secrets-bearing Docker build with no further review.

Fork PRs that need a tester image now go through a new `promote-fork-pr.yml`. A maintainer applies `internal-test` to a fork PR, and the workflow copies that exact commit into an internal branch using only `git fetch`/`git push`, never checking out or executing anything from the fork. It checks the PR's label history to confirm a maintainer with write access actually applied the label, and the `docker`/`tester` label has to be separately re-applied on the resulting internal PR before a secrets-bearing build runs.

Also bumped `actions/checkout` from `v6` to `v7` across every workflow in the repo, since `v6` no longer avoids the issue either.

Tested by standing up a throwaway repo and exercising `promote-fork-pr.yml` end to end for real: label applied, PR created; follow-up push, PR updated in place not duplicated; PR closed, internal branch cleaned up and internal PR closed with it.

No CHANGELOG entry included on purpose, to avoid publicly detailing a security fix before it's actually merged.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [ ] Yes
- [X] No
