### PR TITLE
Fix requirements version check comparing packages against wrong expected version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restore per-item label removal when deleting smart-label collections, preventing an `AttributeError` from the removed `batch_edit_tags` API.
 - `modules/plex.py`: standardize Plex API retry handling so known 400/404/401 responses and Kometa `Failed` exceptions remain terminal, while exhausted transient retries re-raise their underlying exception instead of becoming opaque `RetryError`; collection move failures also include the item title and original Plex response, and `query_collection`/`get_actor_id` convert terminal Plex responses into contextual Kometa errors.
 - Added Drop-in replacement for the jikan api as it is being deprecated
+- Fix the startup requirements version check so each package is compared against its own pinned requirement. Previously `v1`/`v2` leaked between loop iterations and the package name lookup was case-sensitive, causing bogus messages such as `GitPython version: 3.1.55 does not match expected: 1.4.14`, where the expected value came from an unrelated package.
 
 ## [v2.4.5] - 2026-07-22
 

--- a/kometa.py
+++ b/kometa.py
@@ -486,20 +486,21 @@ def start(attrs):
                         pinned_versions = [spec.version for spec in requirement.specifier if spec.operator == "=="]
                         if pinned_versions:
                             required_versions[requirement.name] = pinned_versions[0]
-                v1 = parse("0")
-                v2 = parse("0")
+                required_versions_ci = {k.lower(): v for k, v in required_versions.items()}
+                required_specs_ci = {k.lower(): v for k, v in required_specs.items()}
                 for req_name, sys_ver in system_versions.items():
-                    if sys_ver:
-                        v1 = parse(sys_ver)
-                    if req_name in required_versions:
-                        v2 = parse(required_versions[req_name])
-                    if sys_ver:
+                    if not sys_ver:
+                        continue
+                    key = req_name.lower()
+                    v1 = parse(sys_ver)
+                    if key in required_versions_ci:
+                        v2 = parse(required_versions_ci[key])
                         if v1 < v2:
                             logger.info(f"    {req_name} version: {v1} requires an update to: {v2}")
-                        if v1 > v2:
+                        elif v1 > v2:
                             logger.info(f"    {req_name} version: {v1} does not match expected: {v2}")
-                        if req_name not in required_versions and req_name in required_specs and v1 not in required_specs[req_name]:
-                            logger.info(f"    {req_name} version: {v1} does not satisfy expected: {required_specs[req_name]}")
+                    elif key in required_specs_ci and v1 not in required_specs_ci[key]:
+                        logger.info(f"    {req_name} version: {v1} does not satisfy expected: {required_specs_ci[key]}")
             except FileNotFoundError:
                 logger.error("    File Error: requirements.txt not found")
         if "time" in attrs and attrs["time"]:


### PR DESCRIPTION
## Summary

Fixes the confusing startup message:

```
GitPython version: 3.1.55 does not match expected: 1.4.14
```

Both versions are actually correct/current — they were just being compared against each other by mistake.

## Root cause

The startup requirements version-check loop in `kometa.py` had two bugs:

1. **Stale loop variables** — `v1`/`v2` were declared *outside* the loop and only updated on a successful lookup. When a package's requirement wasn't found, `v2` retained the previous iteration's value.
2. **Case-sensitive name match** — `system_versions` uses the key `GitPython`, but `requirements.txt` (and `packaging.Requirement.name`) uses `gitpython`. So `"GitPython" in required_versions` was `False`, `v2` was never updated, and GitPython (3.1.55) was compared against the prior iteration's package version (arrapi, 1.4.14).

## Fix

- Reset `v1`/`v2` per iteration.
- Match requirement names case-insensitively.
- Use `elif` so the spec-satisfaction check only runs when there is no pinned `==` version.

## Notes

- Targets `nightly` per contributing guidelines.
- `CHANGELOG.md` updated under `## [Unreleased]` -> `### Fixed`.