### PR TITLE
Fix IMDb GraphQL request handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add TVDB ID support to YamTrack builder, enabling import of TVDB show IDs from YamTrack lists and tracked pages alongside existing TMDb support.
 
 ### Fixed
+- Send IMDb's web client identifier with GraphQL requests so `imdb_search` and IMDb-backed defaults are not rejected with HTTP 403; report HTTP and non-JSON GraphQL responses as contextual IMDb errors instead of uncaught JSON decoding tracebacks. #3444
 - Batch collection and playlist `item_label`, `item_label.remove`, `item_label.sync`, and `non_item_remove_label` updates through Plex multi-edit requests, grouped by library and media type and split by `plex_bulk_edit_batch_size`, instead of sending one label request per item.
 - Fail Letterboxd collection validation when a configured list or watchlist cannot be loaded, preventing sync mode from emptying an existing collection after a blocked or unavailable source request.
 - Treat TMDb connection failures, timeouts, HTTP 408/429/5xx, and backend-unavailable responses as transient service failures: retry discovery, pagination, item requests, and lazy object hydration consistently; emit concise retry warnings instead of tracebacks; and surface exhausted retries as a service-unavailable error.

--- a/modules/imdb.py
+++ b/modules/imdb.py
@@ -504,7 +504,20 @@ class IMDb:
         return response.xpath(xpath) if xpath else response
 
     def _graph_request(self, json_data):
-        return self.requests.post_json(graphql_url, headers={"content-type": "application/json"}, json=json_data)
+        response = self.requests.post(
+            graphql_url,
+            headers={
+                "content-type": "application/json",
+                "x-imdb-client-name": "imdb-web-next",
+            },
+            json=json_data,
+        )
+        if response.status_code >= 400:
+            raise Failed(f"IMDb Error: GraphQL request failed with HTTP {response.status_code}")
+        try:
+            return response.json()
+        except ValueError as e:
+            raise Failed("IMDb Error: GraphQL request returned a non-JSON response") from e
 
     @property
     def search_hash(self):

--- a/tests/test_imdb.py
+++ b/tests/test_imdb.py
@@ -3,8 +3,9 @@
 from unittest.mock import MagicMock
 
 import pytest
+from requests.exceptions import JSONDecodeError
 
-from modules.imdb import IMDb
+from modules.imdb import IMDb, graphql_url
 from modules.util import Failed
 
 
@@ -13,6 +14,53 @@ def make_imdb(graph_response):
     imdb = IMDb(requests=MagicMock(), cache=None, default_dir="/tmp")
     imdb._graph_request = MagicMock(return_value=graph_response)
     return imdb
+
+
+# ---------------------------------------------------------------------------
+# IMDb GraphQL request handling
+# ---------------------------------------------------------------------------
+
+
+class TestGraphRequest:
+
+    def test_sends_imdb_web_client_header(self):
+        requests = MagicMock()
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"data": {"result": "ok"}}
+        requests.post.return_value = response
+        imdb = IMDb(requests=requests, cache=None, default_dir="/tmp")
+        payload = {"query": "{ result }"}
+
+        assert imdb._graph_request(payload) == {"data": {"result": "ok"}}
+        requests.post.assert_called_once_with(
+            graphql_url,
+            headers={
+                "content-type": "application/json",
+                "x-imdb-client-name": "imdb-web-next",
+            },
+            json=payload,
+        )
+
+    def test_http_error_raises_contextual_imdb_error(self):
+        requests = MagicMock()
+        response = MagicMock(status_code=403)
+        requests.post.return_value = response
+        imdb = IMDb(requests=requests, cache=None, default_dir="/tmp")
+
+        with pytest.raises(Failed, match="IMDb Error: GraphQL request failed with HTTP 403"):
+            imdb._graph_request({"query": "{ result }"})
+
+        response.json.assert_not_called()
+
+    def test_non_json_response_raises_contextual_imdb_error(self):
+        requests = MagicMock()
+        response = MagicMock(status_code=200)
+        response.json.side_effect = JSONDecodeError("Expecting value", "<html>", 0)
+        requests.post.return_value = response
+        imdb = IMDb(requests=requests, cache=None, default_dir="/tmp")
+
+        with pytest.raises(Failed, match="IMDb Error: GraphQL request returned a non-JSON response"):
+            imdb._graph_request({"query": "{ result }"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

IMDb GraphQL requests were being rejected with HTTP 403 because they did not identify the IMDb web client. Since the response was an HTML error page, the request wrapper then raised an unhelpful `JSONDecodeError`. This caused IMDb-backed defaults, including the "Based On" collections, to fail.

This change:

- sends `x-imdb-client-name: imdb-web-next` with IMDb GraphQL requests;
- reports HTTP failures as contextual IMDb errors before attempting JSON parsing;
- reports unexpected non-JSON responses as contextual IMDb errors; and
- adds regression coverage for successful, HTTP-error, and non-JSON responses.

Validation:

- full pytest suite passed;
- `tests/test_imdb.py`: 23 passed;
- Black, isort, flake8, and `git diff --check` passed; and
- a live read-only IMDb GraphQL title query returned a successful JSON response.

## Related Issues [optional]

- Related Issue #3444
- Closes #3444

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [x] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [x] Not Applicable

## Have you updated the CHANGELOG.md?

- [x] Yes
- [ ] No
