### PR TITLE
Limit repeated empty TVDb retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Treat TMDb connection failures, timeouts, HTTP 408/429/5xx, and backend-unavailable responses as transient service failures: retry discovery, pagination, item requests, and lazy object hydration consistently; emit concise retry warnings instead of tracebacks; and surface exhausted retries as a service-unavailable error.
-- Add the affected URL and HTTP status to exhausted empty TVDb response warnings; limit empty documents to three attempts while retaining six attempts for other transient failures; and open a run-scoped circuit after two distinct URLs exhaust retries so a systemic TVDb outage does not generate thousands of requests and hours of retry delays.
+- Add the affected URL and HTTP status to exhausted empty TVDb response warnings; limit empty documents to three attempts with short exponential delays while retaining six attempts and the existing delay for other transient failures; and open a run-scoped circuit after two distinct URLs exhaust retries so a systemic TVDb outage does not generate thousands of requests and hours of retry delays.
 - `modules/plex.py`: standardize Plex API retry handling so known 400/404/401 responses and Kometa `Failed` exceptions remain terminal, while exhausted transient retries re-raise their underlying exception instead of becoming opaque `RetryError`; collection move failures also include the item title and original Plex response, and `query_collection`/`get_actor_id` convert terminal Plex responses into contextual Kometa errors.
 - Drop-in replacement for the jikan api
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Treat TMDb connection failures, timeouts, HTTP 408/429/5xx, and backend-unavailable responses as transient service failures: retry discovery, pagination, item requests, and lazy object hydration consistently; emit concise retry warnings instead of tracebacks; and surface exhausted retries as a service-unavailable error.
+- Add the affected URL and HTTP status to exhausted empty TVDb response warnings; limit empty documents to three attempts while retaining six attempts for other transient failures; and open a run-scoped circuit after two distinct URLs exhaust retries so a systemic TVDb outage does not generate thousands of requests and hours of retry delays.
 - `modules/plex.py`: standardize Plex API retry handling so known 400/404/401 responses and Kometa `Failed` exceptions remain terminal, while exhausted transient retries re-raise their underlying exception instead of becoming opaque `RetryError`; collection move failures also include the item title and original Plex response, and `query_collection`/`get_actor_id` convert terminal Plex responses into contextual Kometa errors.
 - Drop-in replacement for the jikan api
 

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1771,6 +1771,8 @@ class CollectionBuilder:
                 self.summaries[method_name] = self.config.TVDb.get_tvdb_obj(method_data, is_movie=self.library.is_movie).summary
             except tvdb.NotFound as e:
                 logger.debug(e)
+            except tvdb.CircuitOpen:
+                pass
             except tvdb.Unavailable as e:
                 logger.warning(e)
         elif method_name == "tvdb_description":
@@ -1810,6 +1812,8 @@ class CollectionBuilder:
                 self.posters[method_name] = f"{self.config.TVDb.get_tvdb_obj(method_data, is_movie=self.library.is_movie).poster_url}"
             except tvdb.NotFound as e:
                 logger.debug(e)
+            except tvdb.CircuitOpen:
+                pass
             except tvdb.Unavailable as e:
                 logger.warning(e)
         elif method_name == "file_poster":
@@ -1832,6 +1836,8 @@ class CollectionBuilder:
                 self.posters[method_name] = f"{self.config.TVDb.get_tvdb_obj(method_data, is_movie=self.library.is_movie).background_url}"
             except tvdb.NotFound as e:
                 logger.debug(e)
+            except tvdb.CircuitOpen:
+                pass
             except tvdb.Unavailable as e:
                 logger.warning(e)
         elif method_name == "file_background":
@@ -3436,6 +3442,8 @@ class CollectionBuilder:
                         self.posters[method_name] = item.poster_url
                 except tvdb.NotFound as e:
                     logger.debug(e)
+                except tvdb.CircuitOpen:
+                    pass
                 except tvdb.Unavailable as e:
                     logger.warning(e)
             elif method_name.startswith("tvdb_list"):
@@ -4518,6 +4526,8 @@ class CollectionBuilder:
                             except tvdb.NotFound as e:
                                 logger.debug(e)
                                 or_result = False
+                            except tvdb.CircuitOpen:
+                                or_result = False
                             except tvdb.Unavailable as e:
                                 logger.warning(e)
                                 or_result = False
@@ -4664,6 +4674,8 @@ class CollectionBuilder:
                     # TVDb ID is stale (e.g. TMDb still points at a series TVDb no longer has); not user-actionable, log quietly
                     logger.debug(e)
                     continue
+                except tvdb.CircuitOpen:
+                    break
                 except tvdb.Unavailable as e:
                     # TVDb didn't return usable content in time; not a confirmed absence, may resolve on a later run
                     logger.warning(e)
@@ -5398,6 +5410,8 @@ class CollectionBuilder:
                     except tvdb.NotFound as e:
                         logger.debug(e)
                         continue
+                    except tvdb.CircuitOpen:
+                        break
                     except tvdb.Unavailable as e:
                         logger.warning(e)
                         continue

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -339,6 +339,8 @@ class Operations:
                                 _tvdb_obj = self.config.TVDb.get_tvdb_obj(item_tvdb_id, is_movie=self.library.is_movie)
                             except tvdb.NotFound as err:
                                 logger.debug(str(err))
+                            except tvdb.CircuitOpen:
+                                pass
                             except tvdb.Unavailable as err:
                                 logger.warning(str(err))
                             except Failed as err:

--- a/modules/tvdb.py
+++ b/modules/tvdb.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from lxml import html
 from lxml.etree import ParserError
 from requests.exceptions import MissingSchema
-from tenacity import retry, retry_if_not_exception_type, wait_fixed
+from tenacity import retry, retry_if_not_exception_type, wait_exponential, wait_fixed
 
 from modules import util
 from modules.util import Failed
@@ -41,12 +41,20 @@ class TVDbEmptyResponse(Exception):
 empty_response_attempts = 3
 empty_response_circuit_threshold = 2
 default_attempts = 6
+empty_response_wait = wait_exponential(multiplier=1, min=1, max=8)
+default_wait = wait_fixed(10)
 
 
 def _tvdb_stop(retry_state):
     """Use a smaller retry budget for empty documents than other transient failures."""
     attempts = empty_response_attempts if isinstance(retry_state.outcome.exception(), TVDbEmptyResponse) else default_attempts
     return retry_state.attempt_number >= attempts
+
+
+def _tvdb_wait(retry_state):
+    """Back off quickly for empty documents while preserving the existing delay for other transient failures."""
+    wait = empty_response_wait if isinstance(retry_state.outcome.exception(), TVDbEmptyResponse) else default_wait
+    return wait(retry_state)
 
 
 def _tvdb_retry_exhausted(retry_state):
@@ -353,7 +361,7 @@ class TVDb:
         tvdb_id, _, _ = self.get_id_from_url(tvdb_url, is_movie=is_movie)
         return TVDbObj(self, tvdb_id, is_movie=is_movie)
 
-    @retry(stop=_tvdb_stop, wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed), retry_error_callback=_tvdb_retry_exhausted)
+    @retry(stop=_tvdb_stop, wait=_tvdb_wait, retry=retry_if_not_exception_type(Failed), retry_error_callback=_tvdb_retry_exhausted)
     def get_request(self, tvdb_url):
         if self._empty_response_circuit_open:
             raise CircuitOpen(f"TVDb Error: Skipping TVDb requests for the remainder of this run after {self._empty_response_failures} distinct URLs exhausted empty-response retries")

--- a/modules/tvdb.py
+++ b/modules/tvdb.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from lxml import html
 from lxml.etree import ParserError
 from requests.exceptions import MissingSchema
-from tenacity import retry, retry_if_not_exception_type, stop_after_attempt, wait_fixed
+from tenacity import retry, retry_if_not_exception_type, wait_fixed
 
 from modules import util
 from modules.util import Failed
@@ -21,13 +21,49 @@ class Unavailable(Failed):
     """Raised when TVDb never returned usable content after retries were exhausted (e.g. repeated 202/empty-body); not a confirmed absence like NotFound."""
 
 
+class CircuitOpen(Unavailable):
+    """Raised without making a request after repeated empty TVDb responses indicate a systemic outage."""
+
+
 class TVDbServerError(Exception):
     """Raised for 5xx responses from TVDb; not a Failed subclass so tenacity's retry_if_not_exception_type(Failed) will retry it."""
 
 
+class TVDbEmptyResponse(Exception):
+    """Raised when TVDb returns a successful HTTP status with no document to parse."""
+
+    def __init__(self, url, status_code):
+        self.url = url
+        self.status_code = status_code
+        super().__init__(f"empty document from {url} (HTTP {status_code})")
+
+
+empty_response_attempts = 3
+empty_response_circuit_threshold = 2
+default_attempts = 6
+
+
+def _tvdb_stop(retry_state):
+    """Use a smaller retry budget for empty documents than other transient failures."""
+    attempts = empty_response_attempts if isinstance(retry_state.outcome.exception(), TVDbEmptyResponse) else default_attempts
+    return retry_state.attempt_number >= attempts
+
+
 def _tvdb_retry_exhausted(retry_state):
     """Convert an exhausted TVDb retry loop (5xx, or repeated unparsable 202/empty responses) into Unavailable."""
-    raise Unavailable(f"TVDb Error: No usable response from TVDb after {retry_state.attempt_number} attempt(s): {retry_state.outcome.exception()}") from retry_state.outcome.exception()
+    exception = retry_state.outcome.exception()
+    tvdb = retry_state.args[0]
+    circuit_message = ""
+    if isinstance(exception, TVDbEmptyResponse):
+        tvdb._empty_response_urls.add(exception.url)
+        tvdb._empty_response_failures = len(tvdb._empty_response_urls)
+        if tvdb._empty_response_failures >= empty_response_circuit_threshold:
+            tvdb._empty_response_circuit_open = True
+            circuit_message = f"; circuit opened after {tvdb._empty_response_failures} distinct URLs exhausted empty-response retries"
+    else:
+        tvdb._empty_response_urls.clear()
+        tvdb._empty_response_failures = 0
+    raise Unavailable(f"TVDb Error: No usable response from TVDb after {retry_state.attempt_number} attempt(s): {exception}{circuit_message}") from exception
 
 
 builders = ["tvdb_list", "tvdb_list_details", "tvdb_movie", "tvdb_movie_details", "tvdb_show", "tvdb_show_details"]
@@ -309,19 +345,32 @@ class TVDb:
         self.cache = cache
         self.language = tvdb_language
         self.expiration = expiration
+        self._empty_response_failures = 0
+        self._empty_response_urls = set()
+        self._empty_response_circuit_open = False
 
     def get_tvdb_obj(self, tvdb_url, is_movie=False):
         tvdb_id, _, _ = self.get_id_from_url(tvdb_url, is_movie=is_movie)
         return TVDbObj(self, tvdb_id, is_movie=is_movie)
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed), retry_error_callback=_tvdb_retry_exhausted)
+    @retry(stop=_tvdb_stop, wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed), retry_error_callback=_tvdb_retry_exhausted)
     def get_request(self, tvdb_url):
+        if self._empty_response_circuit_open:
+            raise CircuitOpen(f"TVDb Error: Skipping TVDb requests for the remainder of this run after {self._empty_response_failures} distinct URLs exhausted empty-response retries")
+        if tvdb_url in self._empty_response_urls:
+            raise Unavailable(f"TVDb Error: Skipping {tvdb_url} because it already exhausted empty-response retries during this run")
         response = self.requests.get(tvdb_url, language=self.language)
         if response.status_code >= 400:
+            self._empty_response_urls.clear()
+            self._empty_response_failures = 0
             # 4xx = definitive "gone" (NotFound); 5xx = transient (TVDbServerError, retried by tenacity)
             if 400 <= response.status_code < 500:
                 raise NotFound(f"({response.status_code}) {response.reason}")
             raise TVDbServerError(f"({response.status_code}) {response.reason}")
+        if not response.content:
+            raise TVDbEmptyResponse(tvdb_url, response.status_code)
+        self._empty_response_urls.clear()
+        self._empty_response_failures = 0
         return html.fromstring(response.content)
 
     def get_id_from_url(self, tvdb_url, is_movie=False, ignore_cache=False):
@@ -347,6 +396,8 @@ class TVDb:
         logger.trace(f"URL: {tvdb_url}")
         try:
             response = self.get_request(tvdb_url)
+        except Unavailable:
+            raise
         except (ParserError, Failed, TVDbServerError):
             raise Failed(f"TVDb Error: Failed not parse {tvdb_url}")
         results = response.xpath(f"//*[text()='TheTVDB.com {media_type} ID']/parent::node()/span/text()")

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -93,6 +93,7 @@ def make_builder(**attrs) -> CollectionBuilder:
         "libraries": [],
         "ignore_imdb_ids": [],
         "ignore_ids": [],
+        "missing_movies": [],
         "missing_parts": [],
         "missing_shows": [],
         "do_missing": True,

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -397,6 +397,32 @@ class TestTmdbLookupResilience:
 
 
 # ═══════════════════════════════════════════════════════════════════════
+# TVDb outage resilience
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestTvdbOutageResilience:
+    def test_run_missing_stops_after_tvdb_circuit_opens(self, monkeypatch):
+        logger = FakeLogger()
+        monkeypatch.setattr(builder_module, "logger", logger)
+        get_tvdb_obj = MagicMock(side_effect=builder_module.tvdb.CircuitOpen("TVDb circuit open"))
+        library = SimpleNamespace(is_movie=False, is_show=True, Sonarr=None)
+        builder = make_builder(
+            library=library,
+            config=SimpleNamespace(TVDb=SimpleNamespace(get_tvdb_obj=get_tvdb_obj)),
+            is_playlist=False,
+            missing_shows=[1, 2, 3],
+            details={"show_missing": False, "show_filtered": False, "missing_only_released": False},
+            run_again=False,
+        )
+
+        builder.run_missing()
+
+        get_tvdb_obj.assert_called_once_with(1)
+        assert logger.warning_messages == []
+
+
+# ═══════════════════════════════════════════════════════════════════════
 # delete
 # ═══════════════════════════════════════════════════════════════════════
 

--- a/tests/test_tvdb.py
+++ b/tests/test_tvdb.py
@@ -114,7 +114,8 @@ def test_usable_response_resets_empty_response_streak(monkeypatch):
     assert t._empty_response_circuit_open is False
 
 
-def test_circuit_open_propagates_from_url_lookup():
+def test_circuit_open_propagates_from_url_lookup(monkeypatch):
+    monkeypatch.setattr(tvdb, "logger", MagicMock())
     t = _make_tvdb(200)
     t._empty_response_failures = tvdb.empty_response_circuit_threshold
     t._empty_response_circuit_open = True

--- a/tests/test_tvdb.py
+++ b/tests/test_tvdb.py
@@ -1,19 +1,21 @@
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
+from tenacity import wait_none
 
 from modules import tvdb
 from modules.util import Failed
 
 
-def _make_tvdb(response_status):
+def _make_tvdb(response_status, content=b"<html></html>"):
     """Build a TVDb instance whose underlying requests.get returns the chosen status."""
     fake_response = SimpleNamespace(
         status_code=response_status,
         reason="Mocked",
-        content=b"<html></html>",
+        content=content,
     )
-    fake_requests = SimpleNamespace(get=lambda url, language=None: fake_response)
+    fake_requests = SimpleNamespace(get=MagicMock(return_value=fake_response))
     return tvdb.TVDb(requests=fake_requests, cache=None, tvdb_language="eng", expiration=60)
 
 
@@ -36,6 +38,7 @@ def test_get_request_raises_failed_on_5xx(monkeypatch):
         t.get_request("https://www.thetvdb.com/dereferrer/series/81189")
     # Must not be the NotFound subclass — 5xx is treated as transient.
     assert not isinstance(excinfo.value, tvdb.NotFound)
+    assert t.requests.get.call_count == 6
 
 
 def test_tvdbobj_init_propagates_notfound_for_stale_id():
@@ -44,3 +47,79 @@ def test_tvdbobj_init_propagates_notfound_for_stale_id():
         tvdb.TVDbObj(t, 463160, is_movie=False, ignore_cache=True)
     assert "463160" in str(excinfo.value)
     assert "No Series found" in str(excinfo.value)
+
+
+def test_empty_response_exhaustion_includes_url_and_status(monkeypatch):
+    url = "https://www.thetvdb.com/dereferrer/series/81189"
+    t = _make_tvdb(202, content=b"")
+    monkeypatch.setattr(tvdb.TVDb.get_request.retry, "wait", wait_none())
+
+    with pytest.raises(tvdb.Unavailable) as excinfo:
+        t.get_request(url)
+
+    assert url in str(excinfo.value)
+    assert "HTTP 202" in str(excinfo.value)
+    assert "after 3 attempt(s)" in str(excinfo.value)
+    assert t.requests.get.call_count == 3
+    assert t._empty_response_failures == 1
+    assert t._empty_response_circuit_open is False
+
+
+def test_two_distinct_exhausted_empty_responses_open_circuit(monkeypatch):
+    t = _make_tvdb(200, content=b"")
+    monkeypatch.setattr(tvdb.TVDb.get_request.retry, "wait", wait_none())
+
+    with pytest.raises(tvdb.Unavailable, match="empty document"):
+        t.get_request("https://www.thetvdb.com/dereferrer/series/1")
+
+    with pytest.raises(tvdb.Unavailable, match="circuit opened after 2 distinct URLs"):
+        t.get_request("https://www.thetvdb.com/dereferrer/series/2")
+
+    assert t.requests.get.call_count == 6
+    assert t._empty_response_circuit_open is True
+
+    with pytest.raises(tvdb.CircuitOpen, match="remainder of this run"):
+        t.get_request("https://www.thetvdb.com/dereferrer/series/3")
+
+    assert t.requests.get.call_count == 6
+
+
+def test_exhausted_empty_url_fails_fast_when_repeated(monkeypatch):
+    url = "https://www.thetvdb.com/dereferrer/series/1"
+    t = _make_tvdb(200, content=b"")
+    monkeypatch.setattr(tvdb.TVDb.get_request.retry, "wait", wait_none())
+
+    with pytest.raises(tvdb.Unavailable, match="empty document"):
+        t.get_request(url)
+    with pytest.raises(tvdb.Unavailable, match="already exhausted"):
+        t.get_request(url)
+
+    assert t.requests.get.call_count == 3
+    assert t._empty_response_failures == 1
+    assert t._empty_response_circuit_open is False
+
+
+def test_usable_response_resets_empty_response_streak(monkeypatch):
+    t = _make_tvdb(202, content=b"")
+    usable_response = SimpleNamespace(status_code=200, reason="OK", content=b"<html></html>")
+    t.requests.get.side_effect = [t.requests.get.return_value] * 3 + [usable_response]
+    monkeypatch.setattr(tvdb.TVDb.get_request.retry, "wait", wait_none())
+
+    with pytest.raises(tvdb.Unavailable):
+        t.get_request("https://www.thetvdb.com/dereferrer/series/1")
+
+    t.get_request("https://www.thetvdb.com/dereferrer/series/2")
+
+    assert t._empty_response_failures == 0
+    assert t._empty_response_circuit_open is False
+
+
+def test_circuit_open_propagates_from_url_lookup():
+    t = _make_tvdb(200)
+    t._empty_response_failures = tvdb.empty_response_circuit_threshold
+    t._empty_response_circuit_open = True
+
+    with pytest.raises(tvdb.CircuitOpen):
+        t.get_id_from_url("https://www.thetvdb.com/series/example")
+
+    t.requests.get.assert_not_called()

--- a/tests/test_tvdb.py
+++ b/tests/test_tvdb.py
@@ -24,6 +24,13 @@ def test_notfound_is_failed_subclass():
     assert issubclass(tvdb.NotFound, Failed)
 
 
+@pytest.mark.parametrize(("exception", "attempt_number", "expected_wait"), [(tvdb.TVDbEmptyResponse("https://example.com", 202), 1, 1), (tvdb.TVDbEmptyResponse("https://example.com", 202), 2, 2), (tvdb.TVDbServerError("(503) Mocked"), 1, 10)])
+def test_tvdb_wait_depends_on_failure_type(exception, attempt_number, expected_wait):
+    retry_state = SimpleNamespace(outcome=SimpleNamespace(exception=lambda: exception), attempt_number=attempt_number)
+
+    assert tvdb._tvdb_wait(retry_state) == expected_wait
+
+
 def test_get_request_raises_notfound_on_4xx():
     t = _make_tvdb(404)
     with pytest.raises(tvdb.NotFound):


### PR DESCRIPTION
<!--
Thank you for contributing to Kometa! Please complete the sections below so that your pull request can be reviewed efficiently.
-->

## What type of PR is this?

<!-- Check all that apply. -->

- [X] Bug Fix
- [ ] Feature/Tweak
- [ ] Refactor
- [ ] Documentation Update
- [ ] Build or CI Change
- [ ] Other

## Description

Limits the number of requests and retry delays generated when TVDb repeatedly returns a successful HTTP status with an empty response body.

### What we discovered

A stable `2.4.5` log contained 265 occurrences of:

```text
TVDb Error: No usable response from TVDb after 6 attempt(s): Document is empty
```

The warnings occurred while resolving missing shows across multiple collections. Each lookup independently retried the same empty-document condition six times with a fixed 10-second wait. In the observed run, that could produce as many as 1,590 requests and approximately 3 hours 40 minutes of retry sleep.

The current warning also omits the requested URL and HTTP status, so it is impossible to identify which TVDb ID failed or distinguish an empty HTTP `200` from TVDb's empty HTTP `202` response.

### Previous behavior

| Condition | Attempts | Result |
|:--|--:|:--|
| One empty response URL | 6 | Warning without URL/status after approximately 50 seconds of retry sleep |
| Additional empty response URLs | 6 each | The complete retry cycle repeats independently for every ID |
| Same failed URL requested again | 6 more | The complete retry cycle repeats |
| TVDb-wide empty-response outage | Unbounded by run | Request and delay amplification continues across collections |

### New behavior

| Condition | Behavior |
|:--|:--|
| Empty response with a successful HTTP status | Retry up to 3 attempts with 1- and 2-second delays; include URL/status on exhaustion |
| Same exhausted URL requested again | Fail fast without another network request |
| Two distinct URLs exhaust empty-response retries | Open a TVDb circuit for the remainder of the run |
| Request made after the circuit opens | Skip without a network request or repeated warning |
| Usable response before the circuit opens | Clear the exhausted-URL streak |
| HTTP 4xx | Remain terminal `NotFound` responses |
| HTTP 5xx and other transient failures | Retain the existing 6-attempt retry budget and 10-second delay |

With unique failing URLs, the empty-response outage path is now capped at six network requests and approximately 6 seconds of retry sleep before the circuit opens.

### Why use two distinct URLs?

One TVDb page can temporarily return an empty response while it is being generated. Opening a global circuit after only one page fails could suppress unrelated pages that remain available. Requiring two distinct exhausted URLs provides evidence of a broader outage while still bounding the request amplification.

### Caller behavior

| Caller | Circuit-open handling |
|:--|:--|
| Missing-show processing | Stop the remaining TVDb lookups for that collection |
| Run-again missing shows | Stop the remaining TVDb lookups |
| Builder metadata, artwork, details, and filters | Skip TVDb-dependent work without repeating the circuit warning |
| Library operations | Skip TVDb-dependent work without repeating the circuit warning |

### Testing

Regression coverage verifies:

- empty responses use 1- and 2-second exponential delays while other transient failures retain the 10-second delay;
- empty-response exhaustion includes the URL, HTTP status, and three-attempt count;
- two distinct exhausted URLs open the circuit after six total requests;
- an already-exhausted URL fails fast without another request;
- a usable response clears the pre-circuit failure streak;
- circuit-open errors propagate through URL lookup without being relabeled;
- bulk missing-show processing stops after the circuit opens; and
- HTTP 5xx failures retain six attempts.

| Validation | Result |
|:--|:--|
| Pyright baseline | Passed: 5 baseline errors, 5 current errors, no regressions |
| Black | Passed |
| `git diff --check` | Passed |
| Focused pytest | Not run locally because the host lacks the pinned `tenacity` and `arrapi` dependencies required during collection |

## Related Issues [optional]

<!-- Link any related issues here, for example: Fixes #1234. -->

None.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No
