### PR TITLE
[Defaults: Streaming] Stop using non-existent `Originals` lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Propagate the exit code from the worker process so `--validate` (and other runs) return a non-zero status on failure. Previously `start()` ran inside a `ProcessPoolExecutor` whose result was never retrieved, so a `sys.exit(1)` from a failed validation was swallowed and the parent always exited `0`, breaking CI usage.
 - Fix the startup requirements version check so each package is compared against its own pinned requirement. Previously `v1`/`v2` leaked between loop iterations and the package name lookup was case-sensitive, causing bogus messages such as `GitPython version: 3.1.55 does not match expected: 1.4.14`, where the expected value came from an unrelated package.
 - Resolve movie folder paths using the path style reported by the media server rather than the platform Kometa runs on. A Linux or Docker install pointed at a Plex server on Windows received paths such as `P:\Movies\Title\file.mkv`, which `os.path.dirname` reduced to an empty string, logging `Plex Error: No location found` for every movie and silently disabling `add_existing`, `upgrade_existing`, `monitor_existing`, `item_radarr_tag`, and `item_sonarr_tag`.
-
+- Fix `streaming` Defaults to more consistently use regional variants of Amazon, and stop trying to use `Originals` lists that do not exist
 ## [v2.4.5] - 2026-07-22
 
 ### Added

--- a/defaults/both/streaming.yml
+++ b/defaults/both/streaming.yml
@@ -39,7 +39,7 @@ templates:
       final_tmdb_key:
         default: <<tmdb_key>>
         conditions:
-          - region: [CA, AU, NL, ES]
+          - region.not: [AT, DE, GB, JP, US]
             tmdb_key: [9]
             value: 119
 
@@ -54,7 +54,7 @@ templates:
       allowed_streaming:
         conditions:
           - originals_only: true
-            tmdb_key: [103, 1759, 41, 2300, 230, 283, 510, 39, 37, 188]
+            tmdb_key: [103, 1759, 41, 2300, 230, 283, 510, 39, 37, 188, 149, 339, 2241, 528, 1854, 63, 73, 62, 2162]
             value: False
           - region.not: GB
             tmdb_key: [103, 41, 2300, 39]

--- a/defaults/overlays/streaming.yml
+++ b/defaults/overlays/streaming.yml
@@ -94,13 +94,13 @@ templates:
       final_tmdb_key:
         default: <<tmdb_key>>
         conditions:
-          - region: [CA, AU, NL, ES]
+          - region.not: [AT, DE, GB, JP, US]
             tmdb_key: [9]
             value: 119
       allowed_streaming:
         conditions:
           - originals_only: true
-            tmdb_key: [103, 1759, 41, 2300, 230, 283, 510, 39, 37, 188]
+            tmdb_key: [103, 1759, 41, 2300, 230, 283, 510, 39, 37, 188, 149, 339, 2241, 528, 1854, 63, 73, 62, 2162]
             value: False
           - region.not: GB
             tmdb_key: [103, 41, 2300, 39]

--- a/docs/defaults/both/streaming.md
+++ b/docs/defaults/both/streaming.md
@@ -23,7 +23,7 @@ hide:
 | `discovery+ Shows`            | `discovery`   | Collection of Shows Streaming on discovery+.            |
 | `Disney+ Movies/Shows`        | `disney`      | Collection of Movies/Shows Streaming on Disney+.        |
 | `Filmin Movies/Shows`         | `filmin`      | Collection of Movies/Shows Streaming on Filmin.         |
-| `Hayu Shows`                  | `hayu`        | Collection of Shows Streaming on Hulu.                  |
+| `Hayu Shows`                  | `hayu`        | Collection of Shows Streaming on hayu.                  |
 | `HBO Max Movies/Shows`        | `hbomax`      | Collection of Movies/Shows Streaming on HBO Max.        |
 | `Hulu Movies/Shows`           | `hulu`        | Collection of Movies/Shows Streaming on Hulu.           |
 | `ITVX Movies/Shows`           | `itvx`        | Collection of Movies/Shows Streaming on ITVX.           |


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [] Documentation Update
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Corrects provider handling in the streaming collection and overlay defaults.

- Uses TMDb provider ID `119` for Prime Video in all regions except `AT`, `DE`, `GB`, `JP`, and `US`, where provider ID `9` is used.
- Prevents Movistar Plus+, AMC+, Filmin, Tubi, and Atres Player from running when `originals_only` is enabled because corresponding originals lists are not available.
- Applies the same provider logic to both streaming collections and streaming overlays.
- Corrects the Hayu documentation, which previously referred to Hulu.

The updated Prime Video region handling was checked against TMDb's region-filtered movie and TV watch-provider data.

## Related Issues [optional]

- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

- [X] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [] No