### PR TITLE
Handle missing IMDb chart fallback data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Send IMDb's web client identifier with GraphQL requests so `imdb_search` and IMDb-backed defaults are not rejected with HTTP 403; report HTTP and non-JSON GraphQL responses as contextual IMDb errors instead of uncaught JSON decoding tracebacks. #3444
+- Report IMDb chart GraphQL and HTML fallback failures as contextual IMDb errors instead of raising `IndexError` when the fallback page does not contain `__NEXT_DATA__` chart data. #3446
 - Batch collection and playlist `item_label`, `item_label.remove`, `item_label.sync`, and `non_item_remove_label` updates through Plex multi-edit requests, grouped by library and media type and split by `plex_bulk_edit_batch_size`, instead of sending one label request per item.
 - Fail Letterboxd collection validation when a configured list or watchlist cannot be loaded, preventing sync mode from emptying an existing collection after a blocked or unavailable source request.
 - Treat TMDb connection failures, timeouts, HTTP 408/429/5xx, and backend-unavailable responses as transient service failures: retry discovery, pagination, item requests, and lazy object hydration consistently; emit concise retry warnings instead of tracebacks; and surface exhausted retries as a service-unavailable error.

--- a/modules/imdb.py
+++ b/modules/imdb.py
@@ -870,17 +870,28 @@ class IMDb:
         if chart not in chart_urls:
             raise Failed(f"IMDb Error: chart: {chart} not ")
         # Primary: use direct GraphQL API (bypasses HTML scraping issues)
+        graphql_error: str | None = None
         if chart in chart_graphql_map:
             try:
                 ids = self._chart_graphql(chart)
                 if ids:
                     logger.debug(f"GraphQL chart query returned {len(ids)} IDs for {chart}")
                     return ids
+                graphql_error = "returned no IMDb IDs"
             except Exception as e:
+                graphql_error = str(e)
                 logger.debug(f"GraphQL chart query error for {chart}: {e}")
         # Fallback: HTML scraping via original xpath method
-        script_data = self._request(f"{base_url}/{chart_urls[chart]}", language=language, xpath="//script[@id='__NEXT_DATA__']/text()")[0]
-        return [x.group(1) for x in re.finditer(r'"(tt\d+)"', script_data)]
+        script_results = self._request(f"{base_url}/{chart_urls[chart]}", language=language, xpath="//script[@id='__NEXT_DATA__']/text()")
+        if not script_results:
+            message = f"IMDb Error: HTML fallback returned no chart data for {charts[chart]}"
+            if graphql_error:
+                message = f"{message} after GraphQL request failed: {graphql_error}"
+            raise Failed(message)
+        ids = [x.group(1) for x in re.finditer(r'"(tt\d+)"', script_results[0])]
+        if not ids:
+            raise Failed(f"IMDb Error: No IMDb IDs found in HTML fallback for {charts[chart]}")
+        return ids
 
     def get_imdb_ids(self, method, data, language):
         if method == "imdb_id":

--- a/tests/test_imdb.py
+++ b/tests/test_imdb.py
@@ -268,3 +268,48 @@ class TestValidateImdbWatchlist:
         """
         result = self._imdb().validate_imdb("Test", "imdb_watchlist", [{"user_id": "ur64054558"}])
         assert result[0]["user_id"] == "ur64054558"
+
+
+class TestIdsFromChart:
+
+    @pytest.fixture(autouse=True)
+    def _mock_logger(self, monkeypatch):
+        monkeypatch.setattr("modules.imdb.logger", MagicMock())
+
+    def _imdb(self):
+        return IMDb(requests=MagicMock(), cache=None, default_dir="/tmp")
+
+    def test_graphql_success_does_not_use_html_fallback(self):
+        imdb = self._imdb()
+        imdb._chart_graphql = MagicMock(return_value=["tt0111161", "tt0068646"])
+        imdb._request = MagicMock()
+
+        assert imdb._ids_from_chart("top_movies", "en") == ["tt0111161", "tt0068646"]
+        imdb._request.assert_not_called()
+
+    def test_html_fallback_returns_ids_after_graphql_failure(self):
+        imdb = self._imdb()
+        imdb._chart_graphql = MagicMock(side_effect=Failed("GraphQL unavailable"))
+        imdb._request = MagicMock(return_value=['{"id":"tt0111161"},{"id":"tt0068646"}'])
+
+        assert imdb._ids_from_chart("top_movies", "en") == ["tt0111161", "tt0068646"]
+
+    def test_empty_html_fallback_preserves_graphql_failure(self):
+        imdb = self._imdb()
+        imdb._chart_graphql = MagicMock(side_effect=Failed("GraphQL unavailable"))
+        imdb._request = MagicMock(return_value=[])
+
+        with pytest.raises(Failed) as exc_info:
+            imdb._ids_from_chart("top_movies", "en")
+
+        error = str(exc_info.value)
+        assert "HTML fallback returned no chart data for Top 250 Movies" in error
+        assert "GraphQL request failed: GraphQL unavailable" in error
+
+    def test_html_fallback_without_ids_raises_failed(self):
+        imdb = self._imdb()
+        imdb._chart_graphql = MagicMock(return_value=[])
+        imdb._request = MagicMock(return_value=['{"props":{"pageProps":{}}}'])
+
+        with pytest.raises(Failed, match="No IMDb IDs found in HTML fallback for Top 250 Movies"):
+            imdb._ids_from_chart("top_movies", "en")


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

IMDb chart retrieval tries GraphQL first and falls back to scraping `__NEXT_DATA__` from the chart page. When both methods failed, the fallback blindly accessed the first XPath result and raised `IndexError: list index out of range`.

This change:

- checks that the HTML fallback returned `__NEXT_DATA__` before indexing it;
- verifies that the fallback content contains IMDb IDs;
- preserves the original GraphQL failure in the contextual IMDb error; and
- adds regression coverage for GraphQL success, successful fallback, missing fallback data, and fallback data without IMDb IDs.

Validation:

- full pytest suite: 946 passed;
- `tests/test_imdb.py`: 27 passed; and
- Black, isort, flake8, and `git diff --check` passed.

## Related Issues [optional]

- Related Issue #3446
- Closes #3446

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [x] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [x] Not Applicable

## Have you updated the CHANGELOG.md?

- [x] Yes
- [ ] No
