### PR TITLE
Resolve media paths using the server's path style, not Kometa's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `modules/plex.py`: standardize Plex API retry handling so known 400/404/401 responses and Kometa `Failed` exceptions remain terminal, while exhausted transient retries re-raise their underlying exception instead of becoming opaque `RetryError`; collection move failures also include the item title and original Plex response, and `query_collection`/`get_actor_id` convert terminal Plex responses into contextual Kometa errors.
 - Added Drop-in replacement for the jikan api as it is being deprecated
 - Fix the startup requirements version check so each package is compared against its own pinned requirement. Previously `v1`/`v2` leaked between loop iterations and the package name lookup was case-sensitive, causing bogus messages such as `GitPython version: 3.1.55 does not match expected: 1.4.14`, where the expected value came from an unrelated package.
+- Resolve movie folder paths using the path style reported by the media server rather than the platform Kometa runs on. A Linux or Docker install pointed at a Plex server on Windows received paths such as `P:\Movies\Title\file.mkv`, which `os.path.dirname` reduced to an empty string, logging `Plex Error: No location found` for every movie and silently disabling `add_existing`, `upgrade_existing`, `monitor_existing`, `item_radarr_tag`, and `item_sonarr_tag`.
 
 ## [v2.4.5] - 2026-07-22
 

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -4819,7 +4819,7 @@ class CollectionBuilder:
             ):
                 if item.locations:
                     if self.library.is_movie:
-                        path = os.path.dirname(str(item.locations[0]))
+                        path = util.media_dirname(item.locations[0])
                     elif self.library.is_show:
                         path = str(item.locations[0])
                 if not path:

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -238,7 +238,7 @@ class Operations:
                     except Failed:
                         pass
                 if item.locations:
-                    path = os.path.dirname(str(item.locations[0])) if self.library.is_movie else str(item.locations[0])
+                    path = util.media_dirname(item.locations[0]) if self.library.is_movie else str(item.locations[0])
                     if self.library.Radarr and self.library.radarr_add_all_existing and tmdb_id:
                         path = path.replace(self.library.Radarr.plex_path, self.library.Radarr.radarr_path)
                         path = path[:-1] if path.endswith(("/", "\\")) else path

--- a/modules/util.py
+++ b/modules/util.py
@@ -426,19 +426,11 @@ def item_set(item, item_id):
 
 
 def media_dirname(path):
-    """Return the parent directory of a media path reported by the media server.
+    """Return the parent directory of a media path, using the path's own separator style.
 
-    Plex reports library paths using the separator of the machine running the server, which is
-    not necessarily the machine running Kometa. A Kometa install on Linux (for example the
-    Docker image) talking to a Plex server on Windows receives paths like
-    ``P:\\Movies\\Title\\file.mkv``.
-
-    ``os.path.dirname`` only understands the separator of the platform Kometa is running on, so
-    on Linux it finds no ``/`` in that string and returns ``""``. Callers treat the empty result
-    as "no location found", which silently disables every Radarr/Sonarr path operation.
-
-    Picking the flavour from the path itself keeps both layouts working regardless of which
-    platform each side runs on.
+    Plex reports paths from the server's platform, which need not match Kometa's.
+    os.path.dirname returns "" for a Windows path on Linux, which callers read as
+    "no location found".
     """
     path = str(path)
     if ntpath.splitdrive(path)[0] or path.startswith("\\\\") or ("\\" in path and "/" not in path):

--- a/modules/util.py
+++ b/modules/util.py
@@ -1,4 +1,5 @@
 import glob
+import ntpath
 import os
 import re
 import signal
@@ -422,6 +423,27 @@ def item_title(item):
 
 def item_set(item, item_id):
     return {"title": item_title(item), "tmdb" if isinstance(item, Movie) else "tvdb": item_id}
+
+
+def media_dirname(path):
+    """Return the parent directory of a media path reported by the media server.
+
+    Plex reports library paths using the separator of the machine running the server, which is
+    not necessarily the machine running Kometa. A Kometa install on Linux (for example the
+    Docker image) talking to a Plex server on Windows receives paths like
+    ``P:\\Movies\\Title\\file.mkv``.
+
+    ``os.path.dirname`` only understands the separator of the platform Kometa is running on, so
+    on Linux it finds no ``/`` in that string and returns ``""``. Callers treat the empty result
+    as "no location found", which silently disables every Radarr/Sonarr path operation.
+
+    Picking the flavour from the path itself keeps both layouts working regardless of which
+    platform each side runs on.
+    """
+    path = str(path)
+    if ntpath.splitdrive(path)[0] or path.startswith("\\\\") or ("\\" in path and "/" not in path):
+        return ntpath.dirname(path)
+    return os.path.dirname(path)
 
 
 def is_locked(filepath):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -160,3 +160,41 @@ class TestParseValidatesOptionsList:
                 translation={"alpha": 1, "beta": 2},
                 options=None,
             )
+
+
+class TestMediaDirname:
+    """Plex reports paths using the separator of the machine running the server,
+    which need not match the machine running Kometa. os.path.dirname only knows
+    its own platform's separator, so a Linux Kometa talking to a Windows Plex
+    returned "" for every movie and callers reported "No location found".
+    """
+
+    def test_windows_path_on_any_platform(self):
+        from modules.util import media_dirname
+
+        assert media_dirname(r"P:\Movies\Title (2024)\Title (2024).mkv") == r"P:\Movies\Title (2024)"
+
+    def test_windows_unc_path(self):
+        from modules.util import media_dirname
+
+        assert media_dirname(r"\\server\share\Movies\Title\Title.mkv") == r"\\server\share\Movies\Title"
+
+    def test_posix_path(self):
+        from modules.util import media_dirname
+
+        assert media_dirname("/media/Movies/Title (2024)/Title (2024).mkv") == "/media/Movies/Title (2024)"
+
+    def test_windows_path_is_truthy(self):
+        """The bug was the empty return being treated as 'no location found'."""
+        from modules.util import media_dirname
+
+        assert media_dirname(r"P:\Movies\Title\file.mkv")
+
+    def test_accepts_non_str(self):
+        from modules.util import media_dirname
+
+        class FakePath:
+            def __str__(self):
+                return r"P:\Movies\Title\file.mkv"
+
+        assert media_dirname(FakePath()) == r"P:\Movies\Title"


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Plex reports library paths using the separator of the machine running the server, which need not match the machine running Kometa. A Kometa install on Linux (for example the Docker image) pointed at a Plex server on Windows gets paths like `P:\Movies\Title\file.mkv`.

`os.path.dirname` only understands the separator of the platform Kometa itself is running on, so on Linux it finds no `/` in that string and returns `""`:

```python
>>> import os
>>> os.path.dirname(r'P:\Movies\Title (2024)\Title (2024).mkv')   # on Linux
''
```

Both call sites treat that empty result as "no location found":

- `modules/builder.py` logs `Plex Error: No location found for <title>: [...]` and skips the item
- `modules/operations.py` has the same `os.path.dirname` call in the `radarr_add_all_existing` / `sonarr_add_all_existing` path

The user-visible effect is that `add_existing`, `upgrade_existing`, `monitor_existing`, `item_radarr_tag` and `item_sonarr_tag` silently do nothing for the entire library, while the log fills with one error per item. On my library that was 55,866 errors in a single run.

**This is not a regression.** The same `os.path.dirname` call is present in v2.1.0, v2.3.1 and v2.4.0. It only appears once Kometa and Plex are on platforms with different path styles, which is why it typically shows up right after someone moves an existing bare-metal Windows install into Docker — which is exactly what happened here. Collections, posters and overlays are unaffected (they go through the Plex API and never touch the path), so the failure is easy to miss.

### The change

Adds `util.media_dirname`, which picks the path flavour from the path itself instead of from the host platform, and uses it at both call sites:

```python
def media_dirname(path):
    path = str(path)
    if ntpath.splitdrive(path)[0] or path.startswith("\\\\") or ("\\" in path and "/" not in path):
        return ntpath.dirname(path)
    return os.path.dirname(path)
```

Windows drive-letter paths and UNC paths route to `ntpath`; everything else keeps the current `os.path` behaviour, so POSIX-to-POSIX and Windows-to-Windows setups are untouched.

### Testing

Verified on the affected setup (Kometa in Docker on WSL2, Plex on Windows, library on `P:\`):

```
old  os.path.dirname -> ''                        | falsy: True
new  media_dirname   -> 'P:\Movies\Title (2024)'  | falsy: False
```

- Added 5 tests in `tests/test_util.py` covering Windows drive-letter paths, UNC paths, POSIX paths, the truthiness that the callers depend on, and non-`str` input.
- Full suite passes: `914 passed`.
- `black --check`, `isort --check-only`, `flake8 --max-line-length=256 --extend-ignore=E203,W503,E501`, `bandit` and `pyspelling` all clean.

## Related Issues [optional]

- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No
