### PR TITLE
Standardize transient TMDb retry handling

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -31,6 +31,7 @@ atmos
 atres
 avenir
 Babygirl
+backend
 backoff
 bafta
 bambara
@@ -454,6 +455,7 @@ TomatoRotten
 tooltip
 tooltips
 traceback
+tracebacks
 trakt
 trakt's
 transcoded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Treat TMDb connection failures, timeouts, HTTP 408/429/5xx, and backend-unavailable responses as transient service failures: retry discovery, pagination, item requests, and lazy object hydration consistently; emit concise retry warnings instead of tracebacks; and surface exhausted retries as a service-unavailable error.
 - `modules/plex.py`: standardize Plex API retry handling so known 400/404/401 responses and Kometa `Failed` exceptions remain terminal, while exhausted transient retries re-raise their underlying exception instead of becoming opaque `RetryError`; collection move failures also include the item title and original Plex response, and `query_collection`/`get_actor_id` convert terminal Plex responses into contextual Kometa errors.
 - Drop-in replacement for the jikan api
 

--- a/modules/tmdb.py
+++ b/modules/tmdb.py
@@ -142,6 +142,8 @@ def _is_transient_tmdb_exception(exception):
         exception_status = getattr(current, "status_code", None)
         structured_statuses = []
         for status in (response_status, exception_status):
+            if status is None:
+                continue
             try:
                 structured_statuses.append(int(status))
             except (TypeError, ValueError):

--- a/modules/tmdb.py
+++ b/modules/tmdb.py
@@ -2,13 +2,13 @@ import re
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import ConnectTimeout, ReadTimeout, Timeout
-from tenacity import RetryError, retry, retry_if_not_exception_type, stop_after_attempt, wait_fixed
+from tenacity import RetryError, retry, retry_if_exception, stop_after_attempt, wait_fixed
 from tmdbapis import Movie
 from tmdbapis import NotFound as TMDbNotFound
 from tmdbapis import TMDbAPIs, TMDbException
 
 from modules import util
-from modules.util import Failed
+from modules.util import Failed, ServiceError
 
 logger = util.logger
 
@@ -21,6 +21,10 @@ class NotFound(Failed):
     from the library by the franchise default that have since been deleted upstream
     — TMDb now only permits collections for true movie sequels).
     """
+
+
+class Unavailable(ServiceError):
+    """Raised when transient TMDb failures exhaust their retry budget."""
 
 
 int_builders = ["tmdb_airing_today", "tmdb_popular", "tmdb_top_rated", "tmdb_now_playing", "tmdb_on_the_air", "tmdb_trending_daily", "tmdb_trending_weekly", "tmdb_upcoming"]
@@ -102,6 +106,8 @@ discover_all = discover_special + discover_strings + discover_years + discover_b
 discover_monetization_types = ["flatrate", "free", "ads", "rent", "buy"]
 discover_types = {"Documentary": "documentary", "News": "news", "Miniseries": "miniseries", "Reality": "reality", "Scripted": "scripted", "Talk Show": "talk_show", "Video": "video"}
 discover_status = {"Returning Series": "returning", "Planned": "planned", "In Production": "production", "Ended": "ended", "Canceled": "canceled", "Pilot": "pilot"}
+transient_http_status_codes = {408, 429}
+transient_tmdb_status_codes = {9, 24, 25, 43, 46}
 
 
 class TMDbCountry:
@@ -131,6 +137,17 @@ def _is_transient_tmdb_exception(exception):
         if isinstance(current, (RequestsConnectionError, ConnectTimeout, ReadTimeout, Timeout)):
             return True
         message = str(current)
+        response = getattr(current, "response", None)
+        response_status = getattr(response, "status_code", None)
+        exception_status = getattr(current, "status_code", None)
+        http_match = re.search(r"\((\d{3})\s+\[", message)
+        tmdb_match = re.search(r"['\"]?status_code['\"]?\s*:\s*(\d+)\b", message)
+        http_status = int(http_match.group(1)) if http_match else response_status
+        tmdb_status = int(tmdb_match.group(1)) if tmdb_match else exception_status
+        if isinstance(http_status, int) and (http_status in transient_http_status_codes or http_status >= 500):
+            return True
+        if isinstance(tmdb_status, int) and tmdb_status in transient_tmdb_status_codes:
+            return True
         if any(pattern in message for pattern in ("Connection reset by peer", "Connection aborted", "Failed to Connect", "Read timed out", "timed out")):
             return True
         current = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
@@ -138,10 +155,27 @@ def _is_transient_tmdb_exception(exception):
 
 
 def _log_tmdb_exception(tmdb_id, exception):
-    if _is_transient_tmdb_exception(exception):
-        logger.warning(f"TMDb Warning: transient network error for TMDb ID {tmdb_id}: {exception}")
-    else:
+    if not _is_transient_tmdb_exception(exception):
         logger.stacktrace()
+
+
+def _tmdb_retry_warning(retry_state):
+    exception = retry_state.outcome.exception()
+    logger.warning(f"TMDb Warning: transient service error in {retry_state.fn.__name__}; retrying after attempt {retry_state.attempt_number}: {exception}")
+
+
+def _tmdb_retry_exhausted(retry_state):
+    exception = retry_state.outcome.exception()
+    raise Unavailable(f"TMDb Error: Service unavailable after {retry_state.attempt_number} attempts: {exception}") from exception
+
+
+TMDB_RETRY = retry(
+    stop=stop_after_attempt(6),
+    wait=wait_fixed(10),
+    retry=retry_if_exception(_is_transient_tmdb_exception),
+    before_sleep=_tmdb_retry_warning,
+    retry_error_callback=_tmdb_retry_exhausted,
+)
 
 
 class TMDBObj:
@@ -175,21 +209,28 @@ class TMDbMovie(TMDBObj):
             data, expired = self._tmdb.cache.query_tmdb_movie(tmdb_id, self._tmdb.language, self._tmdb.expiration)
         if expired or not data:
             data = self.load_movie()
-        super()._load(data)
-
-        self.original_title = data["original_title"] if isinstance(data, dict) else data.original_title
-        self.release_date = data["release_date"] if isinstance(data, dict) else data.release_date
-        self.studio = data["studio"] if isinstance(data, dict) else data.companies[0].name if data.companies else None
-        self.collection_id = data["collection_id"] if isinstance(data, dict) else data.collection.id if data.collection else None
-        self.collection_name = data["collection_name"] if isinstance(data, dict) else data.collection.name if data.collection else None
-        # tvdb_id is only meaningful for shows; set None here so the attribute
-        # exists on the class and pyright doesn't flag it in convert_from().
-        self.tvdb_id: None = None
+        self._load_data(data)
 
         if self._tmdb.cache and not ignore_cache:
             self._tmdb.cache.update_tmdb_movie(expired, self, self._tmdb.language, self._tmdb.expiration)
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
+    def _load_data(self, data):
+        try:
+            super()._load(data)
+            self.original_title = data["original_title"] if isinstance(data, dict) else data.original_title
+            self.release_date = data["release_date"] if isinstance(data, dict) else data.release_date
+            self.studio = data["studio"] if isinstance(data, dict) else data.companies[0].name if data.companies else None
+            self.collection_id = data["collection_id"] if isinstance(data, dict) else data.collection.id if data.collection else None
+            self.collection_name = data["collection_name"] if isinstance(data, dict) else data.collection.name if data.collection else None
+            # tvdb_id is only meaningful for shows; set None here so the attribute
+            # exists on the class and pyright doesn't flag it in convert_from().
+            self.tvdb_id: None = None
+        except TMDbException as e:
+            _log_tmdb_exception(self.tmdb_id, e)
+            raise
+
+    @TMDB_RETRY
     def load_movie(self):
         try:
             return self._tmdb.TMDb.movie(self.tmdb_id, partial="external_ids,keywords,images")
@@ -209,24 +250,31 @@ class TMDbShow(TMDBObj):
             data, expired = self._tmdb.cache.query_tmdb_show(tmdb_id, self._tmdb.language, self._tmdb.expiration)
         if expired or not data:
             data = self.load_show()
-        super()._load(data)
-
-        self.original_title = data["original_title"] if isinstance(data, dict) else data.original_name
-        self.first_air_date = data["first_air_date"] if isinstance(data, dict) else data.first_air_date
-        self.last_air_date = data["last_air_date"] if isinstance(data, dict) else data.last_air_date
-        self.status = data["status"] if isinstance(data, dict) else data.status
-        self.type = data["type"] if isinstance(data, dict) else data.type
-        self.studio = data["studio"] if isinstance(data, dict) else data.networks[0].name if data.networks else None
-        self.tvdb_id = data["tvdb_id"] if isinstance(data, dict) else data.tvdb_id
-        loop = data.origin_countries if not isinstance(data, dict) else data["countries"].split("|") if data["countries"] else []  # noqa
-        self.countries = [TMDbCountry(c) for c in loop]
-        loop = data.seasons if not isinstance(data, dict) else data["seasons"].split("%|%") if data["seasons"] else []  # noqa
-        self.seasons = [TMDbSeason(s) for s in loop]
+        self._load_data(data)
 
         if self._tmdb.cache and not ignore_cache:
             self._tmdb.cache.update_tmdb_show(expired, self, self._tmdb.language, self._tmdb.expiration)
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
+    def _load_data(self, data):
+        try:
+            super()._load(data)
+            self.original_title = data["original_title"] if isinstance(data, dict) else data.original_name
+            self.first_air_date = data["first_air_date"] if isinstance(data, dict) else data.first_air_date
+            self.last_air_date = data["last_air_date"] if isinstance(data, dict) else data.last_air_date
+            self.status = data["status"] if isinstance(data, dict) else data.status
+            self.type = data["type"] if isinstance(data, dict) else data.type
+            self.studio = data["studio"] if isinstance(data, dict) else data.networks[0].name if data.networks else None
+            self.tvdb_id = data["tvdb_id"] if isinstance(data, dict) else data.tvdb_id
+            loop = data.origin_countries if not isinstance(data, dict) else data["countries"].split("|") if data["countries"] else []  # noqa
+            self.countries = [TMDbCountry(c) for c in loop]
+            loop = data.seasons if not isinstance(data, dict) else data["seasons"].split("%|%") if data["seasons"] else []  # noqa
+            self.seasons = [TMDbSeason(s) for s in loop]
+        except TMDbException as e:
+            _log_tmdb_exception(self.tmdb_id, e)
+            raise
+
+    @TMDB_RETRY
     def load_show(self):
         try:
             return self._tmdb.TMDb.tv_show(self.tmdb_id, partial="external_ids,keywords,images")
@@ -248,21 +296,28 @@ class TMDbEpisode:
             data, expired = self._tmdb.cache.query_tmdb_episode(self.tmdb_id, self.season_number, self.episode_number, self._tmdb.language, self._tmdb.expiration)
         if expired or not data:
             data = self.load_episode()
-
-        self.episode_id = data["episode_id"] if isinstance(data, dict) else data.id
-        self.title = data["title"] if isinstance(data, dict) else data.title
-        self.air_date = data["air_date"] if isinstance(data, dict) else data.air_date
-        self.overview = data["overview"] if isinstance(data, dict) else data.overview
-        self.still_url = data["still_url"] if isinstance(data, dict) else data.still_url
-        self.vote_count = data["vote_count"] if isinstance(data, dict) else data.vote_count
-        self.vote_average = data["vote_average"] if isinstance(data, dict) else data.vote_average
-        self.imdb_id = data["imdb_id"] if isinstance(data, dict) else data.imdb_id
-        self.tvdb_id = data["tvdb_id"] if isinstance(data, dict) else data.tvdb_id
+        self._load_data(data)
 
         if self._tmdb.cache and not ignore_cache:
             self._tmdb.cache.update_tmdb_episode(expired, self, self._tmdb.language, self._tmdb.expiration)
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
+    def _load_data(self, data):
+        try:
+            self.episode_id = data["episode_id"] if isinstance(data, dict) else data.id
+            self.title = data["title"] if isinstance(data, dict) else data.title
+            self.air_date = data["air_date"] if isinstance(data, dict) else data.air_date
+            self.overview = data["overview"] if isinstance(data, dict) else data.overview
+            self.still_url = data["still_url"] if isinstance(data, dict) else data.still_url
+            self.vote_count = data["vote_count"] if isinstance(data, dict) else data.vote_count
+            self.vote_average = data["vote_average"] if isinstance(data, dict) else data.vote_average
+            self.imdb_id = data["imdb_id"] if isinstance(data, dict) else data.imdb_id
+            self.tvdb_id = data["tvdb_id"] if isinstance(data, dict) else data.tvdb_id
+        except TMDbException as e:
+            _log_tmdb_exception(self.tmdb_id, e)
+            raise
+
+    @TMDB_RETRY
     def load_episode(self):
         try:
             return self._tmdb.TMDb.tv_episode(self.tmdb_id, self.season_number, self.episode_number)
@@ -298,7 +353,7 @@ class TMDb:
             raise Failed(f"TMDb Error: No {convert_to.upper().replace('B_', 'b ')} found for TMDb ID {tmdb_id}")
         return check_id
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
     def convert_tvdb_to(self, tvdb_id):
         try:
             results = self.TMDb.find_by_id(tvdb_id=tvdb_id)
@@ -308,7 +363,7 @@ class TMDb:
             pass
         raise Failed(f"TMDb Error: No TMDb ID found for TVDb ID {tvdb_id}")
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
     def convert_imdb_to(self, imdb_id):
         try:
             results = self.TMDb.find_by_id(imdb_id=imdb_id)
@@ -338,7 +393,7 @@ class TMDb:
     def get_movie(self, tmdb_id, ignore_cache=False):
         return TMDbMovie(self, tmdb_id, ignore_cache=ignore_cache)
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
     def get_movie_release_dates(self, tmdb_id):
         try:
             return self.TMDb.movie(tmdb_id, partial="release_dates").release_dates
@@ -351,7 +406,7 @@ class TMDb:
     def get_show(self, tmdb_id, ignore_cache=False):
         return TMDbShow(self, tmdb_id, ignore_cache=ignore_cache)
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
     def get_season(self, tmdb_id, season_number, partial=None):
         try:
             return self.TMDb.tv_season(tmdb_id, season_number, partial=partial)
@@ -395,53 +450,53 @@ class TMDb:
             raise Failed(f"TMDb Error: No Episode found for TMDb Episode ID {episode_id}")
         return episode_map[episode_id]
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
     def get_collection(self, tmdb_id, partial=None):
         try:
             return self.TMDb.collection(tmdb_id, partial=partial)
         except TMDbNotFound as e:
             raise NotFound(f"TMDb Error: No Collection found for TMDb ID {tmdb_id}: {e}")
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
     def get_person(self, tmdb_id, partial=None):
         try:
             return self.TMDb.person(tmdb_id, partial=partial)
         except TMDbNotFound as e:
             raise Failed(f"TMDb Error: No Person found for TMDb ID {tmdb_id}: {e}")
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
     def _company(self, tmdb_id, partial=None):
         try:
             return self.TMDb.company(tmdb_id, partial=partial)
         except TMDbNotFound as e:
             raise Failed(f"TMDb Error: No Company found for TMDb ID {tmdb_id}: {e}")
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
     def _network(self, tmdb_id, partial=None):
         try:
             return self.TMDb.network(tmdb_id, partial=partial)
         except TMDbNotFound as e:
             raise Failed(f"TMDb Error: No Network found for TMDb ID {tmdb_id}: {e}")
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
     def _keyword(self, tmdb_id):
         try:
             return self.TMDb.keyword(tmdb_id)
         except TMDbNotFound as e:
             raise Failed(f"TMDb Error: No Keyword found for TMDb ID {tmdb_id}: {e}")
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
     def get_list(self, tmdb_id):
         try:
             return self.TMDb.list(tmdb_id)
         except TMDbNotFound as e:
             raise Failed(f"TMDb Error: No List found for TMDb ID {tmdb_id}: {e}")
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
     def get_popular_people(self, limit):
         return {str(p.id): p.name for p in self.TMDb.popular_people().get_results(limit)}
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
     def search_people(self, name):
         try:
             return self.TMDb.people_search(name)
@@ -492,7 +547,7 @@ class TMDb:
             self.get_list(tmdb_id)
         return tmdb_id
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
+    @TMDB_RETRY
     def get_items(self, method, data, region, is_movie, result_type):
         if method == "tmdb_popular":
             results = self.TMDb.popular_movies(region=region) if is_movie else self.TMDb.popular_tv()
@@ -509,6 +564,12 @@ class TMDb:
         else:
             results = self.TMDb.trending("movie" if is_movie else "tv", "day" if method == "tmdb_trending_daily" else "week")
         return [(i.id, result_type) for i in results.get_results(data)]
+
+    @TMDB_RETRY
+    def _get_discover_ids(self, attrs, is_movie, result_type, limit):
+        results = self.TMDb.discover_movies(**attrs) if is_movie else self.TMDb.discover_tv_shows(**attrs)
+        amount = results.total_results if limit == 0 or results.total_results < limit else limit
+        return [(i.id, result_type) for i in results.get_results(amount)], amount
 
     def get_tmdb_ids(self, method, data, is_movie, region):
         if not region and self.region:
@@ -539,9 +600,7 @@ class TMDb:
             if is_movie and region and "region" not in attrs:
                 attrs["region"] = region
             logger.trace(f"Params: {attrs}")
-            results = self.TMDb.discover_movies(**attrs) if is_movie else self.TMDb.discover_tv_shows(**attrs)
-            amount = results.total_results if limit == 0 or results.total_results < limit else limit
-            ids = [(i.id, result_type) for i in results.get_results(amount)]
+            ids, amount = self._get_discover_ids(attrs, is_movie, result_type, limit)
             logger.info(f"Processing {pretty}: {amount} {media_type}{'' if amount == 1 else 's'}")
             for attr, value in attrs.items():
                 logger.info(f"           {attr}: {value}")

--- a/modules/tmdb.py
+++ b/modules/tmdb.py
@@ -140,13 +140,19 @@ def _is_transient_tmdb_exception(exception):
         response = getattr(current, "response", None)
         response_status = getattr(response, "status_code", None)
         exception_status = getattr(current, "status_code", None)
-        http_match = re.search(r"\((\d{3})\s+\[", message)
-        tmdb_match = re.search(r"['\"]?status_code['\"]?\s*:\s*(\d+)\b", message)
-        http_status = int(http_match.group(1)) if http_match else response_status
-        tmdb_status = int(tmdb_match.group(1)) if tmdb_match else exception_status
-        if isinstance(http_status, int) and (http_status in transient_http_status_codes or http_status >= 500):
-            return True
-        if isinstance(tmdb_status, int) and tmdb_status in transient_tmdb_status_codes:
+        structured_statuses = []
+        for status in (response_status, exception_status):
+            try:
+                structured_statuses.append(int(status))
+            except (TypeError, ValueError):
+                pass
+        if structured_statuses:
+            statuses = structured_statuses
+        else:
+            http_match = re.search(r"\((\d{3})\s+\[", message)
+            tmdb_match = re.search(r"['\"]?status_code['\"]?\s*:\s*(\d+)\b", message)
+            statuses = [int(match.group(1)) for match in (http_match, tmdb_match) if match]
+        if any(status in transient_http_status_codes or status >= 500 or status in transient_tmdb_status_codes for status in statuses):
             return True
         if any(pattern in message for pattern in ("Connection reset by peer", "Connection aborted", "Failed to Connect", "Read timed out", "timed out")):
             return True
@@ -565,11 +571,14 @@ class TMDb:
             results = self.TMDb.trending("movie" if is_movie else "tv", "day" if method == "tmdb_trending_daily" else "week")
         return [(i.id, result_type) for i in results.get_results(data)]
 
-    @TMDB_RETRY
     def _get_discover_ids(self, attrs, is_movie, result_type, limit):
         results = self.TMDb.discover_movies(**attrs) if is_movie else self.TMDb.discover_tv_shows(**attrs)
         amount = results.total_results if limit == 0 or results.total_results < limit else limit
-        return [(i.id, result_type) for i in results.get_results(amount)], amount
+        return self._get_discover_results(results, amount, result_type), amount
+
+    @TMDB_RETRY
+    def _get_discover_results(self, results, amount, result_type):
+        return [(i.id, result_type) for i in results.get_results(amount)]
 
     def get_tmdb_ids(self, method, data, is_movie, region):
         if not region and self.region:

--- a/tests/test_tmdb.py
+++ b/tests/test_tmdb.py
@@ -2,11 +2,11 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-from tenacity import RetryError
+from tenacity import RetryError, wait_none
 from tmdbapis import NotFound as TMDbApiNotFound
 
 from modules import tmdb
-from modules.util import Failed
+from modules.util import Failed, ServiceError
 
 
 def _bare_tmdb(monkeypatch):
@@ -35,6 +35,139 @@ def _episode(episode_id, season_number, episode_number, vote_average):
 def test_notfound_is_failed_subclass():
     # Callers that keep catching every TMDb failure as Failed must still work.
     assert issubclass(tmdb.NotFound, Failed)
+
+
+def test_unavailable_is_service_error_subclass():
+    assert issubclass(tmdb.Unavailable, ServiceError)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "(502 [Bad Gateway]) {'status_code': 43, 'status_message': \"Couldn't connect to the backend server.\"}",
+        "(408 [Request Timeout]) {'status_code': 24}",
+        "(429 [Too Many Requests]) {'status_code': 25}",
+        "(503 [Service Unavailable]) {'status_code': 9}",
+        "{'status_code': 46, 'status_message': 'The API is undergoing maintenance.'}",
+    ],
+)
+def test_tmdb_service_failures_are_transient(message):
+    assert tmdb._is_transient_tmdb_exception(tmdb.TMDbException(message))
+
+
+def test_tmdb_404_is_not_transient():
+    assert not tmdb._is_transient_tmdb_exception(tmdb.TMDbException("(404 [Not Found]) {'status_code': 34}"))
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        tmdb.TMDbException("(502 [Bad Gateway]) {'status_code': 43}"),
+        tmdb.TMDbException("(429 [Too Many Requests]) {'status_code': 25}"),
+        tmdb.ReadTimeout("TMDb request timed out"),
+    ],
+)
+def test_discover_retries_transient_service_errors_without_traceback(monkeypatch, error):
+    t = _bare_tmdb(monkeypatch)
+    logger = tmdb.logger
+    results = SimpleNamespace(total_results=2, get_results=MagicMock(return_value=[SimpleNamespace(id=10), SimpleNamespace(id=20)]))
+    discover = MagicMock(side_effect=[error, results])
+    t.TMDb = SimpleNamespace(discover_tv_shows=discover)
+    monkeypatch.setattr(tmdb.TMDb._get_discover_ids.retry, "wait", wait_none())
+
+    ids, amount = t._get_discover_ids({"watch_region": "US"}, False, "tmdb_show", 0)
+
+    assert ids == [(10, "tmdb_show"), (20, "tmdb_show")]
+    assert amount == 2
+    assert discover.call_count == 2
+    assert len(logger.warning_messages) == 1
+    assert "transient service error" in logger.warning_messages[0]
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        tmdb.TMDbException("(401 [Unauthorized]) {'status_code': 7}"),
+        tmdb.TMDbException("(404 [Not Found]) {'status_code': 34}"),
+        Failed("terminal Kometa failure"),
+        TypeError("programming error"),
+    ],
+)
+def test_discover_does_not_retry_terminal_errors(monkeypatch, error):
+    t = _bare_tmdb(monkeypatch)
+    discover = MagicMock(side_effect=error)
+    t.TMDb = SimpleNamespace(discover_tv_shows=discover)
+    monkeypatch.setattr(tmdb.TMDb._get_discover_ids.retry, "wait", wait_none())
+
+    with pytest.raises(type(error)) as excinfo:
+        t._get_discover_ids({}, False, "tmdb_show", 0)
+
+    assert str(excinfo.value) == str(error)
+    discover.assert_called_once_with()
+
+
+def test_discover_exhaustion_becomes_service_unavailable(monkeypatch):
+    t = _bare_tmdb(monkeypatch)
+    discover = MagicMock(side_effect=tmdb.TMDbException("(502 [Bad Gateway]) {'status_code': 43}"))
+    t.TMDb = SimpleNamespace(discover_tv_shows=discover)
+    monkeypatch.setattr(tmdb.TMDb._get_discover_ids.retry, "wait", wait_none())
+
+    with pytest.raises(tmdb.Unavailable, match="Service unavailable after 6 attempts"):
+        t._get_discover_ids({}, False, "tmdb_show", 0)
+
+    assert discover.call_count == 6
+
+
+def test_show_hydration_retries_lazy_transient_502(monkeypatch):
+    t = _bare_tmdb(monkeypatch)
+    logger = MagicMock()
+    monkeypatch.setattr(tmdb, "logger", logger)
+    t.cache = None
+    t.language = "en"
+    t.expiration = 30
+
+    class FlakyShow:
+        title = "Test Show"
+        tagline = ""
+        overview = ""
+        imdb_id = "tt123"
+        poster_url = None
+        backdrop_url = None
+        logos = []
+        vote_average = 8.0
+        original_language = SimpleNamespace(iso_639_1="en", english_name="English")
+        genres = []
+        keywords = []
+        original_name = "Test Show"
+        first_air_date = None
+        last_air_date = None
+        status = "Returning Series"
+        type = "Scripted"
+        networks = []
+        tvdb_id = 123
+        origin_countries = []
+        seasons = []
+
+        def __init__(self):
+            self.vote_count_calls = 0
+
+        @property
+        def vote_count(self):
+            self.vote_count_calls += 1
+            if self.vote_count_calls == 1:
+                raise tmdb.TMDbException("(502 [Bad Gateway]) {'status_code': 43}")
+            return 10
+
+    data = FlakyShow()
+    t.TMDb = SimpleNamespace(tv_show=MagicMock(return_value=data))
+    monkeypatch.setattr(tmdb.TMDbShow._load_data.retry, "wait", wait_none())
+
+    show = tmdb.TMDbShow(t, 500)
+
+    assert show.vote_count == 10
+    assert data.vote_count_calls == 2
+    logger.warning.assert_called_once()
+    logger.stacktrace.assert_not_called()
 
 
 def test_get_collection_raises_notfound_for_deleted_collection(monkeypatch):

--- a/tests/test_tmdb.py
+++ b/tests/test_tmdb.py
@@ -59,6 +59,19 @@ def test_tmdb_404_is_not_transient():
     assert not tmdb._is_transient_tmdb_exception(tmdb.TMDbException("(404 [Not Found]) {'status_code': 34}"))
 
 
+def test_structured_status_takes_precedence_over_message_status():
+    response_error = Exception("(502 [Bad Gateway]) {'status_code': 43}")
+    response_error.response = SimpleNamespace(status_code=404)
+    exception_error = Exception("(502 [Bad Gateway]) {'status_code': 43}")
+    exception_error.status_code = 404
+    transient_error = Exception("(404 [Not Found]) {'status_code': 34}")
+    transient_error.response = SimpleNamespace(status_code=502)
+
+    assert not tmdb._is_transient_tmdb_exception(response_error)
+    assert not tmdb._is_transient_tmdb_exception(exception_error)
+    assert tmdb._is_transient_tmdb_exception(transient_error)
+
+
 @pytest.mark.parametrize(
     "error",
     [
@@ -70,16 +83,17 @@ def test_tmdb_404_is_not_transient():
 def test_discover_retries_transient_service_errors_without_traceback(monkeypatch, error):
     t = _bare_tmdb(monkeypatch)
     logger = tmdb.logger
-    results = SimpleNamespace(total_results=2, get_results=MagicMock(return_value=[SimpleNamespace(id=10), SimpleNamespace(id=20)]))
-    discover = MagicMock(side_effect=[error, results])
+    results = SimpleNamespace(total_results=2, get_results=MagicMock(side_effect=[error, [SimpleNamespace(id=10), SimpleNamespace(id=20)]]))
+    discover = MagicMock(return_value=results)
     t.TMDb = SimpleNamespace(discover_tv_shows=discover)
-    monkeypatch.setattr(tmdb.TMDb._get_discover_ids.retry, "wait", wait_none())
+    monkeypatch.setattr(tmdb.TMDb._get_discover_results.retry, "wait", wait_none())
 
     ids, amount = t._get_discover_ids({"watch_region": "US"}, False, "tmdb_show", 0)
 
     assert ids == [(10, "tmdb_show"), (20, "tmdb_show")]
     assert amount == 2
-    assert discover.call_count == 2
+    discover.assert_called_once_with(watch_region="US")
+    assert results.get_results.call_count == 2
     assert len(logger.warning_messages) == 1
     assert "transient service error" in logger.warning_messages[0]
 
@@ -95,27 +109,31 @@ def test_discover_retries_transient_service_errors_without_traceback(monkeypatch
 )
 def test_discover_does_not_retry_terminal_errors(monkeypatch, error):
     t = _bare_tmdb(monkeypatch)
-    discover = MagicMock(side_effect=error)
+    results = SimpleNamespace(total_results=2, get_results=MagicMock(side_effect=error))
+    discover = MagicMock(return_value=results)
     t.TMDb = SimpleNamespace(discover_tv_shows=discover)
-    monkeypatch.setattr(tmdb.TMDb._get_discover_ids.retry, "wait", wait_none())
+    monkeypatch.setattr(tmdb.TMDb._get_discover_results.retry, "wait", wait_none())
 
     with pytest.raises(type(error)) as excinfo:
         t._get_discover_ids({}, False, "tmdb_show", 0)
 
     assert str(excinfo.value) == str(error)
     discover.assert_called_once_with()
+    results.get_results.assert_called_once_with(2)
 
 
 def test_discover_exhaustion_becomes_service_unavailable(monkeypatch):
     t = _bare_tmdb(monkeypatch)
-    discover = MagicMock(side_effect=tmdb.TMDbException("(502 [Bad Gateway]) {'status_code': 43}"))
+    results = SimpleNamespace(total_results=2, get_results=MagicMock(side_effect=tmdb.TMDbException("(502 [Bad Gateway]) {'status_code': 43}")))
+    discover = MagicMock(return_value=results)
     t.TMDb = SimpleNamespace(discover_tv_shows=discover)
-    monkeypatch.setattr(tmdb.TMDb._get_discover_ids.retry, "wait", wait_none())
+    monkeypatch.setattr(tmdb.TMDb._get_discover_results.retry, "wait", wait_none())
 
     with pytest.raises(tmdb.Unavailable, match="Service unavailable after 6 attempts"):
         t._get_discover_ids({}, False, "tmdb_show", 0)
 
-    assert discover.call_count == 6
+    discover.assert_called_once_with()
+    assert results.get_results.call_count == 6
 
 
 def test_show_hydration_retries_lazy_transient_502(monkeypatch):


### PR DESCRIPTION
<!--
Thank you for contributing to Kometa! Please complete the sections below so that your pull request can be reviewed efficiently.
-->

## What type of PR is this?

<!-- Check all that apply. -->

- [X] Bug Fix
- [ ] Feature/Tweak
- [ ] Refactor
- [ ] Documentation Update
- [ ] Build or CI Change
- [ ] Other

## Description

Standardizes handling of transient TMDb failures. The original trigger was a `(502 [Bad Gateway])` response with TMDb status code `43` during the `ITVX Shows` collection, which escaped as an unknown error and produced repeated tracebacks.

### Retry classification

| Condition | Behavior |
|:--|:--|
| Connection errors and timeouts | Retry up to six attempts |
| HTTP `408`, `429`, and `5xx` responses | Retry up to six attempts |
| TMDb service codes `9`, `24`, `25`, `43`, and `46` | Retry up to six attempts |
| HTTP `401`/`404`, Kometa `Failed`, and programming exceptions | Terminal; do not retry |
| Transient failure after all attempts | Raise `Unavailable`, categorized as a `ServiceError` |

Structured `response.status_code` and exception `status_code` attributes take precedence over regex parsing of exception messages.

### Affected request paths

| Path | Change |
|:--|:--|
| Existing TMDb request wrappers | Use the shared transient-failure policy |
| Discovery pagination | Construct the discovery object once and retry only `get_results`, preserving its page cache across attempts |
| Lazy movie, show, and episode hydration | Keep property-triggered API calls inside the retry boundary |

After retries are exhausted, the collection runner records a Service Error instead of reporting a generic unknown error with a traceback.

### Testing

| Validation | Result |
|:--|:--|
| Regression coverage | Added for structured-status precedence, transient and terminal failures, pagination reuse, discovery recovery/exhaustion, and lazy hydration |
| Pyright baseline | Passed: 5 baseline errors, 5 current errors, no regressions |
| Black | Passed |
| `git diff --check` | Passed |
| Focused pytest | Not run locally because the host lacks the pinned runtime dependencies and dependency installation was unavailable |

## Related Issues [optional]

<!-- Link any related issues here, for example: Fixes #1234. -->

None.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No
