### PR TITLE
Stop ntfy startup access-test notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Treat TMDb connection failures, timeouts, HTTP 408/429/5xx, and backend-unavailable responses as transient service failures: retry discovery, pagination, item requests, and lazy object hydration consistently; emit concise retry warnings instead of tracebacks; and surface exhausted retries as a service-unavailable error.
 - Add the affected URL and HTTP status to exhausted empty TVDb response warnings; limit empty documents to three attempts with short exponential delays while retaining six attempts and the existing delay for other transient failures; and open a run-scoped circuit after two distinct URLs exhaust retries so a systemic TVDb outage does not generate thousands of requests and hours of retry delays.
+- Stop ntfy from sending an access-test notification on every run; the startup publish test is now opt-in with `ntfy.test_on_start: true`.
 - `modules/plex.py`: standardize Plex API retry handling so known 400/404/401 responses and Kometa `Failed` exceptions remain terminal, while exhausted transient retries re-raise their underlying exception instead of becoming opaque `RetryError`; collection move failures also include the item title and original Plex response, and `query_collection`/`get_actor_id` convert terminal Plex responses into contextual Kometa errors.
 - Drop-in replacement for the jikan api
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Treat TMDb connection failures, timeouts, HTTP 408/429/5xx, and backend-unavailable responses as transient service failures: retry discovery, pagination, item requests, and lazy object hydration consistently; emit concise retry warnings instead of tracebacks; and surface exhausted retries as a service-unavailable error.
 - Add the affected URL and HTTP status to exhausted empty TVDb response warnings; limit empty documents to three attempts with short exponential delays while retaining six attempts and the existing delay for other transient failures; and open a run-scoped circuit after two distinct URLs exhaust retries so a systemic TVDb outage does not generate thousands of requests and hours of retry delays.
-- Stop ntfy from sending an access-test notification on every run; the startup publish test is now opt-in with `ntfy.test_on_start: true`.
+- Stop ntfy from sending an access-test notification whenever Kometa initializes the ntfy client.
 - `modules/plex.py`: standardize Plex API retry handling so known 400/404/401 responses and Kometa `Failed` exceptions remain terminal, while exhausted transient retries re-raise their underlying exception instead of becoming opaque `RetryError`; collection move failures also include the item title and original Plex response, and `query_collection`/`get_actor_id` convert terminal Plex responses into contextual Kometa errors.
 - Drop-in replacement for the jikan api
 

--- a/docs/config/ntfy.md
+++ b/docs/config/ntfy.md
@@ -13,17 +13,15 @@ ntfy:
   url: https://ntfy.sh  # or a different ntfy server URL
   token: tk_thisismyaccesstoken
   topic: kometa  # or a different topic name
-  test_on_start: false
 ```
 
-| Attribute      | Description                                                                                  | Allowed Values (default in **bold**) |                  Required                  |
-|:---------------|:---------------------------------------------------------------------------------------------|:-------------------------------------|:------------------------------------------:|
-| `url`          | ntfy server URL.                                                                             | Any valid URL or leave **blank**     | :fontawesome-solid-circle-check:{ .green } |
-| `token`        | ntfy user access token.                                                                      | Any valid token or leave **blank**   | :fontawesome-solid-circle-check:{ .green } |
-| `topic`        | ntfy topic name.                                                                             | Any valid topic or leave **blank**   | :fontawesome-solid-circle-check:{ .green } |
-| `test_on_start` | Send a low-priority test notification when Kometa initializes the ntfy client.              | `true` or **`false`**                | :fontawesome-solid-circle-xmark:{ .red }   |
+| Attribute | Description             | Allowed Values (default in **bold**) |                  Required                  |
+|:----------|:------------------------|:-------------------------------------|:------------------------------------------:|
+| `url`     | ntfy server URL.        | Any valid URL or leave **blank**     | :fontawesome-solid-circle-check:{ .green } |
+| `token`   | ntfy user access token. | Any valid token or leave **blank**   | :fontawesome-solid-circle-check:{ .green } |
+| `topic`   | ntfy topic name.        | Any valid topic or leave **blank**   | :fontawesome-solid-circle-check:{ .green } |
 
-By default, Kometa does not publish a notification while loading the ntfy configuration. Network and write access are checked when the first configured ntfy webhook is sent. Set `test_on_start: true` to verify publishing during initialization; this intentionally sends one low-priority test notification on every Kometa run.
+Kometa does not publish a test notification while loading the ntfy configuration. Network and write access are checked when the first configured ntfy webhook is sent.
 
 ## Setup
 

--- a/docs/config/ntfy.md
+++ b/docs/config/ntfy.md
@@ -13,13 +13,17 @@ ntfy:
   url: https://ntfy.sh  # or a different ntfy server URL
   token: tk_thisismyaccesstoken
   topic: kometa  # or a different topic name
+  test_on_start: false
 ```
 
-| Attribute | Description             | Allowed Values (default in **bold**) |                  Required                  |
-|:----------|:------------------------|:-------------------------------------|:------------------------------------------:|
-| `url`     | ntfy server URL.        | Any valid URL or leave **blank**     | :fontawesome-solid-circle-check:{ .green } |
-| `token`   | ntfy user access token. | Any valid token or leave **blank**   | :fontawesome-solid-circle-check:{ .green } |
-| `topic`   | ntfy topic name.        | Any valid topic or leave **blank**   | :fontawesome-solid-circle-check:{ .green } |
+| Attribute      | Description                                                                                  | Allowed Values (default in **bold**) |                  Required                  |
+|:---------------|:---------------------------------------------------------------------------------------------|:-------------------------------------|:------------------------------------------:|
+| `url`          | ntfy server URL.                                                                             | Any valid URL or leave **blank**     | :fontawesome-solid-circle-check:{ .green } |
+| `token`        | ntfy user access token.                                                                      | Any valid token or leave **blank**   | :fontawesome-solid-circle-check:{ .green } |
+| `topic`        | ntfy topic name.                                                                             | Any valid topic or leave **blank**   | :fontawesome-solid-circle-check:{ .green } |
+| `test_on_start` | Send a low-priority test notification when Kometa initializes the ntfy client.              | `true` or **`false`**                | :fontawesome-solid-circle-xmark:{ .red }   |
+
+By default, Kometa does not publish a notification while loading the ntfy configuration. Network and write access are checked when the first configured ntfy webhook is sent. Set `test_on_start: true` to verify publishing during initialization; this intentionally sends one low-priority test notification on every Kometa run.
 
 ## Setup
 

--- a/json-schema/config-schema.json
+++ b/json-schema/config-schema.json
@@ -1095,6 +1095,10 @@
         },
         "topic": {
           "type": "string"
+        },
+        "test_on_start": {
+          "type": "boolean",
+          "default": false
         }
       },
       "required": [

--- a/json-schema/config-schema.json
+++ b/json-schema/config-schema.json
@@ -1095,10 +1095,6 @@
         },
         "topic": {
           "type": "string"
-        },
-        "test_on_start": {
-          "type": "boolean",
-          "default": false
         }
       },
       "required": [

--- a/modules/config.py
+++ b/modules/config.py
@@ -976,7 +976,6 @@ class ConfigFile:
                         "url": check_for_attribute(self.data, "url", parent="ntfy", throw=True),
                         "token": check_for_attribute(self.data, "token", parent="ntfy", throw=True),
                         "topic": check_for_attribute(self.data, "topic", parent="ntfy", throw=True),
-                        "test_on_start": check_for_attribute(self.data, "test_on_start", parent="ntfy", var_type="bool", default=False),
                     },
                 )
             except Failed as e:

--- a/modules/config.py
+++ b/modules/config.py
@@ -976,6 +976,7 @@ class ConfigFile:
                         "url": check_for_attribute(self.data, "url", parent="ntfy", throw=True),
                         "token": check_for_attribute(self.data, "token", parent="ntfy", throw=True),
                         "topic": check_for_attribute(self.data, "topic", parent="ntfy", throw=True),
+                        "test_on_start": check_for_attribute(self.data, "test_on_start", parent="ntfy", var_type="bool", default=False),
                     },
                 )
             except Failed as e:
@@ -984,7 +985,7 @@ class ConfigFile:
                 else:
                     logger.stacktrace()
                     logger.error(e)
-            logger.info(f"ntfy Connection {'Failed' if self.NtfyFactory is None else 'Successful'}")
+            logger.info(f"ntfy Configuration {'Failed' if self.NtfyFactory is None else 'Successful'}")
         else:
             logger.info("ntfy attribute not found")
 

--- a/modules/ntfy.py
+++ b/modules/ntfy.py
@@ -14,16 +14,6 @@ class Ntfy:
         logger.secret(self.url)
         logger.secret(self.token)
 
-        if params.get("test_on_start", False):
-            self._test_url()
-
-    def _test_url(self):
-        try:
-            self._request(message="Kometa - Testing ntfy Access", priority=1)
-        except Exception:
-            logger.stacktrace()
-            raise Failed("ntfy Error: Invalid details")
-
     def _request(self, message: str, title: str | None = None, priority: int = 3):
         headers = {"Authorization": f"Bearer {self.token}", "Icon": "https://kometa.wiki/en/latest/assets/icon.png", "Priority": str(priority)}
         if title:

--- a/modules/ntfy.py
+++ b/modules/ntfy.py
@@ -14,7 +14,8 @@ class Ntfy:
         logger.secret(self.url)
         logger.secret(self.token)
 
-        self._test_url()
+        if params.get("test_on_start", False):
+            self._test_url()
 
     def _test_url(self):
         try:

--- a/tests/test_small_modules.py
+++ b/tests/test_small_modules.py
@@ -78,7 +78,7 @@ class TestNtfy:
         adapter.notification({"event": "test"})
         adapter._request.assert_called_once()
 
-    def test_init_does_not_publish_access_test_by_default(self, monkeypatch):
+    def test_init_does_not_publish_access_test(self, monkeypatch):
         from modules.ntfy import Ntfy
 
         monkeypatch.setattr("modules.ntfy.logger", FakeLogger())
@@ -87,20 +87,6 @@ class TestNtfy:
         Ntfy(requests, {"url": "http://ntfy:8080", "token": "fake", "topic": "test"})
 
         requests.post.assert_not_called()
-
-    def test_init_publishes_access_test_when_enabled(self, monkeypatch):
-        from modules.ntfy import Ntfy
-
-        monkeypatch.setattr("modules.ntfy.logger", FakeLogger())
-        requests = MagicMock()
-
-        Ntfy(requests, {"url": "http://ntfy:8080", "token": "fake", "topic": "test", "test_on_start": True})
-
-        requests.post.assert_called_once_with(
-            "http://ntfy:8080/test",
-            headers={"Authorization": "Bearer fake", "Icon": "https://kometa.wiki/en/latest/assets/icon.png", "Priority": "1"},
-            data="Kometa - Testing ntfy Access",
-        )
 
 
 class TestNotifiarr:

--- a/tests/test_small_modules.py
+++ b/tests/test_small_modules.py
@@ -78,6 +78,30 @@ class TestNtfy:
         adapter.notification({"event": "test"})
         adapter._request.assert_called_once()
 
+    def test_init_does_not_publish_access_test_by_default(self, monkeypatch):
+        from modules.ntfy import Ntfy
+
+        monkeypatch.setattr("modules.ntfy.logger", FakeLogger())
+        requests = MagicMock()
+
+        Ntfy(requests, {"url": "http://ntfy:8080", "token": "fake", "topic": "test"})
+
+        requests.post.assert_not_called()
+
+    def test_init_publishes_access_test_when_enabled(self, monkeypatch):
+        from modules.ntfy import Ntfy
+
+        monkeypatch.setattr("modules.ntfy.logger", FakeLogger())
+        requests = MagicMock()
+
+        Ntfy(requests, {"url": "http://ntfy:8080", "token": "fake", "topic": "test", "test_on_start": True})
+
+        requests.post.assert_called_once_with(
+            "http://ntfy:8080/test",
+            headers={"Authorization": "Bearer fake", "Icon": "https://kometa.wiki/en/latest/assets/icon.png", "Priority": "1"},
+            data="Kometa - Testing ntfy Access",
+        )
+
 
 class TestNotifiarr:
     @pytest.fixture


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG.md and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [X] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Stops the native ntfy integration from publishing a low-priority `Kometa - Testing ntfy Access` notification every time Kometa initializes.

### Root cause

`Ntfy.__init__()` called `_test_url()` unconditionally. That method attempted to validate write access by publishing a real notification, so every normal Kometa run generated a message even when the user had enabled only a specific webhook event such as `error`.

### New behavior

| Stage | Previous behavior | New behavior |
|:--|:--|:--|
| ntfy initialization | Publish an access-test notification | Load and validate the configured values without making a network request |
| Configured webhook event | Publish the event notification | Unchanged |
| Invalid network, token, or topic write access | Detected by publishing the startup test | Reported when the first configured ntfy webhook is sent |

The ntfy-specific startup test has been removed rather than replaced with a new setting. Other notification integrations do not expose a recurring startup-publish option, and retaining one for ntfy would add configuration solely to preserve the unwanted behavior.

Notifiarr validates its API key using a read-only user-settings endpoint. ntfy topics can have separate read and write permissions, so a subscription/read request would not prove that Kometa can publish. The ntfy status log therefore now reports successful configuration instead of claiming a connection was tested.

### Testing

Regression coverage verifies that:

- constructing the ntfy client performs no POST; and
- configured event notifications continue to use the existing request path.

| Validation | Result |
|:--|:--|
| Python compilation | Passed |
| Black | Passed |
| `git diff --check` | Passed |
| Focused pytest | Could not collect locally because the host lacks the pinned `arrapi` dependency imported by the shared small-modules test file |

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, GitHub will automatically close the issue.
-->
- Closes #3415

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

<!--
    This is optional and only necessary when your PR changes supported attributes,
    accepted values, or structure for Configuration Files, Collection Files,
    Metadata Files, Overlay Files, Playlist Files, or Defaults template variables.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG.md entry.
    We may ask you to update the CHANGELOG.md if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
