### PR TITLE
Fix: Ensure delete webhooks cover all deletion paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the affected URL and HTTP status to exhausted empty TVDb response warnings; limit empty documents to three attempts with short exponential delays while retaining six attempts and the existing delay for other transient failures; and open a run-scoped circuit after two distinct URLs exhaust retries so a systemic TVDb outage does not generate thousands of requests and hours of retry delays.
 - Stop ntfy from sending an access-test notification whenever Kometa initializes the ntfy client.
 - Restore per-item label removal when deleting smart-label collections, preventing an `AttributeError` from the removed `batch_edit_tags` API.
+- Dispatch the configured `delete` webhook after every successful Kometa-managed collection or playlist deletion instead of only for `delete_not_scheduled` and `delete_playlist`; suppress the event for playlist sync's internal delete-and-recopy step. #3420
 - `modules/plex.py`: standardize Plex API retry handling so known 400/404/401 responses and Kometa `Failed` exceptions remain terminal, while exhausted transient retries re-raise their underlying exception instead of becoming opaque `RetryError`; collection move failures also include the item title and original Plex response, and `query_collection`/`get_actor_id` convert terminal Plex responses into contextual Kometa errors.
 - Added Drop-in replacement for the jikan api as it is being deprecated
 

--- a/kometa.py
+++ b/kometa.py
@@ -1373,7 +1373,6 @@ def run_collection(config, library, metadata, requested_collections):
         except NotScheduled as e:
             logger.info(e)
             if str(e).endswith("and was deleted"):
-                library.notify_delete(e)
                 library.stats["deleted"] += 1
                 library.status[str(mapping_name)]["status"] = "Deleted Not Scheduled"
             elif str(e).startswith("Skipped because run_definition"):
@@ -1584,13 +1583,11 @@ def run_playlists(config):
             except Deleted as e:
                 logger.info(e)
                 status[mapping_name]["status"] = "Deleted"
-                config.notify_delete(e, server=server_name)
             except NotScheduled as e:
                 logger.info(e)
                 if str(e).endswith("and was deleted"):
                     stats["deleted"] += 1
                     status[mapping_name]["status"] = "Deleted Not Scheduled"
-                    config.notify_delete(e)
                 else:
                     status[mapping_name]["status"] = "Not Scheduled"
             except Failed as e:

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -5316,7 +5316,7 @@ class CollectionBuilder:
             logger.info("")
             for user in self.valid_users:
                 try:
-                    self.library.delete_user_playlist(self.obj.title, user)
+                    self.library.delete_user_playlist(self.obj.title, user, notify=False)
                 except Failed:
                     pass
                 if user != self.library.account.username:

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -854,8 +854,8 @@ class Plex(Library):
     def notify(self, text, collection=None, critical=True):
         self.config.notify(text, server=self.PlexServer.friendlyName, library=self.name, collection=collection, critical=critical)
 
-    def notify_delete(self, message):
-        self.config.notify_delete(message, server=self.PlexServer.friendlyName, library=self.name)
+    def notify_delete(self, message, playlist=False):
+        self.config.notify_delete(message, server=self.PlexServer.friendlyName, library=None if playlist else self.name)
 
     def set_server_preroll(self, preroll):
         self.PlexServer.settings.get("cinemaTrailersPrerollID").set(preroll)
@@ -961,12 +961,16 @@ class Plex(Library):
     def query(self, method):
         return method()
 
-    def delete(self, obj):
+    def delete(self, obj, notify=True, delete_message=None):
         try:
-            return self.query(obj.delete)
+            result = self.query(obj.delete)
         except Exception:
             logger.stacktrace()
             raise Failed(f"Plex Error: Failed to delete {obj.title}")
+        if notify:
+            is_playlist = isinstance(obj, Playlist) or getattr(obj, "type", None) == "playlist"
+            self.notify_delete(delete_message or f"{'Playlist' if is_playlist else 'Collection'} {obj.title} deleted", playlist=is_playlist)
+        return result
 
     @PLEX_RETRY
     def query_data(self, method, data):
@@ -1273,9 +1277,9 @@ class Plex(Library):
             self._users = users
         return self._users
 
-    def delete_user_playlist(self, title, user):
+    def delete_user_playlist(self, title, user, notify=True):
         try:
-            self.delete(self.PlexServer.switchUser(user).playlist(title))
+            self.delete(self.PlexServer.switchUser(user).playlist(title), notify=notify, delete_message=f"Playlist {title} deleted on User {user}")
         except NotFound as e:
             raise Failed(e)
         except (ConnectionError, ConnectTimeout, ReadTimeout) as e:

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -140,6 +140,13 @@ class TestNotify:
         mock_config.notify_delete.assert_called_once()
         args, kwargs = mock_config.notify_delete.call_args
         assert kwargs.get("server") == "MyServer"
+        assert kwargs.get("library") == "Test Library"
+
+    def test_notify_playlist_delete_omits_library(self):
+        mock_config = MagicMock()
+        plex = make_plex(config=mock_config, PlexServer=SimpleNamespace(friendlyName="MyServer"))
+        plex.notify_delete("Playlist removed", playlist=True)
+        mock_config.notify_delete.assert_called_once_with("Playlist removed", server="MyServer", library=None)
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -266,11 +273,67 @@ class TestFetchItem:
 
 
 class TestDelete:
-    def test_delete_calls_server_delete(self):
-        item = make_plex_item()
-        plex = make_plex()
+    def test_delete_calls_server_delete_and_notifies_collection(self):
+        item = make_plex_item(type="collection")
+        mock_config = MagicMock()
+        plex = make_plex(config=mock_config, PlexServer=SimpleNamespace(friendlyName="MyServer"))
         plex.delete(item)
         item.delete.assert_called_once()
+        mock_config.notify_delete.assert_called_once_with("Collection Test Item deleted", server="MyServer", library="Test Library")
+
+    def test_delete_notifies_playlist_without_library(self):
+        item = make_plex_item(title="My Playlist", type="playlist")
+        mock_config = MagicMock()
+        plex = make_plex(config=mock_config, PlexServer=SimpleNamespace(friendlyName="MyServer"))
+
+        plex.delete(item)
+
+        mock_config.notify_delete.assert_called_once_with("Playlist My Playlist deleted", server="MyServer", library=None)
+
+    def test_delete_can_suppress_notification(self):
+        item = make_plex_item(type="playlist")
+        mock_config = MagicMock()
+        plex = make_plex(config=mock_config)
+
+        plex.delete(item, notify=False)
+
+        item.delete.assert_called_once()
+        mock_config.notify_delete.assert_not_called()
+
+    def test_failed_delete_does_not_notify(self):
+        item = make_plex_item(type="collection")
+        mock_config = MagicMock()
+        plex = make_plex(config=mock_config)
+        plex.query = MagicMock(side_effect=RuntimeError("delete failed"))
+
+        with pytest.raises(Failed, match="Plex Error: Failed to delete Test Item"):
+            plex.delete(item)
+
+        mock_config.notify_delete.assert_not_called()
+
+    def test_delete_user_playlist_includes_user(self):
+        item = make_plex_item(title="My Playlist", type="playlist")
+        mock_config = MagicMock()
+        server = MagicMock()
+        server.friendlyName = "MyServer"
+        server.switchUser.return_value.playlist.return_value = item
+        plex = make_plex(config=mock_config, PlexServer=server)
+
+        plex.delete_user_playlist("My Playlist", "Friend")
+
+        mock_config.notify_delete.assert_called_once_with("Playlist My Playlist deleted on User Friend", server="MyServer", library=None)
+
+    def test_delete_user_playlist_can_suppress_notification(self):
+        item = make_plex_item(title="My Playlist", type="playlist")
+        mock_config = MagicMock()
+        server = MagicMock()
+        server.switchUser.return_value.playlist.return_value = item
+        plex = make_plex(config=mock_config, PlexServer=server)
+
+        plex.delete_user_playlist("My Playlist", "Friend", notify=False)
+
+        item.delete.assert_called_once()
+        mock_config.notify_delete.assert_not_called()
 
 
 # ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG.md and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Ensures the configured global `delete` webhook is dispatched after every successful Kometa-managed collection or playlist deletion.

### What we discovered

The webhook configuration and `Webhooks.delete_hooks()` sender worked correctly, but deletion call sites invoked `notify_delete()` inconsistently. Only `delete_not_scheduled` and `delete_playlist` reached the notifier; most other successful deletion paths called `Plex.delete()` directly and never dispatched the event.

This contradicted the existing webhook documentation, which states that the delete notification is sent whenever Kometa deletes a collection or playlist.

### Previous behavior

| Deletion path | Deleted from Plex | Delete webhook |
|:--|:--:|:--:|
| `delete_not_scheduled` | Yes | Yes |
| `delete_playlist` | Yes | Yes |
| `delete_below_minimum` | Yes | No |
| Library operation `delete_collections` | Yes | No |
| `delete_collections_named` | Yes | No |
| Dynamic collection synchronization cleanup | Yes | No |
| CLI `--delete-collections` | Yes | No |
| Smart/non-smart collection replacement | Yes | No |

### New behavior

Notification is centralized in `Plex.delete()` and runs only after the Plex deletion succeeds. Every collection/playlist deletion path already funnels through this method, so current and future callers receive consistent behavior without duplicating notification calls.

| Scenario | Behavior |
|:--|:--|
| Successful collection deletion | Send one delete event with server and library context |
| Successful playlist deletion | Send one delete event with server context |
| Shared-user playlist deletion | Include the affected user in the message |
| Failed Plex deletion | Do not send a delete event |
| Playlist sync delete-and-recopy | Suppress the delete event because the playlist is being refreshed, not removed |

The old notifications in the `Deleted` and `NotScheduled` exception handlers were removed so those paths do not send duplicate events after notification moved to the successful deletion boundary.

### Testing

Regression coverage verifies:

- collection deletion sends the correct server/library payload;
- playlist deletion omits library context;
- shared-user playlist deletion identifies the user;
- failed deletion does not notify;
- callers can explicitly suppress notification; and
- the playlist-sync suppression path performs the deletion without notifying.

| Validation | Result |
|:--|:--|
| Pyright baseline | Passed: 5 baseline errors, 5 current errors, no regressions |
| Python compilation | Passed |
| Black | Passed |
| `git diff --check` | Passed |
| Focused pytest | Could not collect locally because the host lacks the pinned `tenacity` dependency |

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work/issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, GitHub will automatically close the issue.
-->
- Closes #3420

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [ ] No
- [X] Not Applicable

The existing documentation already describes the intended behavior; this change makes the implementation match it.

## Have you updated the JSON Schema files (if necessary)?

<!--
    This is optional and only necessary when your PR changes supported attributes,
    accepted values, or structure for Configuration Files, Collection Files,
    Metadata Files, Overlay Files, Playlist Files, or Defaults template variables.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG.md entry.
    We may ask you to update the CHANGELOG.md if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
