### PR TITLE
Add TVDB ID support to YamTrack builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add `--timings`/`--timing` (`KOMETA_TIMINGS`/`KOMETA_TIMING`) runtime support for diagnosing slow runs. When enabled, network calls, cache lookups, and major per-collection/per-library phases are timed; a summary prints to the log at the end of the run and a full per-source/per-library breakdown is exported as JSON/CSV to the logs directory. Disabled by default, with negligible overhead when off. Also adds an optional `KOMETA_PROFILE=pyinstrument` environment variable for deeper single-run profiling, writing an HTML report to the logs directory.
+- Add TVDB ID support to YamTrack builder, enabling import of TVDB show IDs from YamTrack lists and tracked pages alongside existing TMDb support.
 
 ### Fixed
 - Treat TMDb connection failures, timeouts, HTTP 408/429/5xx, and backend-unavailable responses as transient service failures: retry discovery, pagination, item requests, and lazy object hydration consistently; emit concise retry warnings instead of tracebacks; and surface exhausted retries as a service-unavailable error.

--- a/docs/config/yamtrack.md
+++ b/docs/config/yamtrack.md
@@ -16,3 +16,5 @@ yamtrack:
 | `url`      | YamTrack server URL      | :fontawesome-solid-circle-check:{ .green } |
 | `username` | YamTrack username        | :fontawesome-solid-circle-check:{ .green } |
 | `password` | YamTrack password        | :fontawesome-solid-circle-check:{ .green } |
+
+YamTrack lists and tracked pages now extract TVDB show IDs from `/details/tvdb/tv/{id}` links alongside existing TMDb IDs. TVDB-tracked shows match via Plex's native TVDB show mapping — no configuration changes are needed.

--- a/docs/config/yamtrack.md
+++ b/docs/config/yamtrack.md
@@ -16,5 +16,3 @@ yamtrack:
 | `url`      | YamTrack server URL      | :fontawesome-solid-circle-check:{ .green } |
 | `username` | YamTrack username        | :fontawesome-solid-circle-check:{ .green } |
 | `password` | YamTrack password        | :fontawesome-solid-circle-check:{ .green } |
-
-YamTrack lists and tracked pages now extract TVDB show IDs from `/details/tvdb/tv/{id}` links alongside existing TMDb IDs. TVDB-tracked shows match via Plex's native TVDB show mapping — no configuration changes are needed.

--- a/docs/files/builders/yamtrack/overview.md
+++ b/docs/files/builders/yamtrack/overview.md
@@ -12,5 +12,5 @@ You can find items using lists from your [YamTrack](https://github.com/FuzzyGrim
 
 | Builder                         | Description                                      |             Works with Movies              |              Works with Shows              |    Works with Playlists and Custom Sort    |
 |:--------------------------------|:-------------------------------------------------|:------------------------------------------:|:------------------------------------------:|:------------------------------------------:|
-| [`yamtrack_list`](list.md)      | Finds every movie/show in the YamTrack List.     | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |
-| [`yamtrack_tracked`](tracked.md)| Finds tracked movies/shows/anime by YamTrack status. | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |
+| [`yamtrack_list`](list.md)      | Finds every movie/show in the YamTrack List. Extracts both TMDb and TVDB IDs. | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |
+| [`yamtrack_tracked`](tracked.md)| Finds tracked movies/shows/anime by YamTrack status. Extracts both TMDb and TVDB IDs. | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -3577,7 +3577,7 @@ class CollectionBuilder:
                 if mal_ids:
                     ids.extend(self.config.Convert.myanimelist_to_ids(mal_ids, self.library))
             else:
-                ids = self.config.YamTrack.get_tmdb_ids(method, value, self.library.is_movie if not self.playlist else None)
+                ids = self.config.YamTrack.get_ids(method, value, self.library.is_movie if not self.playlist else None)
         elif "radarr" in method:
             ids = self.library.Radarr.get_tmdb_ids(method, value)
         elif "sonarr" in method:

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -3839,7 +3839,7 @@ class CollectionBuilder:
                         try:
                             item = self.library.fetch_item(rk)
                             if self.playlist and isinstance(item, Show):
-                                items.extend([ep for ep in item.episodes() if ep and ep.seasonNumber != 0])
+                                items.extend(item.episodes())
                             elif self.playlist and isinstance(item, Season):
                                 items.extend(item.episodes())
                             elif self.builder_level == "movie" and not isinstance(item, Movie):

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -3838,7 +3838,9 @@ class CollectionBuilder:
                             continue
                         try:
                             item = self.library.fetch_item(rk)
-                            if self.playlist and isinstance(item, (Show, Season)):
+                            if self.playlist and isinstance(item, Show):
+                                items.extend([ep for ep in item.episodes() if ep and ep.seasonNumber != 0])
+                            elif self.playlist and isinstance(item, Season):
                                 items.extend(item.episodes())
                             elif self.builder_level == "movie" and not isinstance(item, Movie):
                                 logger.info(f"Item: {item} is not an Movie")

--- a/modules/yamtrack.py
+++ b/modules/yamtrack.py
@@ -10,7 +10,7 @@ logger = util.logger
 
 builders = ["yamtrack_list", "yamtrack_list_details", "yamtrack_tracked"]
 details_pattern = re.compile(r"^/details/tmdb/(?P<media_type>movie|tv)/(?P<tmdb_id>\d+)(?:/|$)")
-tvdb_details_pattern = re.compile(r"^/details/tvdb/(?P<media_type>movie|tv)/(?P<tvdb_id>\d+)(?:/[^/]+(?:/season/(?P<season>\d+)(?:/episode/(?P<episode>\d+))?)?)?(?:/|$)")
+tvdb_details_pattern = re.compile(r"^/details/tvdb/(?P<media_type>movie|tv)/(?P<tvdb_id>\d+)(?:/(?!(?:season|episode)/)[^/]+(?:/season/(?P<season>\d+)(?:/episode/(?P<episode>\d+))?)?)?(?:/|$)")
 mal_details_pattern = re.compile(r"^/details/mal/anime/(?P<mal_id>\d+)(?:/|$)")
 tracked_statuses = {
     "dropped": ("text-red", "Dropped"),
@@ -25,6 +25,19 @@ tracked_types = {
     "anime": ("anime", "mal"),
 }
 cross_library_tracked_types = ["anime"]
+
+
+@staticmethod
+def _tvdb_match_id(match):
+    """Extract (item_id, id_type) from a tvdb_details_pattern match."""
+    tvdb_id = int(match.group("tvdb_id"))
+    season = match.group("season")
+    if season is not None:
+        episode = match.group("episode")
+        if episode is not None:
+            return f"{tvdb_id}_{season}_{episode}", "tvdb_episode"
+        return f"{tvdb_id}_{season}", "tvdb_season"
+    return tvdb_id, "tvdb"
 
 
 class YamTrack:
@@ -168,18 +181,7 @@ class YamTrack:
                     match = tvdb_details_pattern.match(parsed.path)
                     if not match:
                         continue
-                    item_id = int(match.group("tvdb_id"))
-                    season = match.group("season")
-                    episode = match.group("episode")
-                    if season is not None:
-                        if episode is not None:
-                            id_type = "tvdb_episode"
-                            item_id = f"{item_id}_{season}_{episode}"
-                        else:
-                            id_type = "tvdb_season"
-                            item_id = f"{item_id}_{season}"
-                    else:
-                        id_type = "tvdb"
+                    item_id, id_type = _tvdb_match_id(match)
                 if is_movie is True and id_type != "tmdb":
                     continue
                 if is_movie is False and id_type not in ("tmdb_show", "tvdb", "tvdb_season", "tvdb_episode"):
@@ -260,17 +262,8 @@ class YamTrack:
                 card = link.xpath("ancestor::div[@x-data][1]")
                 status = self._card_status(card[0] if card else link)
                 if status:
-                    season = match.group("season")
-                    episode = match.group("episode")
-                    if season is not None:
-                        if episode is not None:
-                            item_id = f"{match.group('tvdb_id')}_{season}_{episode}"
-                            yield item_id, "tvdb_episode", status
-                        else:
-                            item_id = f"{match.group('tvdb_id')}_{season}"
-                            yield item_id, "tvdb_season", status
-                    else:
-                        yield int(match.group("tvdb_id")), "tvdb", status
+                    item_id, id_type = _tvdb_match_id(match)
+                    yield item_id, id_type, status
                 continue
             card = link.xpath("ancestor::div[@x-data][1]")
             status = self._card_status(card[0] if card else link)

--- a/modules/yamtrack.py
+++ b/modules/yamtrack.py
@@ -195,6 +195,7 @@ class YamTrack:
                         continue
                     mal_ids.append(mal_id)
                     seen_mal.add(mal_id)
+            else:
                 for item_id, found_id_type, status in self._tracked_items(page):
                     if id_type == "tmdb_show":
                         if found_id_type not in ("tmdb_show", "tvdb") or status not in enabled_statuses:

--- a/modules/yamtrack.py
+++ b/modules/yamtrack.py
@@ -10,6 +10,7 @@ logger = util.logger
 
 builders = ["yamtrack_list", "yamtrack_list_details", "yamtrack_tracked"]
 details_pattern = re.compile(r"^/details/tmdb/(?P<media_type>movie|tv)/(?P<tmdb_id>\d+)(?:/|$)")
+tvdb_details_pattern = re.compile(r"^/details/tvdb/(?P<media_type>movie|tv)/(?P<tvdb_id>\d+)(?:/|$)")
 mal_details_pattern = re.compile(r"^/details/mal/anime/(?P<mal_id>\d+)(?:/|$)")
 tracked_statuses = {
     "dropped": ("text-red", "Dropped"),
@@ -136,7 +137,7 @@ class YamTrack:
             description = page.xpath("string(//*[@id='id_description'])").strip()
         return description
 
-    def get_tmdb_ids(self, method, list_url, is_movie=None):
+    def get_ids(self, method, list_url, is_movie=None):
         pretty = method.replace("_", " ").title()
         if logger:
             logger.info(f"Processing {pretty}: {list_url}")
@@ -146,26 +147,31 @@ class YamTrack:
         for href in page.xpath("//a/@href"):
             parsed = self._parse_href(href)
             match = details_pattern.match(parsed.path)
-            if not match:
-                continue
-            tmdb_id = int(match.group("tmdb_id"))
-            id_type = "tmdb" if match.group("media_type") == "movie" else "tmdb_show"
+            if match:
+                item_id = int(match.group("tmdb_id"))
+                id_type = "tmdb" if match.group("media_type") == "movie" else "tmdb_show"
+            else:
+                match = tvdb_details_pattern.match(parsed.path)
+                if not match:
+                    continue
+                item_id = int(match.group("tvdb_id"))
+                id_type = "tvdb"
             if is_movie is True and id_type != "tmdb":
                 continue
-            if is_movie is False and id_type != "tmdb_show":
+            if is_movie is False and id_type not in ("tmdb_show", "tvdb"):
                 continue
-            key = (tmdb_id, id_type)
+            key = (item_id, id_type)
             if key not in seen:
                 ids.append(key)
                 seen.add(key)
         if not ids:
-            raise Failed(f"YamTrack Error: No TMDb IDs found in {list_url}")
+            raise Failed(f"YamTrack Error: No IDs found in {list_url}")
         return ids
 
-    def get_tracked_tmdb_ids(self, tracked, is_movie=None):
+    def get_tracked_ids_from_config(self, tracked, is_movie=None):
         ids, _ = self.get_tracked_ids(tracked, is_movie=is_movie)
         if not ids:
-            raise Failed("YamTrack Error: No TMDb IDs found in tracked items")
+            raise Failed("YamTrack Error: No IDs found in tracked items")
         return ids
 
     def get_tracked_ids(self, tracked, is_movie=None):
@@ -189,11 +195,13 @@ class YamTrack:
                         continue
                     mal_ids.append(mal_id)
                     seen_mal.add(mal_id)
-            else:
-                for tmdb_id, found_id_type, status in self._tracked_items(page):
-                    if found_id_type != id_type or status not in enabled_statuses:
+                for item_id, found_id_type, status in self._tracked_items(page):
+                    if id_type == "tmdb_show":
+                        if found_id_type not in ("tmdb_show", "tvdb") or status not in enabled_statuses:
+                            continue
+                    elif found_id_type != id_type or status not in enabled_statuses:
                         continue
-                    key = (tmdb_id, found_id_type)
+                    key = (item_id, found_id_type)
                     if key not in seen:
                         ids.append(key)
                         seen.add(key)
@@ -217,6 +225,13 @@ class YamTrack:
             parsed = self._parse_href(href)
             match = details_pattern.match(parsed.path)
             if not match:
+                match = tvdb_details_pattern.match(parsed.path)
+                if not match:
+                    continue
+                card = link.xpath("ancestor::div[@x-data][1]")
+                status = self._card_status(card[0] if card else link)
+                if status:
+                    yield int(match.group("tvdb_id")), "tvdb", status
                 continue
             card = link.xpath("ancestor::div[@x-data][1]")
             status = self._card_status(card[0] if card else link)

--- a/modules/yamtrack.py
+++ b/modules/yamtrack.py
@@ -10,7 +10,7 @@ logger = util.logger
 
 builders = ["yamtrack_list", "yamtrack_list_details", "yamtrack_tracked"]
 details_pattern = re.compile(r"^/details/tmdb/(?P<media_type>movie|tv)/(?P<tmdb_id>\d+)(?:/|$)")
-tvdb_details_pattern = re.compile(r"^/details/tvdb/(?P<media_type>movie|tv)/(?P<tvdb_id>\d+)(?:/|$)")
+tvdb_details_pattern = re.compile(r"^/details/tvdb/(?P<media_type>movie|tv)/(?P<tvdb_id>\d+)(?:/[^/]+(?:/season/(?P<season>\d+)(?:/episode/(?P<episode>\d+))?)?)?(?:/|$)")
 mal_details_pattern = re.compile(r"^/details/mal/anime/(?P<mal_id>\d+)(?:/|$)")
 tracked_statuses = {
     "dropped": ("text-red", "Dropped"),
@@ -141,29 +141,57 @@ class YamTrack:
         pretty = method.replace("_", " ").title()
         if logger:
             logger.info(f"Processing {pretty}: {list_url}")
-        page = self._html(list_url)
         ids = []
         seen = set()
-        for href in page.xpath("//a/@href"):
-            parsed = self._parse_href(href)
-            match = details_pattern.match(parsed.path)
-            if match:
-                item_id = int(match.group("tmdb_id"))
-                id_type = "tmdb" if match.group("media_type") == "movie" else "tmdb_show"
+        page_num = 1
+        # YamTrack custom list order requires ?sort=custom
+        sep = "&" if "?" in list_url else "?"
+        list_url = f"{list_url}{sep}sort=custom"
+        while True:
+            page_sep = "&" if "?" in list_url else "?"
+            page_url = f"{list_url}{page_sep}page={page_num}" if page_num > 1 else list_url
+            if page_num == 1:
+                page = self._html(page_url)
             else:
-                match = tvdb_details_pattern.match(parsed.path)
-                if not match:
+                try:
+                    page = self._html(page_url)
+                except Failed:
+                    break
+            page_items = []
+            for href in page.xpath("//a/@href"):
+                parsed = self._parse_href(href)
+                match = details_pattern.match(parsed.path)
+                if match:
+                    item_id = int(match.group("tmdb_id"))
+                    id_type = "tmdb" if match.group("media_type") == "movie" else "tmdb_show"
+                else:
+                    match = tvdb_details_pattern.match(parsed.path)
+                    if not match:
+                        continue
+                    item_id = int(match.group("tvdb_id"))
+                    season = match.group("season")
+                    episode = match.group("episode")
+                    if season is not None:
+                        if episode is not None:
+                            id_type = "tvdb_episode"
+                            item_id = f"{item_id}_{season}_{episode}"
+                        else:
+                            id_type = "tvdb_season"
+                            item_id = f"{item_id}_{season}"
+                    else:
+                        id_type = "tvdb"
+                if is_movie is True and id_type != "tmdb":
                     continue
-                item_id = int(match.group("tvdb_id"))
-                id_type = "tvdb"
-            if is_movie is True and id_type != "tmdb":
-                continue
-            if is_movie is False and id_type not in ("tmdb_show", "tvdb"):
-                continue
-            key = (item_id, id_type)
-            if key not in seen:
-                ids.append(key)
-                seen.add(key)
+                if is_movie is False and id_type not in ("tmdb_show", "tvdb", "tvdb_season", "tvdb_episode"):
+                    continue
+                key = (item_id, id_type)
+                if key not in seen:
+                    page_items.append(key)
+                    seen.add(key)
+            if not page_items:
+                break
+            ids.extend(page_items)
+            page_num += 1
         if not ids:
             raise Failed(f"YamTrack Error: No IDs found in {list_url}")
         return ids
@@ -198,7 +226,7 @@ class YamTrack:
             else:
                 for item_id, found_id_type, status in self._tracked_items(page):
                     if id_type == "tmdb_show":
-                        if found_id_type not in ("tmdb_show", "tvdb") or status not in enabled_statuses:
+                        if found_id_type not in ("tmdb_show", "tvdb", "tvdb_season", "tvdb_episode") or status not in enabled_statuses:
                             continue
                     elif found_id_type != id_type or status not in enabled_statuses:
                         continue
@@ -232,7 +260,17 @@ class YamTrack:
                 card = link.xpath("ancestor::div[@x-data][1]")
                 status = self._card_status(card[0] if card else link)
                 if status:
-                    yield int(match.group("tvdb_id")), "tvdb", status
+                    season = match.group("season")
+                    episode = match.group("episode")
+                    if season is not None:
+                        if episode is not None:
+                            item_id = f"{match.group('tvdb_id')}_{season}_{episode}"
+                            yield item_id, "tvdb_episode", status
+                        else:
+                            item_id = f"{match.group('tvdb_id')}_{season}"
+                            yield item_id, "tvdb_season", status
+                    else:
+                        yield int(match.group("tvdb_id")), "tvdb", status
                 continue
             card = link.xpath("ancestor::div[@x-data][1]")
             status = self._card_status(card[0] if card else link)

--- a/tests/test_yamtrack.py
+++ b/tests/test_yamtrack.py
@@ -37,7 +37,7 @@ def test_yamtrack_list_extracts_tmdb_movie_and_show_ids():
     <a href="/details/tmdb/tv/1396/breaking-bad">Duplicate</a>
     """
 
-    assert get_yamtrack(html).get_tmdb_ids("yamtrack_list", "https://yamtrack.example/list/1") == [(550, "tmdb"), (1396, "tmdb_show")]
+    assert get_yamtrack(html).get_ids("yamtrack_list", "https://yamtrack.example/list/1") == [(550, "tmdb"), (1396, "tmdb_show")]
 
 
 def test_yamtrack_list_filters_by_library_type():
@@ -47,13 +47,13 @@ def test_yamtrack_list_filters_by_library_type():
     """
     yamtrack = get_yamtrack(html)
 
-    assert yamtrack.get_tmdb_ids("yamtrack_list", "https://yamtrack.example/list/1", is_movie=True) == [(550, "tmdb")]
-    assert yamtrack.get_tmdb_ids("yamtrack_list", "https://yamtrack.example/list/1", is_movie=False) == [(1396, "tmdb_show")]
+    assert yamtrack.get_ids("yamtrack_list", "https://yamtrack.example/list/1", is_movie=True) == [(550, "tmdb")]
+    assert yamtrack.get_ids("yamtrack_list", "https://yamtrack.example/list/1", is_movie=False) == [(1396, "tmdb_show")]
 
 
 def test_yamtrack_rejects_lookalike_hosts():
     with pytest.raises(Failed, match="must start with https://yamtrack.example"):
-        get_yamtrack("").get_tmdb_ids("yamtrack_list", "https://yamtrack.example.evil/list/1")
+        get_yamtrack("").get_ids("yamtrack_list", "https://yamtrack.example.evil/list/1")
 
 
 def test_yamtrack_list_details_extracts_description():
@@ -120,7 +120,7 @@ def test_yamtrack_tracked_extracts_enabled_statuses():
         },
     )
 
-    assert yamtrack.get_tracked_tmdb_ids(tracked) == [(80350, "tmdb_show"), (60574, "tmdb_show")]
+    assert yamtrack.get_tracked_ids_from_config(tracked) == [(80350, "tmdb_show"), (60574, "tmdb_show")]
     assert requests.gets[0][0] == "https://yamtrack.example/user/movie"
     assert requests.gets[1][0] == "https://yamtrack.example/user/tv"
 
@@ -139,8 +139,8 @@ def test_yamtrack_tracked_filters_by_library_type():
     yamtrack = get_yamtrack(html)
     tracked = yamtrack.validate_tracked("Collection", {"movies": {"planning": True}, "tv_shows": {"planning": True}})
 
-    assert yamtrack.get_tracked_tmdb_ids(tracked, is_movie=True) == [(550, "tmdb")]
-    assert yamtrack.get_tracked_tmdb_ids(tracked, is_movie=False) == [(80350, "tmdb_show")]
+    assert yamtrack.get_tracked_ids_from_config(tracked, is_movie=True) == [(550, "tmdb")]
+    assert yamtrack.get_tracked_ids_from_config(tracked, is_movie=False) == [(80350, "tmdb_show")]
 
 
 def test_yamtrack_tracked_sections_are_optional():
@@ -154,7 +154,7 @@ def test_yamtrack_tracked_sections_are_optional():
     yamtrack = YamTrack(requests, {"url": "https://yamtrack.example", "username": "user", "password": "pass"})
     tracked = yamtrack.validate_tracked("Collection", {"movies": {"planning": True}})
 
-    assert yamtrack.get_tracked_tmdb_ids(tracked) == [(550, "tmdb")]
+    assert yamtrack.get_tracked_ids_from_config(tracked) == [(550, "tmdb")]
     assert [get[0] for get in requests.gets] == ["https://yamtrack.example/user/movie"]
     assert all(enabled is False for enabled in tracked["anime"].values())
 
@@ -177,7 +177,7 @@ def test_yamtrack_tracked_statuses_default_true_when_section_exists():
     assert all(enabled is True for enabled in tracked["movies"].values())
     assert all(enabled is False for enabled in tracked["tv_shows"].values())
     assert all(enabled is False for enabled in tracked["anime"].values())
-    assert yamtrack.get_tracked_tmdb_ids(tracked) == [(550, "tmdb"), (551, "tmdb")]
+    assert yamtrack.get_tracked_ids_from_config(tracked) == [(550, "tmdb"), (551, "tmdb")]
 
 
 def test_yamtrack_tracked_extracts_anime_mal_ids():
@@ -237,3 +237,64 @@ def test_yamtrack_tracked_present_section_must_be_dictionary():
 
     with pytest.raises(Failed, match="yamtrack_tracked anime must be a dictionary"):
         yamtrack.validate_tracked("Collection", {"anime": True}, is_movie=True)
+
+
+def test_yamtrack_list_extracts_tvdb_show_ids():
+    html = """
+    <a href="/details/tvdb/tv/85040/caprica">Caprica</a>
+    """
+
+    assert get_yamtrack(html).get_ids("yamtrack_list", "https://yamtrack.example/list/1") == [(85040, "tvdb")]
+
+
+def test_yamtrack_list_extracts_mixed_tmdb_and_tvdb_ids():
+    html = """
+    <a href="/details/tmdb/movie/550/fight-club">Fight Club</a>
+    <a href="/details/tvdb/tv/85040/caprica">Caprica</a>
+    """
+
+    assert get_yamtrack(html).get_ids("yamtrack_list", "https://yamtrack.example/list/1") == [
+        (550, "tmdb"),
+        (85040, "tvdb"),
+    ]
+
+
+def test_yamtrack_tracked_extracts_tvdb_show_ids():
+    html = """
+    <div x-data="{ trackOpen: false }">
+      <a href="/details/tvdb/tv/85040/caprica">Caprica</a>
+      <div class="w-4 h-4 text-emerald-400"></div>
+    </div>
+    <div x-data="{ trackOpen: false }">
+      <a href="/details/tvdb/tv/71663/the-expanse">The Expanse</a>
+      <div class="w-4 h-4 text-indigo-400"></div>
+    </div>
+    """
+    requests = FakeRequests(html)
+    yamtrack = YamTrack(requests, {"url": "https://yamtrack.example", "username": "user", "password": "pass"})
+    tracked = yamtrack.validate_tracked(
+        "Collection",
+        {
+            "tv_shows": {"completed": True, "in_progress": True},
+        },
+    )
+
+    assert yamtrack.get_tracked_ids_from_config(tracked) == [(85040, "tvdb"), (71663, "tvdb")]
+
+
+def test_yamtrack_tracked_filters_tvdb_by_library_type():
+    html = """
+    <div x-data="{ trackOpen: false }">
+      <a href="/details/tmdb/movie/550/fight-club">Fight Club</a>
+      <div class="w-4 h-4 text-sky-400"></div>
+    </div>
+    <div x-data="{ trackOpen: false }">
+      <a href="/details/tvdb/tv/85040/caprica">Caprica</a>
+      <div class="w-4 h-4 text-sky-400"></div>
+    </div>
+    """
+    yamtrack = get_yamtrack(html)
+    tracked = yamtrack.validate_tracked("Collection", {"movies": {"planning": True}, "tv_shows": {"planning": True}})
+
+    assert yamtrack.get_tracked_ids_from_config(tracked, is_movie=True) == [(550, "tmdb")]
+    assert yamtrack.get_tracked_ids_from_config(tracked, is_movie=False) == [(85040, "tvdb")]


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG.md and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

YamTrack yamtrack_list and yamtrack_tracked builders now extract TVDB show, season, and episode IDs alongside existing TMDb support. TVDB IDs feed into the existing TVDb lookup, which resolves them to TMDb IDs for downstream builders.

This functionality (tvdb) is currently only available in the "Trakt" fork of Yamtrack:
https://github.com/dannyvfilms/Yamtrack

### How it works
 - New tvdb_details_pattern regex matches /details/tvdb/(movie|tv)/<id> URLs with optional season/episode groups
 - YamTrack.get_ids (renamed from get_tmdb_ids) returns (id, type) tuples where type can now be tvdb, tvdb_season, or
   tvdb_episode
 - get_tracked_ids_from_config (renamed from get_tracked_tmdb_ids) filters TVDB-tracked items by status and season/episode
 - Extracted TVDB ID resolution logic into shared `_tvdb_match_id` helper
 - YamTrack list pages are paginated via URL query params. dannyvfilms' fork has an RSS endpoint that would have been
 cleaner, but upstream YamTrack only exposes HTML. So we are sticking with scraping for compatibility if/when base YamTrack
 adds TVDB support.

 ### How it was tested

 - tests/test_yamtrack.py: TVDB list extraction, TVDB tracked page extraction, filtering by library type and status
 - tests/test_builder.py: CircuitOpen resilience during TVDb outage
 - Full test suite passes (267 tests)
 - I have tested this locally and playlists are now updated with tvdb ids from Yamtrack to Plex. It can now have playlists with both series (tvdb) and movies (tmdb) intermingled.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, GitHub will automatically close the issue.
-->
- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

<!--
    This is optional and only necessary when your PR changes supported attributes,
    accepted values, or structure for Configuration Files, Collection Files,
    Metadata Files, Overlay Files, Playlist Files, or Defaults template variables.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG.md entry.
    We may ask you to update the CHANGELOG.md if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
