### PR TITLE
fix(tvdb): trim retries and add per-run circuit breaker for degraded TVDb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `modules/tvdb.py`: stop wasting ~50s per TVDb ID when TVDb is degraded. The `get_request` retry loop is trimmed from 6 fixed 10s waits to 3 attempts with capped exponential backoff, and a per-run circuit breaker now trips after 3 exhausted loops so the remaining lookups fail fast (raise `Unavailable` without a network call) instead of each re-running the full retry budget. Empty-body 200 responses (lxml "Document is empty") are what triggered the prior behaviour, most visibly in the best-effort missing-shows report.
 - `modules/plex.py`: standardize Plex API retry handling so known 400/404/401 responses and Kometa `Failed` exceptions remain terminal, while exhausted transient retries re-raise their underlying exception instead of becoming opaque `RetryError`; collection move failures also include the item title and original Plex response, and `query_collection`/`get_actor_id` convert terminal Plex responses into contextual Kometa errors.
 - Drop-in replacement for the jikan api
 

--- a/modules/tvdb.py
+++ b/modules/tvdb.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from lxml import html
 from lxml.etree import ParserError
 from requests.exceptions import MissingSchema
-from tenacity import retry, retry_if_not_exception_type, stop_after_attempt, wait_fixed
+from tenacity import retry, retry_if_not_exception_type, stop_after_attempt, wait_exponential
 
 from modules import util
 from modules.util import Failed
@@ -26,13 +26,24 @@ class TVDbServerError(Exception):
 
 
 def _tvdb_retry_exhausted(retry_state):
-    """Convert an exhausted TVDb retry loop (5xx, or repeated unparsable 202/empty responses) into Unavailable."""
+    """Convert an exhausted TVDb retry loop (5xx, or repeated unparsable 202/empty responses) into Unavailable.
+
+    Also trips a per-run circuit breaker on the TVDb instance so that once TVDb is clearly degraded, the
+    remaining lookups this run fail fast instead of each burning the full retry budget."""
+    tvdb = retry_state.args[0] if retry_state.args else None
+    if tvdb is not None:
+        tvdb._degraded_failures += 1
+        if tvdb._degraded_failures >= TVDB_DEGRADED_THRESHOLD:
+            tvdb._degraded = True
     raise Unavailable(f"TVDb Error: No usable response from TVDb after {retry_state.attempt_number} attempt(s): {retry_state.outcome.exception()}") from retry_state.outcome.exception()
 
 
 builders = ["tvdb_list", "tvdb_list_details", "tvdb_movie", "tvdb_movie_details", "tvdb_show", "tvdb_show_details"]
 base_url = "https://www.thetvdb.com"
 alt_url = "https://thetvdb.com"
+# After this many exhausted retry loops in one run, treat TVDb as degraded and fail fast for the rest
+# of the run instead of retrying every subsequent lookup (avoids ~50s per ID during a broad outage).
+TVDB_DEGRADED_THRESHOLD = 3
 urls = {
     "list": f"{base_url}/lists/",
     "alt_list": f"{alt_url}/lists/",
@@ -309,13 +320,19 @@ class TVDb:
         self.cache = cache
         self.language = tvdb_language
         self.expiration = expiration
+        # Per-run circuit breaker: trips after TVDB_DEGRADED_THRESHOLD exhausted retry loops so the rest
+        # of the run fails fast instead of retrying a clearly-degraded TVDb.
+        self._degraded = False
+        self._degraded_failures = 0
 
     def get_tvdb_obj(self, tvdb_url, is_movie=False):
         tvdb_id, _, _ = self.get_id_from_url(tvdb_url, is_movie=is_movie)
         return TVDbObj(self, tvdb_id, is_movie=is_movie)
 
-    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed), retry_error_callback=_tvdb_retry_exhausted)
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8), retry=retry_if_not_exception_type(Failed), retry_error_callback=_tvdb_retry_exhausted)
     def get_request(self, tvdb_url):
+        if self._degraded:
+            raise Unavailable("TVDb Error: TVDb marked unavailable for this run after repeated failures; skipping request")
         response = self.requests.get(tvdb_url, language=self.language)
         if response.status_code >= 400:
             # 4xx = definitive "gone" (NotFound); 5xx = transient (TVDbServerError, retried by tenacity)

--- a/tests/test_tvdb.py
+++ b/tests/test_tvdb.py
@@ -44,3 +44,56 @@ def test_tvdbobj_init_propagates_notfound_for_stale_id():
         tvdb.TVDbObj(t, 463160, is_movie=False, ignore_cache=True)
     assert "463160" in str(excinfo.value)
     assert "No Series found" in str(excinfo.value)
+
+
+def _make_tvdb_empty_body():
+    """TVDb whose requests.get returns a 200 with an empty body (parses to lxml 'Document is empty')."""
+    fake_response = SimpleNamespace(status_code=200, reason="OK", content=b"")
+    fake_requests = SimpleNamespace(get=lambda url, language=None: fake_response)
+    return tvdb.TVDb(requests=fake_requests, cache=None, tvdb_language="eng", expiration=60)
+
+
+def test_empty_body_raises_unavailable(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    t = _make_tvdb_empty_body()
+    with pytest.raises(tvdb.Unavailable):
+        t.get_request("https://www.thetvdb.com/dereferrer/series/81189")
+
+
+def test_empty_body_retries_are_trimmed(monkeypatch):
+    """The empty-document retry loop should stop at 3 attempts, not the old 6."""
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    calls = {"n": 0}
+
+    def counting_get(url, language=None):
+        calls["n"] += 1
+        return SimpleNamespace(status_code=200, reason="OK", content=b"")
+
+    t = tvdb.TVDb(requests=SimpleNamespace(get=counting_get), cache=None, tvdb_language="eng", expiration=60)
+    with pytest.raises(tvdb.Unavailable):
+        t.get_request("https://www.thetvdb.com/dereferrer/series/81189")
+    assert calls["n"] == 3
+
+
+def test_circuit_breaker_trips_and_fails_fast(monkeypatch):
+    """After TVDB_DEGRADED_THRESHOLD exhausted loops, further lookups fail fast without any network call."""
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    calls = {"n": 0}
+
+    def counting_get(url, language=None):
+        calls["n"] += 1
+        return SimpleNamespace(status_code=200, reason="OK", content=b"")
+
+    t = tvdb.TVDb(requests=SimpleNamespace(get=counting_get), cache=None, tvdb_language="eng", expiration=60)
+
+    # Drive exactly THRESHOLD exhausted retry loops to trip the breaker.
+    for _ in range(tvdb.TVDB_DEGRADED_THRESHOLD):
+        with pytest.raises(tvdb.Unavailable):
+            t.get_request("https://www.thetvdb.com/dereferrer/series/81189")
+    assert t._degraded is True
+
+    calls_before = calls["n"]
+    # Next call should short-circuit: Unavailable raised before requests.get is ever invoked.
+    with pytest.raises(tvdb.Unavailable):
+        t.get_request("https://www.thetvdb.com/dereferrer/series/99999")
+    assert calls["n"] == calls_before  # no additional network calls


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

When TVDb is degraded it returns HTTP 200 with an **empty body**, which lxml raises as `Document is empty` (a `ParserError`). `TVDb.get_request` used `stop_after_attempt(6), wait_fixed(10)` with `retry_if_not_exception_type(Failed)`; since `ParserError` is not a `Failed` subclass, every such response was retried all 6 times at fixed 10s waits — **~50s per TVDb ID**. This is most visible in the best-effort missing-shows report (`builder.py:4669`), which merely logs a warning and continues, so a broadly-degraded TVDb produced long stalls (e.g. 5 IDs ≈ 5 minutes of `No usable response from TVDb after 6 attempt(s): Document is empty`).

**Changes (`modules/tvdb.py`):**
- Trim the retry loop from `stop_after_attempt(6)` + `wait_fixed(10)` to `stop_after_attempt(3)` + capped exponential backoff (`wait_exponential(min=1, max=8)`). Worst case per ID drops from ~50s to a few seconds.
- Add a per-run **circuit breaker** on the `TVDb` instance: after 3 exhausted retry loops, `_degraded` trips and subsequent `get_request` calls raise `Unavailable` immediately, with **no network call**. `Unavailable` is a `Failed` subclass, so tenacity does not retry it.

Behaviour for genuine 4xx (`NotFound`) and 5xx (`TVDbServerError`) is unchanged; only the wasted retrying against a clearly-degraded TVDb is eliminated.

**Testing:** Added 4 tests (empty-body → `Unavailable`; retries trimmed to exactly 3 attempts; breaker trips at the threshold; breaker then fails fast with zero further network calls). `test_tvdb.py` (7) and `test_builder.py` pass (84 total).

## Related Issues [optional]

N/A

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No