### PR TITLE
Add folder location support to smart filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add `folder_location` and `folder_location.not` Plex search attributes for smart collections and Plex searches, using the root folders configured on the Plex library.
 - Add `--timings`/`--timing` (`KOMETA_TIMINGS`/`KOMETA_TIMING`) runtime support for diagnosing slow runs. When enabled, network calls, cache lookups, and major per-collection/per-library phases are timed; a summary prints to the log at the end of the run and a full per-source/per-library breakdown is exported as JSON/CSV to the logs directory. Disabled by default, with negligible overhead when off. Also adds an optional `KOMETA_PROFILE=pyinstrument` environment variable for deeper single-run profiling, writing an HTML report to the logs directory.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add `folder_location` and `folder_location.not` Plex search attributes for smart collections and Plex searches, using the root folders configured on the Plex library.
+- Add `folder_location` and `folder_location.not` Plex search attributes for movie, show, and track-level music smart collections and Plex searches, using the root folders configured on the Plex library.
 - Add `--timings`/`--timing` (`KOMETA_TIMINGS`/`KOMETA_TIMING`) runtime support for diagnosing slow runs. When enabled, network calls, cache lookups, and major per-collection/per-library phases are timed; a summary prints to the log at the end of the run and a full per-source/per-library breakdown is exported as JSON/CSV to the logs directory. Disabled by default, with negligible overhead when off. Also adds an optional `KOMETA_PROFILE=pyinstrument` environment variable for deeper single-run profiling, writing an HTML report to the logs directory.
 
 ### Fixed

--- a/docs/files/builders/plex/search-options.md
+++ b/docs/files/builders/plex/search-options.md
@@ -167,6 +167,7 @@ The majority of Smart and Manual Builders utilize the same Search Options, meani
     | `country`                                                                                        | Uses the country tags to match                                              | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
     | `decade` :material-numeric-1-circle:{ data-tooltip data-tooltip-id="tippy-plex-search-1" }       | Uses the year tag to match the decade                                       | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |  :fontawesome-solid-circle-xmark:{ .red }  |
     | `director`                                                                                       | Uses the director tags to match                                             | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |  :fontawesome-solid-circle-xmark:{ .red }  |
+    | `folder_location`                                                                                | Uses the Plex library root folder location to match                         | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
     | `genre`                                                                                          | Uses the genre tags to match                                                | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
     | `label`                                                                                          | Uses the label tags to match for top level collections                      | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
     | `season_label`                                                                                   | Uses the label tags to match for season collections                         |  :fontawesome-solid-circle-xmark:{ .red }  | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
@@ -199,10 +200,12 @@ The majority of Smart and Manual Builders utilize the same Search Options, meani
     :material-numeric-1-circle:{ data-tooltip data-tooltip-id="tippy-plex-search-1" }You can use `current_year` to have Kometa use the current years value. This can be combined with a 
     `-#` at the end to subtract that number of years. i.e. `current_year-2`
 
+    `folder_location` values must match a root folder configured in the Plex library. Plex does not expose nested
+    subfolders as Folder Location filter choices.
+
     ???+ tip "Tag Filter Modifiers" 
 
         | Tag Modifier | Description                                                            | Plex Web UI Display |
         |:-------------|:-----------------------------------------------------------------------|:-------------------:|
         | No Modifier  | Matches every item where the attribute matches the given string        |        `is`         |
         | `.not`       | Matches every item where the attribute does not match the given string |      `is not`       |
-

--- a/docs/files/builders/plex/search-options.md
+++ b/docs/files/builders/plex/search-options.md
@@ -167,7 +167,7 @@ The majority of Smart and Manual Builders utilize the same Search Options, meani
     | `country`                                                                                        | Uses the country tags to match                                              | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
     | `decade` :material-numeric-1-circle:{ data-tooltip data-tooltip-id="tippy-plex-search-1" }       | Uses the year tag to match the decade                                       | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |  :fontawesome-solid-circle-xmark:{ .red }  |
     | `director`                                                                                       | Uses the director tags to match                                             | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |  :fontawesome-solid-circle-xmark:{ .red }  |
-    | `folder_location`                                                                                | Uses the Plex library root folder location to match                         | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
+    | `folder_location`                                                                                | Uses the Plex library root folder location to match                         | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |
     | `genre`                                                                                          | Uses the genre tags to match                                                | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
     | `label`                                                                                          | Uses the label tags to match for top level collections                      | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
     | `season_label`                                                                                   | Uses the label tags to match for season collections                         |  :fontawesome-solid-circle-xmark:{ .red }  | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
@@ -201,7 +201,8 @@ The majority of Smart and Manual Builders utilize the same Search Options, meani
     `-#` at the end to subtract that number of years. i.e. `current_year-2`
 
     `folder_location` values must match a root folder configured in the Plex library. Plex does not expose nested
-    subfolders as Folder Location filter choices.
+    subfolders as Folder Location filter choices. In music libraries, `folder_location` is only available with
+    `builder_level: track`.
 
     ???+ tip "Tag Filter Modifiers" 
 

--- a/docs/files/builders/plex/smart-filter.md
+++ b/docs/files/builders/plex/smart-filter.md
@@ -65,6 +65,14 @@ collections:
 ```
 ```yaml
 collections:
+  Music From Archive Folder:
+    builder_level: track
+    smart_filter:
+      all:
+        folder_location: /media/music-archive
+```
+```yaml
+collections:
   Top Action Movies:
     smart_filter:
       all:

--- a/docs/files/builders/plex/smart-filter.md
+++ b/docs/files/builders/plex/smart-filter.md
@@ -58,6 +58,13 @@ collections:
 ```
 ```yaml
 collections:
+  Movies Outside Main Folder:
+    smart_filter:
+      all:
+        folder_location.not: /media/movies
+```
+```yaml
+collections:
   Top Action Movies:
     smart_filter:
       all:

--- a/docs/templates/snippets/plex_search_options.md
+++ b/docs/templates/snippets/plex_search_options.md
@@ -168,6 +168,7 @@
         | `country`                                                                                        | Uses the country tags to match                                              | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
         | `decade` :material-numeric-1-circle:{ data-tooltip data-tooltip-id="tippy-plex-search-1" }       | Uses the year tag to match the decade                                       | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |  :fontawesome-solid-circle-xmark:{ .red }  |
         | `director`                                                                                       | Uses the director tags to match                                             | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |  :fontawesome-solid-circle-xmark:{ .red }  |
+        | `folder_location`                                                                                | Uses the Plex library root folder location to match                         | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
         | `genre`                                                                                          | Uses the genre tags to match                                                | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
         | `label`                                                                                          | Uses the label tags to match for top level collections                      | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
         | `season_label`                                                                                   | Uses the label tags to match for season collections                         |  :fontawesome-solid-circle-xmark:{ .red }  | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
@@ -200,10 +201,12 @@
         :material-numeric-1-circle:{ data-tooltip data-tooltip-id="tippy-plex-search-1" }You can use `current_year` to have Kometa use the current years value. This can be combined with a 
         `-#` at the end to subtract that number of years. i.e. `current_year-2`
 
+        `folder_location` values must match a root folder configured in the Plex library. Plex does not expose nested
+        subfolders as Folder Location filter choices.
+
         ???+ tip "Tag Filter Modifiers" 
 
             | Tag Modifier | Description                                                            | Plex Web UI Display |
             |:-------------|:-----------------------------------------------------------------------|:-------------------:|
             | No Modifier  | Matches every item where the attribute matches the given string        |        `is`         |
             | `.not`       | Matches every item where the attribute does not match the given string |      `is not`       |
-

--- a/docs/templates/snippets/plex_search_options.md
+++ b/docs/templates/snippets/plex_search_options.md
@@ -168,7 +168,7 @@
         | `country`                                                                                        | Uses the country tags to match                                              | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
         | `decade` :material-numeric-1-circle:{ data-tooltip data-tooltip-id="tippy-plex-search-1" }       | Uses the year tag to match the decade                                       | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |  :fontawesome-solid-circle-xmark:{ .red }  |
         | `director`                                                                                       | Uses the director tags to match                                             | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |  :fontawesome-solid-circle-xmark:{ .red }  |
-        | `folder_location`                                                                                | Uses the Plex library root folder location to match                         | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
+        | `folder_location`                                                                                | Uses the Plex library root folder location to match                         | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |
         | `genre`                                                                                          | Uses the genre tags to match                                                | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
         | `label`                                                                                          | Uses the label tags to match for top level collections                      | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
         | `season_label`                                                                                   | Uses the label tags to match for season collections                         |  :fontawesome-solid-circle-xmark:{ .red }  | :fontawesome-solid-circle-check:{ .green } |  :fontawesome-solid-circle-xmark:{ .red }  |
@@ -202,7 +202,8 @@
         `-#` at the end to subtract that number of years. i.e. `current_year-2`
 
         `folder_location` values must match a root folder configured in the Plex library. Plex does not expose nested
-        subfolders as Folder Location filter choices.
+        subfolders as Folder Location filter choices. In music libraries, `folder_location` is only available with
+        `builder_level: track`.
 
         ???+ tip "Tag Filter Modifiers" 
 

--- a/json-schema/builders/plex.yml
+++ b/json-schema/builders/plex.yml
@@ -95,6 +95,12 @@ collections:
       sort_by: year.desc
       limit: 50
 
+  Movies Outside Main Folder (Smart):
+    smart_filter:
+      all:
+        folder_location.not: /media/movies
+      sort_by: title.asc
+
   Mixed Genre Picks (Smart - any):
     smart_filter:
       any:

--- a/json-schema/builders/plex.yml
+++ b/json-schema/builders/plex.yml
@@ -101,6 +101,12 @@ collections:
         folder_location.not: /media/movies
       sort_by: title.asc
 
+  Music From Archive Folder (Smart):
+    builder_level: track
+    smart_filter:
+      all:
+        folder_location: /media/music-archive
+
   Mixed Genre Picks (Smart - any):
     smart_filter:
       any:

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -3989,7 +3989,7 @@ class CollectionBuilder:
                 attr, modifier, final_attr = self.library.split(_key)
 
                 def build_url_arg(arg, mod=None, arg_s=None, mod_s=None):
-                    arg_key = self.library.get_search_key(attr) if attr == "folder_location" else plex.search_translation[attr] if attr in plex.search_translation else attr
+                    arg_key = self.library.get_search_key(attr, libtype=sort_type) if attr == "folder_location" else plex.search_translation[attr] if attr in plex.search_translation else attr
                     arg_key = plex.show_translation[arg_key] if self.library.is_show and arg_key in plex.show_translation else arg_key
                     if mod is None:
                         mod = plex.modifier_translation[modifier] if modifier in plex.modifier_translation else modifier
@@ -4010,7 +4010,7 @@ class CollectionBuilder:
                     error = f"{self.Type} Error: {method} attribute '{final_attr}' only works for movie libraries"
                 elif self.library.is_movie and final_attr in plex.show_only_searches:
                     error = f"{self.Type} Error: {method} attribute '{final_attr}' only works for show libraries"
-                elif self.library.is_music and final_attr not in plex.music_searches + ["all", "any"]:
+                elif self.library.is_music and final_attr not in plex.music_searches + (plex.track_only_searches if sort_type == "track" else []) + ["all", "any"]:
                     error = f"{self.Type} Error: {method} attribute '{final_attr}' does not work for music libraries"
                 elif not self.library.is_music and final_attr in plex.music_searches:
                     error = f"{self.Type} Error: {method} attribute '{final_attr}' only works for music libraries"
@@ -4029,7 +4029,7 @@ class CollectionBuilder:
                                 display_add += inside_display
                                 results += f"{conjunction if len(results) > 0 else ''}push=1&{inside_filter}pop=1&"
                     else:
-                        validation = self.validate_attribute(attr, modifier, final_attr, _data, validate, plex_search=True)
+                        validation = self.validate_attribute(attr, modifier, final_attr, _data, validate, plex_search=True, plex_search_type=sort_type)
                         if validation is not False and validation != 0 and not validation:
                             continue
                         elif attr in plex.date_attributes and modifier in ["", ".not"]:
@@ -4107,12 +4107,12 @@ class CollectionBuilder:
             logger.debug(f"Smart URL: {filter_url}")
         return type_key, filter_details, filter_url
 
-    def validate_attribute(self, attribute, modifier, final, data, validate, plex_search=False):
+    def validate_attribute(self, attribute, modifier, final, data, validate, plex_search=False, plex_search_type=None):
         def smart_pair(list_to_pair):
             return [(t, t) for t in list_to_pair] if plex_search else list_to_pair
 
         if attribute in tag_attributes and modifier in [".regex"]:
-            _, names = self.library.get_search_choices(attribute, title=not plex_search, name_pairs=True)
+            _, names = self.library.get_search_choices(attribute, title=not plex_search, name_pairs=True, libtype=plex_search_type)
             valid_list = []
             used = []
             for reg in util.validate_regex(data, self.Type, validate=validate):
@@ -4221,7 +4221,7 @@ class CollectionBuilder:
                         final_values.append(value)
             else:
                 final_values = util.get_list(data, trim=False) or []
-            search_choices, names = self.library.get_search_choices(attribute, title=not plex_search)
+            search_choices, names = self.library.get_search_choices(attribute, title=not plex_search, libtype=plex_search_type)
             valid_list = []
             for fvalue in final_values:
                 if str(fvalue) in search_choices or str(fvalue).lower() in search_choices:

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -3989,7 +3989,7 @@ class CollectionBuilder:
                 attr, modifier, final_attr = self.library.split(_key)
 
                 def build_url_arg(arg, mod=None, arg_s=None, mod_s=None):
-                    arg_key = plex.search_translation[attr] if attr in plex.search_translation else attr
+                    arg_key = self.library.get_search_key(attr) if attr == "folder_location" else plex.search_translation[attr] if attr in plex.search_translation else attr
                     arg_key = plex.show_translation[arg_key] if self.library.is_show and arg_key in plex.show_translation else arg_key
                     if mod is None:
                         mod = plex.modifier_translation[modifier] if modifier in plex.modifier_translation else modifier

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -586,6 +586,7 @@ searches = (
     + [f"{f}{m}" for f in float_attributes for m in float_modifiers if f != "duration" or m != ".rated"]
 )
 music_searches = [a for a in searches if a.startswith(("artist", "album", "track"))]
+track_only_searches = ["folder_location", "folder_location.not", "folder_location.regex"]
 movie_sorts = {
     "title.asc": "titleSort",
     "title.desc": "titleSort%3Adesc",
@@ -1247,23 +1248,24 @@ class Plex(Library):
             raise Failed(f"Plex Error: Failed to find person ID for '{name}': {e}") from e
 
     @PLEX_RETRY
-    def get_search_key(self, search_name):
+    def get_search_key(self, search_name, libtype=None):
         final_search = search_translation[search_name] if search_name in search_translation else search_name
         final_search = show_translation[final_search] if self.is_show and final_search in show_translation else final_search
         if search_name == "folder_location":
-            filters = self.Plex.listFilters(self.Plex.TYPE)
+            filter_type = libtype or self.Plex.TYPE
+            filters = self.Plex.listFilters(filter_type)
             try:
                 folder_filter = next(f for f in filters if f.filter == "source" or str(f.title).lower().replace(" ", "_") == "folder_location")
             except StopIteration:
                 available_filters = [f.filter for f in filters]
-                raise NotFound(f'Unknown filter field "folder_location" for libtype "{self.Plex.TYPE}". Available filters: {available_filters}') from None
+                raise NotFound(f'Unknown filter field "folder_location" for libtype "{filter_type}". Available filters: {available_filters}') from None
             return folder_filter.filter
         return final_search
 
-    def get_search_choices(self, search_name, title=True, name_pairs=False):
+    def get_search_choices(self, search_name, title=True, name_pairs=False, libtype=None):
         final_search = search_name
         try:
-            final_search = self.get_search_key(search_name)
+            final_search = self.get_search_key(search_name, libtype=libtype)
             final_search = get_tags_translation[final_search] if final_search in get_tags_translation else final_search
             names = []
             choices = {}

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -374,8 +374,45 @@ item_advance_keys = {
     "item_subtitle_mode": ("subtitleMode", subtitle_mode_options),
 }
 new_plex_agents = ["tv.plex.agents.movie", "tv.plex.agents.series"]
-and_searches = ["title.and", "studio.and", "actor.and", "audio_language.and", "collection.and", "content_rating.and", "country.and", "director.and", "genre.and", "label.and", "network.and", "producer.and", "subtitle_language.and", "writer.and"]
-or_searches = ["title", "studio", "actor", "audio_language", "collection", "content_rating", "country", "director", "genre", "label", "network", "producer", "subtitle_language", "writer", "decade", "resolution", "year", "episode_title", "episode_year"]
+and_searches = [
+    "title.and",
+    "studio.and",
+    "actor.and",
+    "audio_language.and",
+    "collection.and",
+    "content_rating.and",
+    "country.and",
+    "director.and",
+    "folder_location.and",
+    "genre.and",
+    "label.and",
+    "network.and",
+    "producer.and",
+    "subtitle_language.and",
+    "writer.and",
+]
+or_searches = [
+    "title",
+    "studio",
+    "actor",
+    "audio_language",
+    "collection",
+    "content_rating",
+    "country",
+    "director",
+    "folder_location",
+    "genre",
+    "label",
+    "network",
+    "producer",
+    "subtitle_language",
+    "writer",
+    "decade",
+    "resolution",
+    "year",
+    "episode_title",
+    "episode_year",
+]
 movie_only_searches = [
     "director",
     "director.not",
@@ -497,7 +534,7 @@ number_attributes = ["plays", "episode_plays", "album_plays", "track_plays", "tr
 number_modifiers = [".gt", ".gte", ".lt", ".lte"]
 float_attributes = ["user_rating", "episode_user_rating", "critic_rating", "episode_critic_rating", "audience_rating", "episode_audience_rating", "duration", "artist_user_rating", "album_user_rating", "album_critic_rating", "track_user_rating"]
 float_modifiers = number_modifiers + [".rated"]
-search_display = {"added": "Date Added", "release": "Release Date", "hdr": "HDR", "progress": "In Progress", "episode_progress": "Episode In Progress"}
+search_display = {"added": "Date Added", "release": "Release Date", "folder_location": "Folder Location", "hdr": "HDR", "progress": "In Progress", "episode_progress": "Episode In Progress"}
 tag_attributes = [
     "actor",
     "episode_actor",
@@ -506,6 +543,7 @@ tag_attributes = [
     "content_rating",
     "country",
     "director",
+    "folder_location",
     "genre",
     "label",
     "season_label",
@@ -1208,11 +1246,25 @@ class Plex(Library):
         except (BadRequest, NotFound, Unauthorized) as e:
             raise Failed(f"Plex Error: Failed to find person ID for '{name}': {e}") from e
 
-    def get_search_choices(self, search_name, title=True, name_pairs=False):
+    @PLEX_RETRY
+    def get_search_key(self, search_name):
         final_search = search_translation[search_name] if search_name in search_translation else search_name
         final_search = show_translation[final_search] if self.is_show and final_search in show_translation else final_search
-        final_search = get_tags_translation[final_search] if final_search in get_tags_translation else final_search
+        if search_name == "folder_location":
+            filters = self.Plex.listFilters(self.Plex.TYPE)
+            try:
+                folder_filter = next(f for f in filters if f.filter == "source" or str(f.title).lower().replace(" ", "_") == "folder_location")
+            except StopIteration:
+                available_filters = [f.filter for f in filters]
+                raise NotFound(f'Unknown filter field "folder_location" for libtype "{self.Plex.TYPE}". Available filters: {available_filters}') from None
+            return folder_filter.filter
+        return final_search
+
+    def get_search_choices(self, search_name, title=True, name_pairs=False):
+        final_search = search_name
         try:
+            final_search = self.get_search_key(search_name)
+            final_search = get_tags_translation[final_search] if final_search in get_tags_translation else final_search
             names = []
             choices = {}
             use_title = title and final_search not in ["contentRating", "audioLanguage", "subtitleLanguage", "resolution"]

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -668,7 +668,55 @@ class TestBuildFilter:
 
         assert expected_filter in url
         assert "Folder Location" in details
-        library.get_search_choices.assert_called_once_with("folder_location", title=False)
+        library.get_search_choices.assert_called_once_with("folder_location", title=False, libtype="movie")
+
+    def test_builds_track_folder_location_smart_filter(self):
+        import modules.plex as plex_module
+
+        list_filters = MagicMock(return_value=[SimpleNamespace(filter="source", title="Folder Location")])
+        library = plex_module.Plex.__new__(plex_module.Plex)
+        library.is_movie = False
+        library.is_show = False
+        library.is_music = True
+        library.Plex = SimpleNamespace(TYPE="artist", listFilters=list_filters)
+        library.get_tags = MagicMock(return_value=[SimpleNamespace(title="/media/music", key="12")])
+        builder = make_builder(
+            library=library,
+            builder_level="track",
+            details={"show_options": False},
+        )
+
+        _, details, url = builder.build_filter(
+            "smart_filter",
+            {"all": {"folder_location": "/media/music"}},
+            default_sort="random",
+        )
+
+        assert "source=12" in url
+        assert "Folder Location" in details
+        assert list_filters.call_count == 2
+        list_filters.assert_called_with("track")
+        library.get_tags.assert_called_once_with("source")
+
+    def test_rejects_folder_location_above_track_level_in_music_library(self):
+        library = SimpleNamespace(
+            is_movie=False,
+            is_show=False,
+            is_music=True,
+            split=lambda value: (value.removesuffix(".not"), ".not" if value.endswith(".not") else "", value),
+        )
+        builder = make_builder(
+            library=library,
+            builder_level="artist",
+            details={"show_options": False},
+        )
+
+        with pytest.raises(builder_module.BuilderValidationError, match="does not work for music libraries"):
+            builder.build_filter(
+                "smart_filter",
+                {"all": {"folder_location": "/media/music"}},
+                default_sort="random",
+            )
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -636,6 +636,40 @@ class TestBuildFilter:
         with pytest.raises(util.BuilderValidationError, match="must be a dictionary"):
             builder.build_filter("tmdb", "not_a_dict")
 
+    @pytest.mark.parametrize(
+        ("attribute", "expected_filter"),
+        [
+            ("folder_location", "source=7"),
+            ("folder_location.not", "source!=7"),
+        ],
+    )
+    def test_builds_folder_location_smart_filter(self, attribute, expected_filter):
+        import modules.plex as plex_module
+
+        library = plex_module.Plex.__new__(plex_module.Plex)
+        library.is_movie = True
+        library.is_show = False
+        library.is_music = False
+        library.Plex = SimpleNamespace(
+            TYPE="movie",
+            listFilters=lambda libtype: [SimpleNamespace(filter="source", title="Folder Location")],
+        )
+        library.get_search_choices = MagicMock(return_value=({"/media/movies": 7}, ["/media/movies"]))
+        builder = make_builder(
+            library=library,
+            details={"show_options": False},
+        )
+
+        _, details, url = builder.build_filter(
+            "smart_filter",
+            {"all": {attribute: "/media/movies"}},
+            default_sort="random",
+        )
+
+        assert expected_filter in url
+        assert "Folder Location" in details
+        library.get_search_choices.assert_called_once_with("folder_location", title=False)
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # Dispatch table sanity tests

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-from plexapi.exceptions import BadRequest
+from plexapi.exceptions import BadRequest, NotFound
 from requests.exceptions import ConnectionError, ReadTimeout
 from tenacity import wait_none
 
@@ -186,6 +186,67 @@ class TestNotify:
         plex = make_plex(config=mock_config, PlexServer=SimpleNamespace(friendlyName="MyServer"))
         plex.notify_delete("Playlist removed", playlist=True)
         mock_config.notify_delete.assert_called_once_with("Playlist removed", server="MyServer", library=None)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# search keys
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestSearchKeys:
+    def test_folder_location_uses_plex_source_filter(self):
+        section = SimpleNamespace(
+            TYPE="movie",
+            listFilters=lambda libtype: [
+                SimpleNamespace(filter="genre", title="Genre"),
+                SimpleNamespace(filter="source", title="Folder Location"),
+            ],
+        )
+        plex = make_plex(Plex=section)
+
+        assert plex.get_search_key("folder_location") == "source"
+
+    def test_folder_location_falls_back_to_filter_title(self):
+        section = SimpleNamespace(
+            TYPE="movie",
+            listFilters=lambda libtype: [SimpleNamespace(filter="location", title="Folder Location")],
+        )
+        plex = make_plex(Plex=section)
+
+        assert plex.get_search_key("folder_location") == "location"
+
+    def test_folder_location_choices_map_paths_to_plex_location_ids(self):
+        section = SimpleNamespace(
+            TYPE="movie",
+            listFilters=lambda libtype: [SimpleNamespace(filter="source", title="Folder Location")],
+        )
+        plex = make_plex(Plex=section)
+        plex.get_tags = MagicMock(
+            return_value=[
+                SimpleNamespace(title="/media/movies", key="7"),
+                SimpleNamespace(title="/media/movies-4k", key="8"),
+            ]
+        )
+
+        choices, names = plex.get_search_choices("folder_location", title=False)
+
+        assert choices["/media/movies"] == "7"
+        assert choices["/media/movies-4k"] == "8"
+        assert names == ["/media/movies", "/media/movies-4k"]
+        plex.get_tags.assert_called_once_with("source")
+
+    def test_folder_location_raises_when_plex_does_not_expose_filter(self):
+        section = SimpleNamespace(
+            TYPE="movie",
+            listFilters=lambda libtype: [SimpleNamespace(filter="genre", title="Genre")],
+        )
+        plex = make_plex(Plex=section)
+
+        with pytest.raises(NotFound, match="folder_location"):
+            plex.get_search_key("folder_location")
+
+        with pytest.raises(Failed, match="folder_location not supported"):
+            plex.get_search_choices("folder_location")
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -195,16 +195,28 @@ class TestNotify:
 
 class TestSearchKeys:
     def test_folder_location_uses_plex_source_filter(self):
-        section = SimpleNamespace(
-            TYPE="movie",
-            listFilters=lambda libtype: [
+        list_filters = MagicMock(
+            return_value=[
                 SimpleNamespace(filter="genre", title="Genre"),
                 SimpleNamespace(filter="source", title="Folder Location"),
-            ],
+            ]
+        )
+        section = SimpleNamespace(
+            TYPE="movie",
+            listFilters=list_filters,
         )
         plex = make_plex(Plex=section)
 
         assert plex.get_search_key("folder_location") == "source"
+        list_filters.assert_called_once_with("movie")
+
+    def test_folder_location_uses_requested_track_filter_type(self):
+        list_filters = MagicMock(return_value=[SimpleNamespace(filter="source", title="Folder Location")])
+        section = SimpleNamespace(TYPE="artist", listFilters=list_filters)
+        plex = make_plex(Plex=section, is_movie=False, type="Music")
+
+        assert plex.get_search_key("folder_location", libtype="track") == "source"
+        list_filters.assert_called_once_with("track")
 
     def test_folder_location_falls_back_to_filter_title(self):
         section = SimpleNamespace(
@@ -216,9 +228,10 @@ class TestSearchKeys:
         assert plex.get_search_key("folder_location") == "location"
 
     def test_folder_location_choices_map_paths_to_plex_location_ids(self):
+        list_filters = MagicMock(return_value=[SimpleNamespace(filter="source", title="Folder Location")])
         section = SimpleNamespace(
             TYPE="movie",
-            listFilters=lambda libtype: [SimpleNamespace(filter="source", title="Folder Location")],
+            listFilters=list_filters,
         )
         plex = make_plex(Plex=section)
         plex.get_tags = MagicMock(
@@ -228,11 +241,12 @@ class TestSearchKeys:
             ]
         )
 
-        choices, names = plex.get_search_choices("folder_location", title=False)
+        choices, names = plex.get_search_choices("folder_location", title=False, libtype="track")
 
         assert choices["/media/movies"] == "7"
         assert choices["/media/movies-4k"] == "8"
         assert names == ["/media/movies", "/media/movies-4k"]
+        list_filters.assert_called_once_with("track")
         plex.get_tags.assert_called_once_with("source")
 
     def test_folder_location_raises_when_plex_does_not_expose_filter(self):


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Adds `folder_location` and `folder_location.not` criteria to Plex `smart_filter`/`plex_search` builders, including track-level music collections, matching Plex's Folder Location smart collection filter.

The implementation discovers the server's Folder Location search key, resolves configured root paths to Plex location IDs, and reports a clear validation error when the connected Plex server does not expose the filter. Documentation, JSON Schema definitions, changelog entry, and unit coverage are included.

Validation:

- `pytest`: 935 passed
- Black, isort, and flake8: passed
- The full `prek` command could not run the spellcheck hook because `aspell` is not installed in the local environment

## Related Issues [optional]

- Related Issue #3441
- Closes #3441

## Have you updated the Documentation to reflect changes (if necessary)?

- [x] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [x] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the CHANGELOG.md?

- [x] Yes
- [ ] No