### PR TITLE
Clarify headless Trakt authorization errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add TVDB ID support to YamTrack builder, enabling import of TVDB show IDs from YamTrack lists and tracked pages alongside existing TMDb support.
 
 ### Fixed
+- Replace the vague `Input Failed` error emitted when Trakt requires authorization in a non-interactive environment with an actionable Trakt-specific message, and include the failed token-refresh HTTP response in debug logs.
 - Send IMDb's web client identifier with GraphQL requests so `imdb_search` and IMDb-backed defaults are not rejected with HTTP 403; report HTTP and non-JSON GraphQL responses as contextual IMDb errors instead of uncaught JSON decoding tracebacks. #3444
 - Report IMDb chart GraphQL and HTML fallback failures as contextual IMDb errors instead of raising `IndexError` when the fallback page does not contain `__NEXT_DATA__` chart data. #3446
 - Batch collection and playlist `item_label`, `item_label.remove`, `item_label.sync`, and `non_item_remove_label` updates through Plex multi-edit requests, grouped by library and media type and split by `plex_bulk_edit_batch_size`, instead of sending one label request per item.

--- a/modules/trakt.py
+++ b/modules/trakt.py
@@ -145,6 +145,10 @@ class Trakt:
                 pin = util.logger_input("Trakt pin (case insensitive)", timeout=300).strip()
             except TimeoutExpired:
                 raise Failed("Input Timeout: Trakt pin required.")
+            except Failed as e:
+                if str(e) == "Input Failed":
+                    raise Failed("Trakt Error: Authorization is required, but no interactive input is available. Reauthenticate Trakt using Kometa Utilities and update the authorization block in the config file.") from e
+                raise
         if not pin:
             raise Failed("Trakt Error: Trakt pin required.")
         json_data = {"code": pin, "client_id": self.client_id, "client_secret": self.client_secret, "redirect_uri": redirect_uri, "grant_type": "authorization_code"}
@@ -175,6 +179,7 @@ class Trakt:
             json_data = {"refresh_token": self.authorization["refresh_token"], "client_id": self.client_id, "client_secret": self.client_secret, "redirect_uri": redirect_uri, "grant_type": "refresh_token"}
             response = self.requests.post(f"{base_url}/oauth/token", json=json_data, headers={"Content-Type": "application/json"})
             if response.status_code != 200:
+                logger.debug(f"Trakt Error: Access Token Refresh Failed: ({response.status_code}) {response.reason}")
                 return False
             return self._save(response.json())
         return False

--- a/modules/trakt.py
+++ b/modules/trakt.py
@@ -147,7 +147,7 @@ class Trakt:
                 raise Failed("Input Timeout: Trakt pin required.")
             except Failed as e:
                 if str(e) == "Input Failed":
-                    raise Failed("Trakt Error: Authorization required; interactive input is unavailable. Reauthenticate with Kometa Utilities and update your config.") from e
+                    raise Failed("Trakt Error: Authorization required; interactive input is unavailable. Reauthenticate at https://utilities.kometa.wiki/ and update your config.") from e
                 raise
         if not pin:
             raise Failed("Trakt Error: Trakt pin required.")

--- a/modules/trakt.py
+++ b/modules/trakt.py
@@ -147,7 +147,7 @@ class Trakt:
                 raise Failed("Input Timeout: Trakt pin required.")
             except Failed as e:
                 if str(e) == "Input Failed":
-                    raise Failed("Trakt Error: Authorization is required, but no interactive input is available. Reauthenticate Trakt using Kometa Utilities and update the authorization block in the config file.") from e
+                    raise Failed("Trakt Error: Authorization required; interactive input is unavailable. Reauthenticate with Kometa Utilities and update your config.") from e
                 raise
         if not pin:
             raise Failed("Trakt Error: Trakt pin required.")

--- a/tests/test_trakt.py
+++ b/tests/test_trakt.py
@@ -75,7 +75,7 @@ class TestTraktAuthorization:
         with pytest.raises(Failed) as exc_info:
             adapter._authorization()
 
-        assert str(exc_info.value) == "Trakt Error: Authorization required; interactive input is unavailable. Reauthenticate with Kometa Utilities and update your config."
+        assert str(exc_info.value) == "Trakt Error: Authorization required; interactive input is unavailable. Reauthenticate at https://utilities.kometa.wiki/ and update your config."
 
     def test_other_input_failures_are_unchanged(self, adapter, monkeypatch):
         monkeypatch.setattr("modules.trakt.webbrowser.open", MagicMock())

--- a/tests/test_trakt.py
+++ b/tests/test_trakt.py
@@ -75,11 +75,7 @@ class TestTraktAuthorization:
         with pytest.raises(Failed) as exc_info:
             adapter._authorization()
 
-        error = str(exc_info.value)
-        assert error.startswith("Trakt Error: Authorization is required")
-        assert "no interactive input is available" in error
-        assert "Kometa Utilities" in error
-        assert "authorization block" in error
+        assert str(exc_info.value) == "Trakt Error: Authorization required; interactive input is unavailable. Reauthenticate with Kometa Utilities and update your config."
 
     def test_other_input_failures_are_unchanged(self, adapter, monkeypatch):
         monkeypatch.setattr("modules.trakt.webbrowser.open", MagicMock())

--- a/tests/test_trakt.py
+++ b/tests/test_trakt.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import modules.builder  # noqa: F401
+from modules.util import Failed
 
 
 class TestTrakt:
@@ -46,3 +47,49 @@ class TestTrakt:
         """slugs is a @property — accessed without ()."""
         adapter._request.return_value = [{"ids": {"slug": "my-list"}}]
         assert adapter.slugs == ["my-list"]
+
+
+class TestTraktAuthorization:
+    @pytest.fixture
+    def adapter(self):
+        from modules.trakt import Trakt
+
+        trakt = Trakt.__new__(Trakt)
+        trakt.requests = MagicMock()
+        trakt.client_id = "client-id"
+        trakt.client_secret = "client-secret"
+        trakt.pin = None
+        trakt.authorization = {"refresh_token": "refresh-token"}
+        return trakt
+
+    @pytest.fixture(autouse=True)
+    def mock_trakt_logger(self, monkeypatch):
+        logger = MagicMock()
+        monkeypatch.setattr("modules.trakt.logger", logger)
+        return logger
+
+    def test_headless_pin_prompt_raises_actionable_trakt_error(self, adapter, monkeypatch):
+        monkeypatch.setattr("modules.trakt.webbrowser.open", MagicMock())
+        monkeypatch.setattr("modules.trakt.util.logger_input", MagicMock(side_effect=Failed("Input Failed")))
+
+        with pytest.raises(Failed) as exc_info:
+            adapter._authorization()
+
+        error = str(exc_info.value)
+        assert error.startswith("Trakt Error: Authorization is required")
+        assert "no interactive input is available" in error
+        assert "Kometa Utilities" in error
+        assert "authorization block" in error
+
+    def test_other_input_failures_are_unchanged(self, adapter, monkeypatch):
+        monkeypatch.setattr("modules.trakt.webbrowser.open", MagicMock())
+        monkeypatch.setattr("modules.trakt.util.logger_input", MagicMock(side_effect=Failed("Different input failure")))
+
+        with pytest.raises(Failed, match="Different input failure"):
+            adapter._authorization()
+
+    def test_failed_refresh_logs_http_response(self, adapter, mock_trakt_logger):
+        adapter.requests.post.return_value = MagicMock(status_code=403, reason="Forbidden")
+
+        assert adapter._refresh() is False
+        mock_trakt_logger.debug.assert_called_once_with("Trakt Error: Access Token Refresh Failed: (403) Forbidden")


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

When Trakt rejected a stored access token and the refresh request failed, Kometa fell back to requesting a Trakt PIN. In a headless environment such as Docker, stdin is unavailable and the generic input helper raised only `Input Failed`.

That response was a little too vague: it did not identify Trakt, explain that interactive input was unavailable, or tell the user how to recover. The end-of-run summary therefore presented `Input Failed` without enough context to act on it.

This change keeps the behavior scoped to Trakt:

- converts only the headless Trakt PIN prompt failure into an actionable Trakt-specific error;
- directs the user to reauthenticate with Kometa Utilities and update the Trakt authorization block;
- logs the failed refresh request's HTTP status and reason at debug level; and
- leaves other generic input failures unchanged.

Validation:

- full pytest suite: 949 passed;
- `tests/test_trakt.py`: 7 passed; and
- Black, isort, flake8, and `git diff --check` passed.

## Related Issues [optional]

Not applicable.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [x] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [x] Not Applicable

## Have you updated the CHANGELOG.md?

- [x] Yes
- [ ] No
