### PR TITLE
feat: concurrency/threading support - shared thread pool, cache RLock, prefetch defaults (part 3)

### DIFF
--- a/.pyright-baseline.json
+++ b/.pyright-baseline.json
@@ -1,12 +1,12 @@
 {
   "_comment": "Ratcheting pyright baseline. DO NOT hand-edit unless you know what you're doing. Regenerate with: python scripts/pyright_baseline.py --regenerate",
-  "total_errors": 8,
+  "total_errors": 7,
   "per_file_errors": {
     "kometa.py": 1,
     "modules/builder.py": 1,
     "modules/config.py": 1,
     "modules/meta.py": 1,
-    "modules/operations.py": 2,
+    "modules/operations.py": 1,
     "modules/plex.py": 2
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support the `folder_location` Plex search option in music-library track builders.
 - Add a `settings.threading` config block (`workers`, `tmdb_pages`, `parallel_sources`, `prefetch_collection_children`) backed by a shared `ThreadPoolExecutor`, used to defer non-Plex `gather_ids` work and Plex item-reload batching off the main collection loop.
-- Add a `--dcl`/`--delete-collections-labels` CLI flag (double-dash only - `-dcl` collides with `-d`/`--divider`) that deletes all collections, same as `-dc`, and for any deleted collection whose title matches an existing Plex label of the same name (the Smart Label default), batch-removes that one label from just the items that have it - instead of `-dl`'s full library-wide, one-item-at-a-time label wipe.
+- Add a `--delete-collections-labels` CLI flag (no short form - would collide with `-d`/`--divider`) that deletes all collections, same as `-dc`, and for any deleted collection whose title matches an existing Plex label of the same name (the Smart Label default), batch-removes that one label from just the items that have it - instead of `-dl`'s full library-wide, one-item-at-a-time label wipe.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support the `folder_location` Plex search option in music-library track builders.
 - Add a `settings.threading` config block (`workers`, `tmdb_pages`, `parallel_sources`, `prefetch_collection_children`) backed by a shared `ThreadPoolExecutor`, used to defer non-Plex `gather_ids` work and Plex item-reload batching off the main collection loop.
-- Add a `-dcl`/`--delete-collections-labels` CLI flag that deletes all collections, same as `-dc`, and for any deleted collection whose title matches an existing Plex label of the same name (the Smart Label default), batch-removes that one label from just the items that have it - instead of `-dl`'s full library-wide, one-item-at-a-time label wipe.
+- Add a `--dcl`/`--delete-collections-labels` CLI flag (double-dash only - `-dcl` collides with `-d`/`--divider`) that deletes all collections, same as `-dc`, and for any deleted collection whose title matches an existing Plex label of the same name (the Smart Label default), batch-removes that one label from just the items that have it - instead of `-dl`'s full library-wide, one-item-at-a-time label wipe.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fetch MDBList data in cache-aware batches of up to 100 items, substantially reducing API quota usage for library operations, direct rating overlays, and overlay value filters.
+- Default `settings.threading.workers` to 4 (was effectively single-threaded) and `settings.threading.prefetch_collection_children` to `true`, deferring a collection's `sync_collection` "what to remove" lookup and PMS's comma-separated `/library/metadata/{ids}` batch-read to the shared thread pool instead of blocking the main collection loop; the cache is now RLock-guarded (`_LockedConnection`) so concurrent worker threads can share one SQLite connection safely.
 
 ### Added
 
 - Support the `folder_location` Plex search option in music-library track builders.
+- Add a `settings.threading` config block (`workers`, `tmdb_pages`, `parallel_sources`, `prefetch_collection_children`) backed by a shared `ThreadPoolExecutor`, used to defer non-Plex `gather_ids` work and Plex item-reload batching off the main collection loop.
 
 ### Fixed
 
 - Fixed `audio_codec` track builder
 - Include collections removed by the `delete_collections` library operation, the `--delete-collections` CLI option, dynamic collection sync, and `delete_collections_named` in the run-end notification total.
 - Fix `audio_language`/`subtitle_language` `plex_search` filters matching zero items whenever a library has multiple Plex-reported locale variants for the requested language (e.g. `de` + `de-DE`); the variants were being `AND` together into an impossible filter instead of `OR`. Regression from #3440.
+- Replace a bare truthy check on a collection builder's Plex object with an explicit `is not None` check, avoiding a silent full Plex `items()` fetch through `Collection`/`Playlist.__len__` on any falsy-looking-but-real collection.
+- Guard against `None` `childCount` on blank/separator collections when computing the collection's starting item count.
+- Only fetch a parent item's `titleSort` when building a display title if sorted output was actually requested, instead of unconditionally.
 
 ## [v2.4.8] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support the `folder_location` Plex search option in music-library track builders.
 - Add a `settings.threading` config block (`workers`, `tmdb_pages`, `parallel_sources`, `prefetch_collection_children`) backed by a shared `ThreadPoolExecutor`, used to defer non-Plex `gather_ids` work and Plex item-reload batching off the main collection loop.
+- Add a `-dcl`/`--delete-collections-labels` CLI flag that deletes all collections, same as `-dc`, and for any deleted collection whose title matches an existing Plex label of the same name (the Smart Label default), batch-removes that one label from just the items that have it - instead of `-dl`'s full library-wide, one-item-at-a-time label wipe.
 
 ### Fixed
 

--- a/config/config.yml.template
+++ b/config/config.yml.template
@@ -88,6 +88,8 @@ settings:
   show_missing: true
   show_missing_assets: true
   save_report: false
+  # threading:
+  #   workers: 4
   tvdb_language: eng
   ignore_ids:
   ignore_imdb_ids:

--- a/docs/config/settings.md
+++ b/docs/config/settings.md
@@ -1097,6 +1097,37 @@ The available setting attributes which can be set at each level are outlined bel
 
 
 
+??? blank "`threading` - Used to control Kometa's shared thread pool for concurrent processing.<a class="headerlink" href="#threading" title="Permanent link">¶</a>"
+
+    <div id="threading" />Controls the shared thread pool Kometa uses to run some work concurrently instead of one call at a time. See [Timing Instrumentation](../kometa/environmental.md#timings) if you want to measure the effect of these settings against your own library.
+
+    <hr style="margin: 0px;">
+
+    **Attribute:** `threading`
+
+    **Levels with this Attribute:** Global
+
+    **Accepted Values:** Dictionary :material-information-outline:{ data-tooltip data-tooltip-id="tippy-yaml-dictionaries" } of the sub-attributes below.
+
+    <table class="clearTable">
+      <tr><td>`workers`</td><td>Number of worker threads in the shared thread pool. Accepts any integer of `1` or greater.</td></tr>
+      <tr><td>`prefetch_collection_children`</td><td>Defers a sync-enabled collection's "what to remove" lookup, and Plex item-reload batching in the operations and overlay loops, to the thread pool instead of blocking the main collection loop. Accepts `true` or `false`.</td></tr>
+    </table>
+
+    **Default Value:** `workers: 4`, `prefetch_collection_children: true`
+
+    ???+ note "Other sub-attributes"
+
+        `threading` has a couple of additional experimental sub-attributes (`tmdb_pages`, `parallel_sources`) that are off by default and intentionally undocumented; they exist for internal bake-off testing and aren't expected to help most libraries. Leave them unset.
+
+    ???+ example "Example"
+
+        ```yaml
+        settings:
+          threading:
+            workers: 8
+        ```
+
 ??? blank "`tvdb_language` - Specify the language to query TVDb in.<a class="headerlink" href="#tvdb-language" title="Permanent link">¶</a>"
 
     <div id="tvdb-language" />Specify the language to query TVDb in.

--- a/docs/kometa/environmental.md
+++ b/docs/kometa/environmental.md
@@ -649,7 +649,7 @@ Kometa will load those environment variables when it starts up, and you don't ha
             docker run -it -v "X:\Media\Kometa\config:/config:rw" kometateam/kometa --delete-labels
             ```
 
-??? blank "Delete Collections + Labels&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`-dcl`/`--delete-collections-labels`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`KOMETA_DELETE_COLLECTIONS_LABELS`<a class="headerlink" href="#delete-collections-labels" title="Permanent link">¶</a>"
+??? blank "Delete Collections + Labels&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`--dcl`/`--delete-collections-labels`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`KOMETA_DELETE_COLLECTIONS_LABELS`<a class="headerlink" href="#delete-collections-labels" title="Permanent link">¶</a>"
 
     <div id="delete-collections-labels" />Delete all collections in each library as the first step in the run, same as [Delete Collections](#delete-collections) above. For any deleted collection whose title matches an existing Plex label of the same name - the default for [Smart Label Collections](../files/settings/#smart-label-definitions) - also batch-removes that one label from just the items that currently have it, instead of the full library-wide label wipe [Delete Labels](#delete-labels) does.
 
@@ -657,9 +657,13 @@ Kometa will load those environment variables when it starts up, and you don't ha
 
         This only detects Smart Label collections using the default label name (the collection's own title). A collection using a custom `smart_label` name won't be matched, since that name isn't known until the config is parsed - use [Delete Labels](#delete-labels) for those.
 
+    ???+ danger "Use `--dcl`, not `-dcl`"
+
+        This flag only has double-dash forms. `-dc` and `-dl` are single-dash because they're exactly 2 characters - Kometa's own convention for short flags - but `-dcl` is 3 characters, and a single dash there collides with `-d`/`--divider` (a flag that takes a value): `-dcl` on the command line is parsed as `-d` with value `cl`, silently corrupting your divider character (every separator renders as a wall of `c`s) and never actually triggering this flag. Always use `--dcl` or `--delete-collections-labels`, never a single dash.
+
     <hr style="margin: 0px;">
 
-    **Shell Flags:** `-dcl` or `--delete-collections-labels` (ex. `--delete-collections-labels`)
+    **Shell Flags:** `--dcl` or `--delete-collections-labels` (ex. `--delete-collections-labels`)
 
     **Environment Variable:** `KOMETA_DELETE_COLLECTIONS_LABELS` (ex. `KOMETA_DELETE_COLLECTIONS_LABELS=true`)
 

--- a/docs/kometa/environmental.md
+++ b/docs/kometa/environmental.md
@@ -649,7 +649,7 @@ Kometa will load those environment variables when it starts up, and you don't ha
             docker run -it -v "X:\Media\Kometa\config:/config:rw" kometateam/kometa --delete-labels
             ```
 
-??? blank "Delete Collections + Labels&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`--dcl`/`--delete-collections-labels`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`KOMETA_DELETE_COLLECTIONS_LABELS`<a class="headerlink" href="#delete-collections-labels" title="Permanent link">¶</a>"
+??? blank "Delete Collections + Labels&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`--delete-collections-labels`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`KOMETA_DELETE_COLLECTIONS_LABELS`<a class="headerlink" href="#delete-collections-labels" title="Permanent link">¶</a>"
 
     <div id="delete-collections-labels" />Delete all collections in each library as the first step in the run, same as [Delete Collections](#delete-collections) above. For any deleted collection whose title matches an existing Plex label of the same name - the default for [Smart Label Collections](../files/settings/#smart-label-definitions) - also batch-removes that one label from just the items that currently have it, instead of the full library-wide label wipe [Delete Labels](#delete-labels) does.
 
@@ -657,13 +657,11 @@ Kometa will load those environment variables when it starts up, and you don't ha
 
         This only detects Smart Label collections using the default label name (the collection's own title). A collection using a custom `smart_label` name won't be matched, since that name isn't known until the config is parsed - use [Delete Labels](#delete-labels) for those.
 
-    ???+ danger "Use `--dcl`, not `-dcl`"
-
-        This flag only has double-dash forms. `-dc` and `-dl` are single-dash because they're exactly 2 characters - Kometa's own convention for short flags - but `-dcl` is 3 characters, and a single dash there collides with `-d`/`--divider` (a flag that takes a value): `-dcl` on the command line is parsed as `-d` with value `cl`, silently corrupting your divider character (every separator renders as a wall of `c`s) and never actually triggering this flag. Always use `--dcl` or `--delete-collections-labels`, never a single dash.
+        This flag has no short form - `-dc` and `-dl` are single-dash because they're exactly 2 characters (Kometa's own convention for short flags); anything longer would collide with an existing single-character flag (e.g. `-d`/`--divider`) when typed with a single dash. Use `--delete-collections-labels` or `--delete-collection-label` in full.
 
     <hr style="margin: 0px;">
 
-    **Shell Flags:** `--dcl` or `--delete-collections-labels` (ex. `--delete-collections-labels`)
+    **Shell Flags:** `--delete-collections-labels` or `--delete-collection-label` (ex. `--delete-collections-labels`)
 
     **Environment Variable:** `KOMETA_DELETE_COLLECTIONS_LABELS` (ex. `KOMETA_DELETE_COLLECTIONS_LABELS=true`)
 

--- a/docs/kometa/environmental.md
+++ b/docs/kometa/environmental.md
@@ -649,6 +649,30 @@ Kometa will load those environment variables when it starts up, and you don't ha
             docker run -it -v "X:\Media\Kometa\config:/config:rw" kometateam/kometa --delete-labels
             ```
 
+??? blank "Delete Collections + Labels&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`-dcl`/`--delete-collections-labels`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`KOMETA_DELETE_COLLECTIONS_LABELS`<a class="headerlink" href="#delete-collections-labels" title="Permanent link">¶</a>"
+
+    <div id="delete-collections-labels" />Delete all collections in each library as the first step in the run, same as [Delete Collections](#delete-collections) above. For any deleted collection whose title matches an existing Plex label of the same name - the default for [Smart Label Collections](../files/settings/#smart-label-definitions) - also batch-removes that one label from just the items that currently have it, instead of the full library-wide label wipe [Delete Labels](#delete-labels) does.
+
+    ???+ note
+
+        This only detects Smart Label collections using the default label name (the collection's own title). A collection using a custom `smart_label` name won't be matched, since that name isn't known until the config is parsed - use [Delete Labels](#delete-labels) for those.
+
+    <hr style="margin: 0px;">
+
+    **Shell Flags:** `-dcl` or `--delete-collections-labels` (ex. `--delete-collections-labels`)
+
+    **Environment Variable:** `KOMETA_DELETE_COLLECTIONS_LABELS` (ex. `KOMETA_DELETE_COLLECTIONS_LABELS=true`)
+
+    !!! example
+        === "Local Environment"
+            ```
+            python kometa.py --delete-collections-labels
+            ```
+        === "Docker Environment"
+            ```
+            docker run -it -v "X:\Media\Kometa\config:/config:rw" kometateam/kometa --delete-collections-labels
+            ```
+
 ??? blank "Resume Run&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`-re`/`--resume`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`KOMETA_RESUME`<a class="headerlink" href="#resume" title="Permanent link">¶</a>"
 
     <div id="resume" />Perform an [immediate run](#run) starting from the first instance of the specified collection, bypassing the time to run flag.

--- a/json-schema/config-schema.json
+++ b/json-schema/config-schema.json
@@ -1965,6 +1965,28 @@
             "append"
           ]
         },
+        "threading": {
+          "description": "Used to control Kometa's shared thread pool for concurrent processing.\nControls the shared thread pool Kometa uses to run some work concurrently instead of one call at a time.",
+          "type": "object",
+          "properties": {
+            "workers": {
+              "description": "Number of worker threads in the shared thread pool.",
+              "type": "integer",
+              "minimum": 1
+            },
+            "prefetch_collection_children": {
+              "description": "Defers a sync-enabled collection's \"what to remove\" lookup, and Plex item-reload batching in the operations and overlay loops, to the thread pool instead of blocking the main collection loop.",
+              "type": "boolean"
+            },
+            "tmdb_pages": {
+              "type": "string"
+            },
+            "parallel_sources": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
         "minimum_items": {
           "description": "Used to control minimum items requires to build a collection/playlist.\nSet the minimum number of items that must be found in order to build or update a collection/playlist.",
           "type": "integer",

--- a/kometa.py
+++ b/kometa.py
@@ -109,6 +109,7 @@ arguments = {
     "ignore-ghost": {"args": "ig", "type": "bool", "help": "Run ignoring ghost logging"},
     "delete-collections": {"args": ["dc", "delete", "delete-collection"], "type": "bool", "help": "Deletes all Collections in the Plex Library before running"},
     "delete-labels": {"args": ["dl", "delete-label"], "type": "bool", "help": "Deletes all Labels in the Plex Library before running"},
+    "delete-collections-labels": {"args": ["dcl", "delete-collection-label"], "type": "bool", "help": "Deletes all Collections; for any that match an existing Plex label of the same name, batch-removes that label from just the items that have it"},
     "resume": {"args": "re", "type": "str", "help": "Resume collection run from a specific collection"},
     "no-countdown": {"args": "nc", "type": "bool", "help": "Run without displaying the countdown"},
     "no-missing": {"args": "nm", "type": "bool", "help": "Run without running the missing section"},
@@ -1085,12 +1086,16 @@ def run_libraries(config) -> tuple[LibraryRunStatus, bool]:
             logger.debug(f"Optimize: {library.optimize}")
             logger.debug(f"Timeout: {library.timeout}")
 
-            if run_args["delete-collections"] and not run_args["playlists-only"]:
+            if (run_args["delete-collections"] or run_args["delete-collections-labels"]) and not run_args["playlists-only"]:
                 time_start = datetime.now()
                 logger.info("")
                 logger.separator(f"Deleting all Collections from the {library.name} Library", space=False, border=False)
                 logger.info("")
                 for collection in library.get_all_collections():
+                    if run_args["delete-collections-labels"]:
+                        removed_count = library.remove_smart_label_for_collection(collection)
+                        if removed_count:
+                            logger.info(f"Label '{collection.title}' Removed from {removed_count} item{'s' if removed_count != 1 else ''}")
                     try:
                         library.delete_collection(collection)
                         logger.info(f"Collection {collection.title} Deleted")

--- a/kometa.py
+++ b/kometa.py
@@ -471,6 +471,7 @@ def start(attrs):
         my_requests = Requests(local_version, local_part, env_branch, git_branch, verify_ssl=False if run_args["no-verify-ssl"] else True)
         # Startup banner doubles as a mount-verification tripwire - missing despite --timings/KOMETA_TIMINGS means the mounted /modules code was silently ignored.
         timings.registry.banner()
+        timings.registry.enable_plex_request_log(logger.log_dir)
         timings.registry.set_meta(
             kometa_version=str(my_requests.local),
             git_sha=timings.git_sha(),
@@ -867,6 +868,7 @@ def start(attrs):
         if timings.registry.enabled:
             # Silent by design (never calls logger, so meta.log is unaffected) - placed after Error Summary so the run is fully accounted for first.
             timings.registry.export(logger.log_dir)
+        timings.registry.close_plex_request_log()
 
         start_str = start_time.strftime("%H:%M:%S %Y-%m-%d")
         end_str = end_time.strftime("%H:%M:%S %Y-%m-%d")

--- a/kometa.py
+++ b/kometa.py
@@ -278,7 +278,7 @@ from modules import timings  # noqa: E402
 timings.ENABLED = run_args["timings"]
 timings.registry.enabled = run_args["timings"]
 
-from modules.builder import CollectionBuilder  # noqa: E402
+from modules.builder import CollectionBuilder, prefetch_gather_ids  # noqa: E402
 from modules.config import ConfigFile  # noqa: E402
 from modules.request import Requests  # noqa: E402
 from modules.util import BuilderValidationError, Deleted, Failed, FilterFailed, MappingConvertError, NonExisting, NotScheduled, OverlayError, ServiceError  # noqa: E402
@@ -1288,12 +1288,16 @@ def run_collection(config, library, metadata, requested_collections):
                 logger.info("")
                 logger.info(f"Sync Mode: {'sync' if builder.sync else 'append'}")
 
-                for method, value in builder.builders:
+                # Experiment C: non-Plex gather_ids calls for this collection's builders start running in the background now; Plex-method builders (None here) still run inline below, on the main thread, in order.
+                prefetched = prefetch_gather_ids(config, builder)
+                for i, (method, value) in enumerate(builder.builders):
                     logger.debug("")
                     logger.debug(f"Builder: {method}: {value}")
                     logger.info("")
                     try:
-                        builder.filter_and_save_items(builder.gather_ids(method, value))
+                        pending = prefetched[i]
+                        ids = pending.result() if pending is not None else builder.gather_ids(method, value)
+                        builder.filter_and_save_items(ids)
                     except BuilderValidationError:
                         raise
                     except OverlayError:

--- a/kometa.py
+++ b/kometa.py
@@ -109,7 +109,7 @@ arguments = {
     "ignore-ghost": {"args": "ig", "type": "bool", "help": "Run ignoring ghost logging"},
     "delete-collections": {"args": ["dc", "delete", "delete-collection"], "type": "bool", "help": "Deletes all Collections in the Plex Library before running"},
     "delete-labels": {"args": ["dl", "delete-label"], "type": "bool", "help": "Deletes all Labels in the Plex Library before running"},
-    "delete-collections-labels": {"args": ["dcl", "delete-collection-label"], "type": "bool", "help": "Deletes all Collections; for any that match an existing Plex label of the same name, batch-removes that label from just the items that have it"},
+    "delete-collections-labels": {"args": "delete-collection-label", "type": "bool", "help": "Deletes all Collections; for any that match an existing Plex label of the same name, batch-removes that label from just the items that have it"},
     "resume": {"args": "re", "type": "str", "help": "Resume collection run from a specific collection"},
     "no-countdown": {"args": "nc", "type": "bool", "help": "Run without displaying the countdown"},
     "no-missing": {"args": "nm", "type": "bool", "help": "Run without running the missing section"},

--- a/kometa.py
+++ b/kometa.py
@@ -653,6 +653,9 @@ def start(attrs):
             except Failed as e:
                 logger.stacktrace()
                 logger.error(f"Webhooks Error: {e}")
+            # Shut down the run's thread pool before closing Cache - no worker may still be touching the SQLite connection during teardown
+            if config.thread_pool:
+                config.thread_pool.shutdown(wait=True)
             # Close cache connection to clean up WAL/SHM files
             if config.Cache:
                 config.Cache.close()

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1,6 +1,7 @@
 import os
 import re
 import time
+from concurrent.futures import Future
 from datetime import datetime, timedelta
 
 from arrapi import ArrException
@@ -1212,7 +1213,7 @@ class CollectionBuilder:
         self.notification_additions = []
         self.notification_removals = []
         self.items = []
-        self.remove_item_map = {}
+        self._remove_item_map = {}
         self.schedule = ""
         self.beginning_count = 0
         self.default_percent = 50
@@ -1839,7 +1840,12 @@ class CollectionBuilder:
             if self.obj is not None:
                 self.exists = True
                 if self.sync or self.playlist:
-                    self.remove_item_map = {i.ratingKey: i for i in self.library.get_collection_items(self.obj, self.smart_label_collection)}
+                    # Playlists need len() below so they fetch eagerly; sync collections don't need this until add_to_collection(), so it's deferred - see property below.
+                    if not self.playlist and self.config.thread_pool is not None and self.config.general["threading"]["prefetch_collection_children"]:
+                        obj, smart_label_collection = self.obj, self.smart_label_collection
+                        self._remove_item_map = self.config.thread_pool.submit(lambda: {i.ratingKey: i for i in self.library.get_collection_items(obj, smart_label_collection)})
+                    else:
+                        self._remove_item_map = {i.ratingKey: i for i in self.library.get_collection_items(self.obj, self.smart_label_collection)}
                 if not self.smart:
                     self.beginning_count = len(self.remove_item_map) if self.playlist else self.obj.childCount or 0
         else:
@@ -5352,6 +5358,18 @@ class CollectionBuilder:
             except ArrException as e:
                 logger.stacktrace()
                 logger.error(f"Arr Error: {e}")
+
+    @property
+    def remove_item_map(self):
+        # Resolves the deferred thread_pool fetch (see __init__) on first real use - usually already done by
+        # the time add_to_collection() reaches it, since construction happens well ahead of the Plex-heavy tail.
+        if isinstance(self._remove_item_map, Future):
+            self._remove_item_map = self._remove_item_map.result()
+        return self._remove_item_map
+
+    @remove_item_map.setter
+    def remove_item_map(self, value):
+        self._remove_item_map = value
 
     @timings.timed("load_collection")
     def load_collection(self):

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -20,6 +20,65 @@ from modules.util import BuilderValidationError, Deleted, Failed, FilterFailed, 
 logger = util.logger
 
 mdb_list_arr_types = {"radarr_taglist": "tmdb", "sonarr_taglist": "tmdb_show"}
+
+
+def _service_lock_key(method):
+    # Experiment C: classifies method into a lock bucket, mirroring gather_ids' dispatch below; unrecognized methods fall into "other" so they're always locked.
+    if "plex" in method:
+        return "plex"
+    if "tautulli" in method:
+        return "tautulli"
+    if "tracearr" in method:
+        return "tracearr"
+    if "anidb" in method:
+        return "anidb"
+    if "anilist" in method:
+        return "anilist"
+    if "mal" in method:
+        return "mal"
+    if "tvdb" in method:
+        return "tvdb"
+    if "imdb" in method:
+        return "imdb"
+    if "icheckmovies" in method:
+        return "icheckmovies"
+    if "letterboxd" in method:
+        return "letterboxd"
+    if method in textfile.builders:
+        return "textfile"
+    if "stevenlu" in method:
+        return "stevenlu"
+    if "mojo" in method:
+        return "mojo"
+    if "mdblist" in method:
+        return "mdblist"
+    if "simkl" in method:
+        return "simkl"
+    if "tmdb" in method:
+        return "tmdb"
+    if "trakt" in method:
+        return "trakt"
+    if "yamtrack" in method:
+        return "yamtrack"
+    if "serializd" in method:
+        return "serializd"
+    if "floppy" in method:
+        return "floppy"
+    if "radarr" in method:
+        return "radarr"
+    if "sonarr" in method:
+        return "sonarr"
+    return "other"
+
+
+def prefetch_gather_ids(config, builder):
+    """Submits non-Plex gather_ids calls to the shared pool, aligned with builder.builders; Plex pairs get None (main-thread only) and so does everything if threading is off."""
+    pairs = builder.builders
+    if config.thread_pool is None or not config.general["threading"]["parallel_sources"]:
+        return [None] * len(pairs)
+    return [None if "plex" in method else config.thread_pool.submit(builder.gather_ids, method, value) for method, value in pairs]
+
+
 advance_new_agent = ["item_metadata_language", "item_use_original_title"]
 advance_show = [
     "item_episode_sorting",
@@ -3684,89 +3743,91 @@ class CollectionBuilder:
             if list_key and expired is False:
                 logger.info(f"Builder: {method} loaded from Cache")
                 return self.config.Cache.query_list_ids(list_key)
-        if "plex" in method:
-            ids = self.library.get_rating_keys(method, value, self.playlist)
-        elif "tautulli" in method:
-            ids = self.library.Tautulli.get_rating_keys(value, self.playlist)
-        elif "tracearr" in method:
-            if self.playlist:
+        # Experiment C: serializes gather_ids calls per service - tmdbapis' shared _api.response isn't thread-safe, assume others are too until audited.
+        with self.config.get_service_lock(_service_lock_key(method)):
+            if "plex" in method:
+                ids = self.library.get_rating_keys(method, value, self.playlist)
+            elif "tautulli" in method:
+                ids = self.library.Tautulli.get_rating_keys(value, self.playlist)
+            elif "tracearr" in method:
+                if self.playlist:
+                    ids = []
+                    connectors = {}
+                    for pl_library in self.libraries:
+                        connector = pl_library.Tracearr
+                        if not connector:
+                            continue
+                        server_key = (connector.api, connector.server_id)
+                        connectors[server_key] = connector
+                    if len(connectors) > 1:
+                        raise Failed("Tracearr Error: Playlist builders can only combine libraries from one Plex server")
+                    for connector in connectors.values():
+                        machine_id = connector.library.PlexServer.machineIdentifier
+                        server_libraries = [library for library in self.libraries if library.PlexServer.machineIdentifier == machine_id]
+                        ids.extend(connector.get_rating_keys(value, is_playlist=True, libraries=server_libraries))
+                else:
+                    ids = self.library.Tracearr.get_rating_keys(value)
+            elif "anidb" in method:
+                anidb_ids = self.config.AniDB.get_anidb_ids(method, value)
+                ids = self.config.Convert.anidb_to_ids(anidb_ids, self.library)
+            elif "anilist" in method:
+                anilist_ids = self.config.AniList.get_anilist_ids(method, value)
+                ids = self.config.Convert.anilist_to_ids(anilist_ids, self.library)
+            elif "mal" in method:
+                mal_ids = self.config.MyAnimeList.get_mal_ids(method, value)
+                ids = self.config.Convert.myanimelist_to_ids(mal_ids, self.library)
+            elif "tvdb" in method:
+                ids = self.config.TVDb.get_tvdb_ids(method, value)
+            elif "imdb" in method:
+                ids = self.config.IMDb.get_imdb_ids(method, value, self.language)
+            elif "icheckmovies" in method:
+                ids = self.config.ICheckMovies.get_imdb_ids(method, value)
+            elif "letterboxd" in method:
+                ids = self.config.Letterboxd.get_tmdb_ids(method, value, self.language)
+            elif method in textfile.builders:
+                #  is_movie=None means playlist mode (movies + shows).
+                # The target method MUST handle all three states correctly:
+                # True = movie-only, False = show-only, None = both.
+                ids = self.config.TextFile.get_ids(value, self.library.is_movie if not self.playlist else None)
+            elif "stevenlu" in method:
+                ids = self.config.StevenLu.get_imdb_ids(method, value)
+            elif "mojo" in method:
+                ids = self.config.BoxOfficeMojo.get_imdb_ids(method, value)
+            elif "mdblist" in method:
+                #  is_movie=None = playlist mode. Must return BOTH movie
+                # and show entries (e.g. (id, "tmdb") + (id, "tmdb_show")).
+                ids = self.config.MDBList.get_tmdb_ids(method, value, self.library.is_movie if not self.playlist else None)
+            elif "simkl" in method:
+                #  is_movie=None = playlist mode. Must return BOTH movie
+                # and show entries (e.g. (id, "tmdb") + (id, "tmdb_show")).
+                ids = self.config.Simkl.get_simkl_ids(method, value, self.library.is_movie if not self.playlist else None)
+            elif "tmdb" in method:
+                ids = self.config.TMDb.get_tmdb_ids(method, value, self.library.is_movie, self.tmdb_region)
+            elif "trakt" in method:
+                ids = self.config.Trakt.get_trakt_ids(method, value, self.library.is_movie)
+            elif "yamtrack" in method:
+                if method == "yamtrack_tracked":
+                    ids, mal_ids = self.config.YamTrack.get_tracked_ids(value, self.library.is_movie if not self.playlist else None)
+                    if mal_ids:
+                        ids.extend(self.config.Convert.myanimelist_to_ids(mal_ids, self.library))
+                else:
+                    ids = self.config.YamTrack.get_ids(method, value, self.library.is_movie if not self.playlist else None)
+            elif "serializd" in method:
+                ids = self.config.Serializd.get_builder_ids(method, value)
+            elif "floppy" in method:
+                if method == "floppy_tracked":
+                    ids, mal_ids = self.config.Floppy.get_tracked_ids(value, self.library.is_movie if not self.playlist else None)
+                    if mal_ids:
+                        ids.extend(self.config.Convert.myanimelist_to_ids(mal_ids, self.library))
+                else:
+                    ids = self.config.Floppy.get_ids(value, self.library.is_movie if not self.playlist else None)
+            elif "radarr" in method:
+                ids = self.library.Radarr.get_tmdb_ids(method, value)
+            elif "sonarr" in method:
+                ids = self.library.Sonarr.get_tvdb_ids(method, value)
+            else:
                 ids = []
-                connectors = {}
-                for pl_library in self.libraries:
-                    connector = pl_library.Tracearr
-                    if not connector:
-                        continue
-                    server_key = (connector.api, connector.server_id)
-                    connectors[server_key] = connector
-                if len(connectors) > 1:
-                    raise Failed("Tracearr Error: Playlist builders can only combine libraries from one Plex server")
-                for connector in connectors.values():
-                    machine_id = connector.library.PlexServer.machineIdentifier
-                    server_libraries = [library for library in self.libraries if library.PlexServer.machineIdentifier == machine_id]
-                    ids.extend(connector.get_rating_keys(value, is_playlist=True, libraries=server_libraries))
-            else:
-                ids = self.library.Tracearr.get_rating_keys(value)
-        elif "anidb" in method:
-            anidb_ids = self.config.AniDB.get_anidb_ids(method, value)
-            ids = self.config.Convert.anidb_to_ids(anidb_ids, self.library)
-        elif "anilist" in method:
-            anilist_ids = self.config.AniList.get_anilist_ids(method, value)
-            ids = self.config.Convert.anilist_to_ids(anilist_ids, self.library)
-        elif "mal" in method:
-            mal_ids = self.config.MyAnimeList.get_mal_ids(method, value)
-            ids = self.config.Convert.myanimelist_to_ids(mal_ids, self.library)
-        elif "tvdb" in method:
-            ids = self.config.TVDb.get_tvdb_ids(method, value)
-        elif "imdb" in method:
-            ids = self.config.IMDb.get_imdb_ids(method, value, self.language)
-        elif "icheckmovies" in method:
-            ids = self.config.ICheckMovies.get_imdb_ids(method, value)
-        elif "letterboxd" in method:
-            ids = self.config.Letterboxd.get_tmdb_ids(method, value, self.language)
-        elif method in textfile.builders:
-            #  is_movie=None means playlist mode (movies + shows).
-            # The target method MUST handle all three states correctly:
-            # True = movie-only, False = show-only, None = both.
-            ids = self.config.TextFile.get_ids(value, self.library.is_movie if not self.playlist else None)
-        elif "stevenlu" in method:
-            ids = self.config.StevenLu.get_imdb_ids(method, value)
-        elif "mojo" in method:
-            ids = self.config.BoxOfficeMojo.get_imdb_ids(method, value)
-        elif "mdblist" in method:
-            #  is_movie=None = playlist mode. Must return BOTH movie
-            # and show entries (e.g. (id, "tmdb") + (id, "tmdb_show")).
-            ids = self.config.MDBList.get_tmdb_ids(method, value, self.library.is_movie if not self.playlist else None)
-        elif "simkl" in method:
-            #  is_movie=None = playlist mode. Must return BOTH movie
-            # and show entries (e.g. (id, "tmdb") + (id, "tmdb_show")).
-            ids = self.config.Simkl.get_simkl_ids(method, value, self.library.is_movie if not self.playlist else None)
-        elif "tmdb" in method:
-            ids = self.config.TMDb.get_tmdb_ids(method, value, self.library.is_movie, self.tmdb_region)
-        elif "trakt" in method:
-            ids = self.config.Trakt.get_trakt_ids(method, value, self.library.is_movie)
-        elif "yamtrack" in method:
-            if method == "yamtrack_tracked":
-                ids, mal_ids = self.config.YamTrack.get_tracked_ids(value, self.library.is_movie if not self.playlist else None)
-                if mal_ids:
-                    ids.extend(self.config.Convert.myanimelist_to_ids(mal_ids, self.library))
-            else:
-                ids = self.config.YamTrack.get_ids(method, value, self.library.is_movie if not self.playlist else None)
-        elif "serializd" in method:
-            ids = self.config.Serializd.get_builder_ids(method, value)
-        elif "floppy" in method:
-            if method == "floppy_tracked":
-                ids, mal_ids = self.config.Floppy.get_tracked_ids(value, self.library.is_movie if not self.playlist else None)
-                if mal_ids:
-                    ids.extend(self.config.Convert.myanimelist_to_ids(mal_ids, self.library))
-            else:
-                ids = self.config.Floppy.get_ids(value, self.library.is_movie if not self.playlist else None)
-        elif "radarr" in method:
-            ids = self.library.Radarr.get_tmdb_ids(method, value)
-        elif "sonarr" in method:
-            ids = self.library.Sonarr.get_tvdb_ids(method, value)
-        else:
-            ids = []
-            logger.error(f"{self.Type} Error: {method} method not supported")
+                logger.error(f"{self.Type} Error: {method} method not supported")
         if self.config.Cache and self.details["cache_builders"] and ids:
             if list_key:
                 self.config.Cache.delete_list_ids(list_key)

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1840,14 +1840,9 @@ class CollectionBuilder:
             if self.obj is not None:
                 self.exists = True
                 if self.sync or self.playlist:
-                    # Playlists need len() below so they fetch eagerly; sync collections don't need this until add_to_collection(), so it's deferred - see property below.
-                    if not self.playlist and self.config.thread_pool is not None and self.config.general["threading"]["prefetch_collection_children"]:
-                        obj, smart_label_collection = self.obj, self.smart_label_collection
-                        self._remove_item_map = self.config.thread_pool.submit(lambda: {i.ratingKey: i for i in self.library.get_collection_items(obj, smart_label_collection)})
-                    else:
-                        self._remove_item_map = {i.ratingKey: i for i in self.library.get_collection_items(self.obj, self.smart_label_collection)}
+                    self._remove_item_map = self._resolve_remove_item_map()
                 if not self.smart:
-                    self.beginning_count = len(self.remove_item_map) if self.playlist else self.obj.childCount or 0
+                    self.beginning_count = len(self.remove_item_map) if self.playlist else self._collection_child_count(self.obj)
         else:
             self.obj = None
             if self.sync:
@@ -3791,21 +3786,17 @@ class CollectionBuilder:
             elif "letterboxd" in method:
                 ids = self.config.Letterboxd.get_tmdb_ids(method, value, self.language)
             elif method in textfile.builders:
-                #  is_movie=None means playlist mode (movies + shows).
-                # The target method MUST handle all three states correctly:
-                # True = movie-only, False = show-only, None = both.
+                # is_movie: True=movie-only, False=show-only, None=playlist mode (both) - get_ids must handle all three.
                 ids = self.config.TextFile.get_ids(value, self.library.is_movie if not self.playlist else None)
             elif "stevenlu" in method:
                 ids = self.config.StevenLu.get_imdb_ids(method, value)
             elif "mojo" in method:
                 ids = self.config.BoxOfficeMojo.get_imdb_ids(method, value)
             elif "mdblist" in method:
-                #  is_movie=None = playlist mode. Must return BOTH movie
-                # and show entries (e.g. (id, "tmdb") + (id, "tmdb_show")).
+                # is_movie=None = playlist mode; must return BOTH movie and show entries (e.g. (id, "tmdb") + (id, "tmdb_show")).
                 ids = self.config.MDBList.get_tmdb_ids(method, value, self.library.is_movie if not self.playlist else None)
             elif "simkl" in method:
-                #  is_movie=None = playlist mode. Must return BOTH movie
-                # and show entries (e.g. (id, "tmdb") + (id, "tmdb_show")).
+                # is_movie=None = playlist mode; must return BOTH movie and show entries (e.g. (id, "tmdb") + (id, "tmdb_show")).
                 ids = self.config.Simkl.get_simkl_ids(method, value, self.library.is_movie if not self.playlist else None)
             elif "tmdb" in method:
                 ids = self.config.TMDb.get_tmdb_ids(method, value, self.library.is_movie, self.tmdb_region)
@@ -5361,8 +5352,7 @@ class CollectionBuilder:
 
     @property
     def remove_item_map(self):
-        # Resolves the deferred thread_pool fetch (see __init__) on first real use - usually already done by
-        # the time add_to_collection() reaches it, since construction happens well ahead of the Plex-heavy tail.
+        # Resolves the deferred thread_pool fetch (see __init__) on first real use - usually already done by the time add_to_collection() reaches it.
         if isinstance(self._remove_item_map, Future):
             self._remove_item_map = self._remove_item_map.result()
         return self._remove_item_map
@@ -5370,6 +5360,18 @@ class CollectionBuilder:
     @remove_item_map.setter
     def remove_item_map(self, value):
         self._remove_item_map = value
+
+    def _resolve_remove_item_map(self):
+        # Playlists need len() below so they fetch eagerly; sync collections don't need this until add_to_collection(), so it's deferred to thread_pool when prefetch_collection_children is enabled - see remove_item_map property.
+        if not self.playlist and self.config.thread_pool is not None and self.config.general["threading"]["prefetch_collection_children"]:
+            obj, smart_label_collection = self.obj, self.smart_label_collection
+            return self.config.thread_pool.submit(lambda: {i.ratingKey: i for i in self.library.get_collection_items(obj, smart_label_collection)})
+        return {i.ratingKey: i for i in self.library.get_collection_items(self.obj, self.smart_label_collection)}
+
+    @staticmethod
+    def _collection_child_count(obj):
+        # Plex returns None for childCount on genuinely-empty separator collections - treat as 0, not a TypeError (builder.py fix, 2026-07-30).
+        return obj.childCount or 0
 
     @timings.timed("load_collection")
     def load_collection(self):

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1026,7 +1026,7 @@ class CollectionBuilder:
             logger.debug("Validating Method: only_run_on_create")
             logger.debug(f"Value: {data[methods['only_run_on_create']]}")
             self.only_run_on_create = util.parse(self.Type, "only_run_on_create", self.data, datatype="bool", methods=methods, default=False)
-        if self.obj and self.only_run_on_create:
+        if self.obj is not None and self.only_run_on_create:
             raise NotScheduled("Skipped because only_run_on_create is True and the collection already exists")
 
         if "allowed_library_types" in methods and "run_definition" not in methods:
@@ -1824,19 +1824,19 @@ class CollectionBuilder:
         self.do_report = not self.config.no_report and (self.details["save_report"])
         self.do_missing = not self.config.no_missing and (self.details["show_missing"] or self.do_report or (self.library.Radarr and self.radarr_details["add_missing"]) or (self.library.Sonarr and self.sonarr_details["add_missing"]))
         if self.build_collection:
-            if self.obj and ((self.smart and not self.obj.smart) or (not self.smart and self.obj.smart)):
+            if self.obj is not None and ((self.smart and not self.obj.smart) or (not self.smart and self.obj.smart)):
                 logger.info("")
                 logger.error(f"{self.Type} Error: Converting {self.obj.title} to a {'smart' if self.smart else 'normal'} collection")
                 self.library.delete(self.obj)
                 self.obj = None
             if self.smart:
                 check_url = self.smart_url if self.smart_url else self.smart_label_url
-                if self.obj:
+                if self.obj is not None:
                     if check_url != self.library.smart_filter(self.obj):
                         self.library.update_smart_collection(self.obj, check_url)
                         logger.info(f"Metadata: Smart Collection updated to {check_url}")
                 self.beginning_count = len(self.library.fetchItems(check_url)) if check_url else 0
-            if self.obj:
+            if self.obj is not None:
                 self.exists = True
                 if self.sync or self.playlist:
                     self.remove_item_map = {i.ratingKey: i for i in self.library.get_collection_items(self.obj, self.smart_label_collection)}
@@ -1848,7 +1848,7 @@ class CollectionBuilder:
                 logger.warning(f"{self.Type} Error: Sync Mode can only be append when using build_collection: false")
                 self.sync = False
             self.run_again = False
-        if self.non_existing is not False and self.obj:
+        if self.non_existing is not False and self.obj is not None:
             raise NotScheduled(self.non_existing)
 
         logger.info("")
@@ -4115,7 +4115,7 @@ class CollectionBuilder:
         if not items:
             self._log_episode_count(total_ids, unique_total=0)
             return None
-        name = self.obj.title if self.obj else self.name
+        name = self.obj.title if self.obj is not None else self.name
         total = len(items)
         max_length = len(str(total))
         found_before = len(self.found_items)
@@ -4619,7 +4619,7 @@ class CollectionBuilder:
         logger.info("")
         logger.separator(f"Adding to {self.name} {self.Type}", space=False, border=False)
         logger.info("")
-        name, collection_items = self.library.get_collection_name_and_items(self.obj if self.obj else self.name, self.smart_label_collection)
+        name, collection_items = self.library.get_collection_name_and_items(self.obj if self.obj is not None else self.name, self.smart_label_collection)
         collection_item_keys = {ci.ratingKey for ci in collection_items}
         total = self.limit if self.limit and len(self.found_items) > self.limit else len(self.found_items)
         spacing = len(str(total)) * 2 + 1
@@ -4642,7 +4642,7 @@ class CollectionBuilder:
                 amount_added += 1
                 if self.details["changes_webhooks"]:
                     self.notification_additions.append(util.item_set(item, self.library.get_id_from_maps(item.ratingKey)))
-        if self.playlist and items_added and not self.obj:
+        if self.playlist and items_added and self.obj is None:
             self.obj = self.library.create_playlist(self.name, items_added)
             logger.info("")
             logger.info(f"Playlist: {self.name} created")
@@ -5046,7 +5046,7 @@ class CollectionBuilder:
 
     @timings.timed("load_collection_items")
     def load_collection_items(self):
-        if self.build_collection and self.obj:
+        if self.build_collection and self.obj is not None:
             self.items = self.library.get_collection_items(self.obj, self.smart_label_collection)
         elif not self.build_collection:
             logger.info("")
@@ -5365,7 +5365,7 @@ class CollectionBuilder:
                 if not self.library.smart_label_check(self.name):
                     raise Failed
                 smart_type, _, self.smart_url = self.build_filter("smart_label", self.smart_label, default_sort="random")
-                if not self.obj:
+                if self.obj is None:
                     self.library.create_smart_collection(self.name, smart_type, self.smart_url, self.ignore_blank_results)
             except Failed:
                 raise Failed(f"{self.Type} Error: Label: {self.name} was not added to any items in the Library")
@@ -5696,7 +5696,7 @@ class CollectionBuilder:
         logger.info("")
         logger.separator(f"Syncing {self.name} {self.Type} to Trakt List {self.sync_to_trakt_list}", space=False, border=False)
         logger.info("")
-        if self.obj:
+        if self.obj is not None:
             self.library.item_reload(self.obj)
         self.load_collection_items()
         current_ids = []
@@ -5770,10 +5770,10 @@ class CollectionBuilder:
         return list(dict.fromkeys(current_ids))
 
     def delete(self):
-        title = self.obj.title if self.obj else self.name
+        title = self.obj.title if self.obj is not None else self.name
         if self.playlist:
             output = f"Deleting {self.Type} {title}"
-        elif self.obj:
+        elif self.obj is not None:
             output = f"{self.Type} {self.obj.title} deleted"
             if self.smart_label_collection:
                 for item in self.library.search(label=self.name, libtype=self.builder_level):
@@ -5792,14 +5792,14 @@ class CollectionBuilder:
                     output += f"\nPlaylist deleted on User {user}"
                 except Failed:
                     output += f"\nPlaylist not found on User {user}"
-        elif self.obj:
+        elif self.obj is not None:
             self.library.delete_collection(self.obj)
-        if self.obj:
+        if self.obj is not None:
             self.deleted = True
         return output
 
     def sync_playlist(self):
-        if self.obj and self.valid_users:
+        if self.obj is not None and self.valid_users:
             logger.info("")
             logger.separator("Syncing Playlist to Users", space=False, border=False)
             logger.info("")
@@ -5813,7 +5813,7 @@ class CollectionBuilder:
                     logger.info(f"Playlist: {self.name} synced to {user}")
 
     def exclude_admin_from_playlist(self):
-        if self.obj and (self.exclude_users is not None and self.library.account.username in self.exclude_users):
+        if self.obj is not None and (self.exclude_users is not None and self.library.account.username in self.exclude_users):
             logger.info("")
             logger.separator("Excluding Admin from Playlist", space=False, border=False)
             logger.info("")
@@ -5824,7 +5824,7 @@ class CollectionBuilder:
                 logger.info(f"Playlist: {self.name} not found on User {self.library.account.username}")
 
     def send_notifications(self, playlist=False):
-        if self.obj and not self.deleted and self.details["changes_webhooks"] and (self.created or len(self.notification_additions) > 0 or len(self.notification_removals) > 0):
+        if self.obj is not None and not self.deleted and self.details["changes_webhooks"] and (self.created or len(self.notification_additions) > 0 or len(self.notification_removals) > 0):
             self.library.item_reload(self.obj)
             try:
                 self.library.Webhooks.collection_hooks(

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1841,7 +1841,7 @@ class CollectionBuilder:
                 if self.sync or self.playlist:
                     self.remove_item_map = {i.ratingKey: i for i in self.library.get_collection_items(self.obj, self.smart_label_collection)}
                 if not self.smart:
-                    self.beginning_count = len(self.remove_item_map) if self.playlist else self.obj.childCount
+                    self.beginning_count = len(self.remove_item_map) if self.playlist else self.obj.childCount or 0
         else:
             self.obj = None
             if self.sync:

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -22,8 +22,7 @@ def sql_identifier(name):
 
 
 class _LockedConnection:
-    """Experiment A1 - wraps the shared connection so `with self.connection as c:` holds a lock for the whole transaction; RLock so the nested update_image_map call re-enters cleanly.
-    Reused for the life of the Cache (not rebuilt per access); __getattr__ proxies to the real connection so direct calls like .execute()/.set_trace_callback() still work, just without the lock."""
+    """Experiment A1 - wraps the shared connection so `with self.connection:` holds an RLock per transaction; reused for Cache's life; __getattr__ proxies direct calls (.execute() etc) through unlocked."""
 
     def __init__(self, connection, lock):
         self._connection, self._lock = connection, lock

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -400,7 +400,7 @@ class Cache:
         self.migrate_overlay_value_cache()
 
     @property
-    def connection(self):
+    def connection(self) -> "_LockedConnection":
         # One shared connection for the life of the run; opening a fresh one per
         # query costs a file open + schema parse and previously was never closed.
         # `with self.connection:` still commits per block exactly as before.
@@ -414,6 +414,7 @@ class Cache:
             self._connection = connection
             # Built once and reused - callers doing `cache.connection is cache.connection` (or holding onto it across calls, e.g. set_trace_callback) need a stable object, not a fresh wrapper every access.
             self._locked_connection = _LockedConnection(self._connection, self._lock)
+        assert self._locked_connection is not None
         return self._locked_connection
 
     def close(self):

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -3,6 +3,7 @@ import os
 import random
 import re
 import sqlite3
+import threading
 from contextlib import closing
 from datetime import datetime, timedelta
 
@@ -20,12 +21,36 @@ def sql_identifier(name):
     return str(name)
 
 
+class _LockedConnection:
+    """Experiment A1 - wraps the shared connection so `with self.connection as c:` holds a lock for the whole transaction; RLock so the nested update_image_map call re-enters cleanly.
+    Reused for the life of the Cache (not rebuilt per access); __getattr__ proxies to the real connection so direct calls like .execute()/.set_trace_callback() still work, just without the lock."""
+
+    def __init__(self, connection, lock):
+        self._connection, self._lock = connection, lock
+
+    def __enter__(self):
+        self._lock.acquire()
+        return self._connection.__enter__()
+
+    def __exit__(self, *args):
+        try:
+            return self._connection.__exit__(*args)
+        finally:
+            self._lock.release()
+
+    def __getattr__(self, name):
+        return getattr(self._connection, name)
+
+
 @timings.wrap_cache_methods
 class Cache:
     def __init__(self, config_path, expiration):
         self.cache_path = f"{os.path.splitext(config_path)[0]}.cache"
         self.expiration = expiration
         self._connection = None
+        self._locked_connection = None
+        # feat/threading Experiment A1 (won the bake-off 2026-07-26 - see perf-results-log.md): RLock guards each `with self.connection:` transaction.
+        self._lock = threading.RLock()
         # In-process memoization for _query_map/_update_map's ID lookups, keyed per map_name - avoids repeat SQLite round-trips for the same ID within one run.
         self._map_cache = {}
         # Same idea for query_guid_map/update_guid_map, which use their own SQL, not _query_map - keyed by plex_guid, caches the raw row so expiration still recomputes fresh each call.
@@ -388,7 +413,9 @@ class Cache:
             except sqlite3.Error:
                 pass
             self._connection = connection
-        return self._connection
+            # Built once and reused - callers doing `cache.connection is cache.connection` (or holding onto it across calls, e.g. set_trace_callback) need a stable object, not a fresh wrapper every access.
+            self._locked_connection = _LockedConnection(self._connection, self._lock)
+        return self._locked_connection
 
     def close(self):
         """Close database connection and clean up WAL/SHM files."""
@@ -401,6 +428,7 @@ class Cache:
                 pass
             finally:
                 self._connection = None
+                self._locked_connection = None
 
     def migrate_overlay_value_cache(self):
         # Upgrade legacy overlay_special_text2 to overlay_value_cache; its presence is the one-time upgrade signal (not created on fresh installs, dropped once migrated), and runs regardless of cache_expiration.

--- a/modules/config.py
+++ b/modules/config.py
@@ -836,13 +836,13 @@ class ConfigFile:
             "cache": check_for_attribute(self.data, "cache", parent="settings", var_type="bool", default=True),
             "cache_expiration": check_for_attribute(self.data, "cache_expiration", parent="settings", var_type="int", default=60, int_min=1),
             "threading": {
-                # settings.threading is two levels deep, one past what check_for_attribute's single `parent` supports, so read it as its own sub-dict here.
-                # do_print=False throughout: an unconfigured run (the common case) should stay silent and behave byte-for-byte like today, not nag about a fork-only experiment block.
-                "workers": check_for_attribute(threading_settings, "workers", var_type="int", default=1, int_min=1, save=False, do_print=False),
+                # settings.threading is two levels deep (past check_for_attribute's single `parent` support), so read it as its own sub-dict; do_print=False throughout so an unconfigured run stays silent.
+                # Phase 2 productization (2026-07-30): workers/prefetch_collection_children default to the bake-off-validated shipped-forward posture, not the old inert-by-default posture - an absent threading block now behaves like the proven-fast config, not like workers:1.
+                "workers": check_for_attribute(threading_settings, "workers", var_type="int", default=4, int_min=1, save=False, do_print=False),
                 "tmdb_pages": check_for_attribute(threading_settings, "tmdb_pages", default="off", test_list=threading_tmdb_pages_options, save=False, do_print=False),
                 "parallel_sources": check_for_attribute(threading_settings, "parallel_sources", var_type="bool", default=False, save=False, do_print=False),
-                # Phase 2 pilot: submit CollectionBuilder's remove_item_map fetch (a read-only, no-shared-state Plex call) to thread_pool instead of blocking __init__, resolved lazily on first use later in the run - default off, bake-off pending.
-                "prefetch_collection_children": check_for_attribute(threading_settings, "prefetch_collection_children", var_type="bool", default=False, save=False, do_print=False),
+                # Confirmed ~2.7-3.0% wall-time win at workers:4, no further gain at workers:8 (overnight churn-loop A/B, see perf-results-log.md) - defaults on.
+                "prefetch_collection_children": check_for_attribute(threading_settings, "prefetch_collection_children", var_type="bool", default=True, save=False, do_print=False),
             },
             "asset_directory": check_for_attribute(self.data, "asset_directory", parent="settings", var_type="list_path", default_is_none=True),
             "asset_folders": check_for_attribute(self.data, "asset_folders", parent="settings", var_type="bool", default=True),

--- a/modules/config.py
+++ b/modules/config.py
@@ -69,10 +69,8 @@ hub_sort_options = {
     "random": "Sort Recommendation Hubs in a random order",
 }
 # feat/threading experiment toggles - fork-only, not part of upstream schema
-threading_cache_mode_options = {
-    "lock": "RLock-guarded shared SQLite connection (Experiment A1)",
-    "threadlocal": "One SQLite connection per thread (Experiment A2)",
-}
+# cache_mode was an Experiment A toggle (lock=A1 vs threadlocal=A2); A1 won the bake-off 2026-07-26 (see
+# perf-results-log.md) and is now Cache's only behavior, so there's nothing left to toggle here.
 threading_tmdb_pages_options = {
     "bypass": "Raw-HTTP TMDb discover page fan-out (Experiment B1)",
     "subclass": "tmdbapis subclass page fan-out (Experiment B2)",
@@ -840,7 +838,6 @@ class ConfigFile:
                 # settings.threading is two levels deep, one past what check_for_attribute's single `parent` supports, so read it as its own sub-dict here.
                 # do_print=False throughout: an unconfigured run (the common case) should stay silent and behave byte-for-byte like today, not nag about a fork-only experiment block.
                 "workers": check_for_attribute(threading_settings, "workers", var_type="int", default=1, int_min=1, save=False, do_print=False),
-                "cache_mode": check_for_attribute(threading_settings, "cache_mode", default="lock", test_list=threading_cache_mode_options, save=False, do_print=False),
                 "tmdb_pages": check_for_attribute(threading_settings, "tmdb_pages", default="off", test_list=threading_tmdb_pages_options, save=False, do_print=False),
                 "parallel_sources": check_for_attribute(threading_settings, "parallel_sources", var_type="bool", default=False, save=False, do_print=False),
             },

--- a/modules/config.py
+++ b/modules/config.py
@@ -1,5 +1,6 @@
 import os
 import re
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 
@@ -915,6 +916,9 @@ class ConfigFile:
         }
         # feat/threading: created only when workers>1, torn down alongside Cache.close() in kometa.py's run cleanup - never a module-level singleton, never outlives this Config/run.
         self.thread_pool = ThreadPoolExecutor(max_workers=self.general["threading"]["workers"]) if self.general["threading"]["workers"] > 1 else None
+        # Experiment C: one lock per service, lazily created (double-checked locking - meta-lock only guards dict mutation, not the service call).
+        self.service_locks = {}
+        self._service_locks_meta_lock = threading.Lock()
         self.custom_repo = None
         if self.general["custom_repo"]:
             repo = self.general["custom_repo"]
@@ -2604,6 +2608,17 @@ class ConfigFile:
             logger.save_errors = False
             logger.clear_errors()
             raise
+
+    def get_service_lock(self, key):
+        """Returns the shared Lock for a given service key (see builder.py's gather_ids), creating it on first use. Safe to call from any thread - the meta-lock only guards the moment a new key is added, never the caller's actual work."""
+        lock = self.service_locks.get(key)
+        if lock is None:
+            with self._service_locks_meta_lock:
+                lock = self.service_locks.get(key)
+                if lock is None:
+                    lock = threading.Lock()
+                    self.service_locks[key] = lock
+        return lock
 
     def thread_map(self, items, fn):
         """Run fn(item) for each item, in parallel on self.thread_pool if threading is enabled, sequentially otherwise. Returns results in input order; raises the first exception in input order once every item has finished."""

--- a/modules/config.py
+++ b/modules/config.py
@@ -69,9 +69,7 @@ hub_sort_options = {
     "configured.desc": "Sort Recommendation Hubs in the order collections appear in your config files (last to first)",
     "random": "Sort Recommendation Hubs in a random order",
 }
-# feat/threading experiment toggles - fork-only, not part of upstream schema
-# cache_mode was an Experiment A toggle (lock=A1 vs threadlocal=A2); A1 won the bake-off 2026-07-26 (see
-# perf-results-log.md) and is now Cache's only behavior, so there's nothing left to toggle here.
+# feat/threading experiment toggles (fork-only, not upstream schema) - cache_mode was Experiment A's lock-vs-threadlocal toggle; A1 won the 2026-07-26 bake-off and is now Cache's only behavior, so nothing's left to toggle here.
 threading_tmdb_pages_options = {
     "bypass": "Raw-HTTP TMDb discover page fan-out (Experiment B1)",
     "subclass": "tmdbapis subclass page fan-out (Experiment B2)",
@@ -837,7 +835,7 @@ class ConfigFile:
             "cache_expiration": check_for_attribute(self.data, "cache_expiration", parent="settings", var_type="int", default=60, int_min=1),
             "threading": {
                 # settings.threading is two levels deep (past check_for_attribute's single `parent` support), so read it as its own sub-dict; do_print=False throughout so an unconfigured run stays silent.
-                # Phase 2 productization (2026-07-30): workers/prefetch_collection_children default to the bake-off-validated shipped-forward posture, not the old inert-by-default posture - an absent threading block now behaves like the proven-fast config, not like workers:1.
+                # Phase 2 (2026-07-30): workers/prefetch_collection_children now default to the bake-off-validated posture - an absent block behaves like the proven-fast config, not workers:1.
                 "workers": check_for_attribute(threading_settings, "workers", var_type="int", default=4, int_min=1, save=False, do_print=False),
                 "tmdb_pages": check_for_attribute(threading_settings, "tmdb_pages", default="off", test_list=threading_tmdb_pages_options, save=False, do_print=False),
                 "parallel_sources": check_for_attribute(threading_settings, "parallel_sources", var_type="bool", default=False, save=False, do_print=False),

--- a/modules/config.py
+++ b/modules/config.py
@@ -1,5 +1,6 @@
 import os
 import re
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 
 from modules import operations, radarr, sonarr, util
@@ -66,6 +67,16 @@ hub_sort_options = {
     "configured": "Sort Recommendation Hubs in the order collections appear in your config files (first to last)",
     "configured.desc": "Sort Recommendation Hubs in the order collections appear in your config files (last to first)",
     "random": "Sort Recommendation Hubs in a random order",
+}
+# feat/threading experiment toggles - fork-only, not part of upstream schema
+threading_cache_mode_options = {
+    "lock": "RLock-guarded shared SQLite connection (Experiment A1)",
+    "threadlocal": "One SQLite connection per thread (Experiment A2)",
+}
+threading_tmdb_pages_options = {
+    "bypass": "Raw-HTTP TMDb discover page fan-out (Experiment B1)",
+    "subclass": "tmdbapis subclass page fan-out (Experiment B2)",
+    "off": "Sequential TMDb discover pagination (control)",
 }
 imdb_label_options = {
     "remove": "Remove All IMDb Parental Labels",
@@ -811,6 +822,9 @@ class ConfigFile:
                     add_operation(image_key, {"mass_image_update": {image_key: image_config}}, schedule=get_schedule(input_dict[image_key]))
             return output_ops
 
+        settings_block = self.data.get("settings") if isinstance(self.data.get("settings"), dict) else None
+        threading_settings = settings_block.get("threading") if settings_block and isinstance(settings_block.get("threading"), dict) else {}
+
         self.general = {
             "run_order": check_for_attribute(
                 self.data,
@@ -822,6 +836,14 @@ class ConfigFile:
             ),
             "cache": check_for_attribute(self.data, "cache", parent="settings", var_type="bool", default=True),
             "cache_expiration": check_for_attribute(self.data, "cache_expiration", parent="settings", var_type="int", default=60, int_min=1),
+            "threading": {
+                # settings.threading is two levels deep, one past what check_for_attribute's single `parent` supports, so read it as its own sub-dict here.
+                # do_print=False throughout: an unconfigured run (the common case) should stay silent and behave byte-for-byte like today, not nag about a fork-only experiment block.
+                "workers": check_for_attribute(threading_settings, "workers", var_type="int", default=1, int_min=1, save=False, do_print=False),
+                "cache_mode": check_for_attribute(threading_settings, "cache_mode", default="lock", test_list=threading_cache_mode_options, save=False, do_print=False),
+                "tmdb_pages": check_for_attribute(threading_settings, "tmdb_pages", default="off", test_list=threading_tmdb_pages_options, save=False, do_print=False),
+                "parallel_sources": check_for_attribute(threading_settings, "parallel_sources", var_type="bool", default=False, save=False, do_print=False),
+            },
             "asset_directory": check_for_attribute(self.data, "asset_directory", parent="settings", var_type="list_path", default_is_none=True),
             "asset_folders": check_for_attribute(self.data, "asset_folders", parent="settings", var_type="bool", default=True),
             "asset_depth": check_for_attribute(self.data, "asset_depth", parent="settings", var_type="int", default=0),
@@ -894,6 +916,8 @@ class ConfigFile:
                 do_print=False,
             ),
         }
+        # feat/threading: created only when workers>1, torn down alongside Cache.close() in kometa.py's run cleanup - never a module-level singleton, never outlives this Config/run.
+        self.thread_pool = ThreadPoolExecutor(max_workers=self.general["threading"]["workers"]) if self.general["threading"]["workers"] > 1 else None
         self.custom_repo = None
         if self.general["custom_repo"]:
             repo = self.general["custom_repo"]
@@ -2583,6 +2607,23 @@ class ConfigFile:
             logger.save_errors = False
             logger.clear_errors()
             raise
+
+    def thread_map(self, items, fn):
+        """Run fn(item) for each item, in parallel on self.thread_pool if threading is enabled, sequentially otherwise. Returns results in input order; raises the first exception in input order once every item has finished."""
+        if self.thread_pool is None:
+            return [fn(item) for item in items]
+        futures = [self.thread_pool.submit(fn, item) for item in items]
+        results = [None] * len(futures)
+        first_exception = None
+        for i, future in enumerate(futures):
+            try:
+                results[i] = future.result()
+            except Exception as e:
+                if first_exception is None:
+                    first_exception = e
+        if first_exception is not None:
+            raise first_exception
+        return results
 
     def notify(self, text, server=None, library=None, collection=None, playlist=None, critical=True):
         for error in util.get_list(text, split=False, return_none=False) or []:

--- a/modules/config.py
+++ b/modules/config.py
@@ -841,6 +841,8 @@ class ConfigFile:
                 "workers": check_for_attribute(threading_settings, "workers", var_type="int", default=1, int_min=1, save=False, do_print=False),
                 "tmdb_pages": check_for_attribute(threading_settings, "tmdb_pages", default="off", test_list=threading_tmdb_pages_options, save=False, do_print=False),
                 "parallel_sources": check_for_attribute(threading_settings, "parallel_sources", var_type="bool", default=False, save=False, do_print=False),
+                # Phase 2 pilot: submit CollectionBuilder's remove_item_map fetch (a read-only, no-shared-state Plex call) to thread_pool instead of blocking __init__, resolved lazily on first use later in the run - default off, bake-off pending.
+                "prefetch_collection_children": check_for_attribute(threading_settings, "prefetch_collection_children", var_type="bool", default=False, save=False, do_print=False),
             },
             "asset_directory": check_for_attribute(self.data, "asset_directory", parent="settings", var_type="list_path", default_is_none=True),
             "asset_folders": check_for_attribute(self.data, "asset_folders", parent="settings", var_type="bool", default=True),

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -241,6 +241,8 @@ class Operations:
                     source = {"tmdb": "TMDb", "trakt": "Trakt", "tvdb": "TVDb", "plex": "Plex", "assets": "Assets"}.get(str(source).lower(), str(source))
                     image_operation_counts[(operation, source, image_type, level, status)] += 1
 
+            # Pre-warms reload data for the whole library in batched requests instead of one per item - see plex.py's bulk_reload().
+            self.library.bulk_reload(items)
             for i, item in enumerate(items, 1):
                 logger.info("")
                 logger.info(f"({i}/{total_items}) {item.title}")

--- a/modules/overlay.py
+++ b/modules/overlay.py
@@ -271,6 +271,7 @@ class Overlay:
                                 width = int(base_width * height / base_height)
                             if width and not height:
                                 height = int(base_height * width / base_width)
+                            assert width is not None and height is not None
                             self.image = self.image.resize((width, height), Image.Resampling.LANCZOS)
                         # Force image data to be loaded into memory before context closes
                         self.image.load()
@@ -369,6 +370,7 @@ class Overlay:
                             width = int(base_width * height / base_height)
                         if width and not height:
                             height = int(base_height * width / base_width)
+                        assert width is not None and height is not None
                         self.image = self.image.resize((width, height), Image.Resampling.LANCZOS)
                     if self.has_coordinates():
                         self.backdrop_box = self.image.size

--- a/modules/overlays.py
+++ b/modules/overlays.py
@@ -8,7 +8,7 @@ from plexapi.exceptions import BadRequest
 from plexapi.video import Episode, Season
 
 from modules import overlay, plex, timings, util
-from modules.builder import CollectionBuilder
+from modules.builder import CollectionBuilder, prefetch_gather_ids
 from modules.util import Failed, FilterFailed, NotScheduled, OverlayError
 
 logger = util.logger
@@ -515,12 +515,16 @@ class Overlays:
 
                         builder.display_filters()
 
-                        for method, value in builder.builders:
+                        # Experiment C: non-Plex gather_ids calls for this overlay's builders start running in the background now; Plex-method builders (None here) still run inline below, on the main thread, in order.
+                        prefetched = prefetch_gather_ids(self.config, builder)
+                        for i, (method, value) in enumerate(builder.builders):
                             logger.debug("")
                             logger.debug(f"Builder: {method}: {value}")
                             logger.info("")
                             try:
-                                builder.filter_and_save_items(builder.gather_ids(method, value))
+                                pending = prefetched[i]
+                                ids = pending.result() if pending is not None else builder.gather_ids(method, value)
+                                builder.filter_and_save_items(ids)
                             except Failed as e:
                                 if builder.ignore_blank_results:
                                     logger.info("")

--- a/modules/overlays.py
+++ b/modules/overlays.py
@@ -108,6 +108,8 @@ class Overlays:
             timings.registry.library_ctx = self.library.name
             # Items freshly composed this run - flushed every plex_bulk_edit_batch_size items (if set), else once at the end.
             overlay_label_items = []
+            # Pre-warms reload data for every item in this overlay pass in batched requests instead of one per item - see plex.py's bulk_reload().
+            self.library.bulk_reload([item for item, _ in key_to_overlays.values()], force=self.library.reapply_overlays)
             for i, (over_key, (item, over_names)) in enumerate(sorted(key_to_overlays.items(), key=lambda io: self.library.get_item_display_title(io[1][0], sort=True)), 1):
                 item_title = self.library.get_item_display_title(item)
 

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -2840,9 +2840,7 @@ class Plex(Library):
         return map_key, attrs
 
     def get_item_display_title(self, item_to_sort, sort=False):
-        # Only fetch the parent (show/artist) when sort actually needs its titleSort - previously fetched
-        # unconditionally and discarded on the sort=False path, which every caller but one uses; found via
-        # the 2026-07-27 reload-origin census (~2,669 wasted single-item GETs, ~19s of a 276s run).
+        # Only fetch the parent (show/artist) when sort needs its titleSort - previously fetched unconditionally and discarded on sort=False (2026-07-27 census: ~2,669 wasted GETs).
         if isinstance(item_to_sort, Album):
             if sort:
                 return f"{item_to_sort.artist().titleSort} Album {item_to_sort.titleSort}"  # type: ignore[union-attr]

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -952,7 +952,9 @@ class Plex(Library):
 
     @PLEX_RETRY
     def fetchItem(self, data):
-        return self.PlexServer.fetchItem(data)
+        # Tagged to confirm this is the mystery batchable-but-untagged single-item GET population found by the reload-origin census - see perf-results-log.md.
+        with timings.tag_context("fetch_item"):
+            return self.PlexServer.fetchItem(data)
 
     @PLEX_RETRY
     def fetchItems(self, uri_args):
@@ -2838,15 +2840,21 @@ class Plex(Library):
         return map_key, attrs
 
     def get_item_display_title(self, item_to_sort, sort=False):
+        # Only fetch the parent (show/artist) when sort actually needs its titleSort - previously fetched
+        # unconditionally and discarded on the sort=False path, which every caller but one uses; found via
+        # the 2026-07-27 reload-origin census (~2,669 wasted single-item GETs, ~19s of a 276s run).
         if isinstance(item_to_sort, Album):
-            artist = item_to_sort.artist()  # type: ignore[union-attr]
-            return f"{artist.titleSort if sort else item_to_sort.parentTitle} Album {item_to_sort.titleSort if sort else item_to_sort.title}"  # type: ignore[union-attr]
+            if sort:
+                return f"{item_to_sort.artist().titleSort} Album {item_to_sort.titleSort}"  # type: ignore[union-attr]
+            return f"{item_to_sort.parentTitle} Album {item_to_sort.title}"
         elif isinstance(item_to_sort, Season):
-            show = item_to_sort.show()
-            return f"{show.titleSort if sort else item_to_sort.parentTitle} Season {item_to_sort.seasonNumber}"  # type: ignore[union-attr]
+            if sort:
+                return f"{item_to_sort.show().titleSort} Season {item_to_sort.seasonNumber}"  # type: ignore[union-attr]
+            return f"{item_to_sort.parentTitle} Season {item_to_sort.seasonNumber}"
         elif isinstance(item_to_sort, Episode):
-            show = item_to_sort.show()
-            return f"{show.titleSort if sort else item_to_sort.grandparentTitle} {item_to_sort.seasonEpisode.upper()}"  # type: ignore[union-attr]
+            if sort:
+                return f"{item_to_sort.show().titleSort} {item_to_sort.seasonEpisode.upper()}"  # type: ignore[union-attr]
+            return f"{item_to_sort.grandparentTitle} {item_to_sort.seasonEpisode.upper()}"
         else:
             return item_to_sort.titleSort if sort else item_to_sort.title
 

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1640,6 +1640,16 @@ class Plex(Library):
                 total_sent += len(chunk)
         logger.exorcise()
 
+    def remove_smart_label_for_collection(self, collection):
+        # -dcl: Smart Label's default label is the collection's own title (see CollectionBuilder.smart_label). Custom smart_label names aren't detectable here, before config is parsed - returns 0, caller no-ops.
+        if not self.smart_label_check(collection.title):
+            return 0
+        labeled_items = self.search(label=collection.title)
+        if not labeled_items:
+            return 0
+        self.batch_edit_tags(labeled_items, "label", remove_tags=[collection.title])
+        return len(labeled_items)
+
     def move_item(self, collection, item, after=None):
         key = f"{collection.key}/items/{item}/move"
         if after:

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1188,6 +1188,67 @@ class Plex(Library):
             raise Failed(f"Item Failed to Load: {e}")
         return item
 
+    def bulk_reload(self, items, force=False):
+        # Pre-warms cached_items via PMS's batched /library/metadata/{ids} endpoint (Probe 2: ~1.68x/item) so later reload()/item_reload() calls become cache hits instead of one request per item.
+        with timings.tag_context("item_reload_batch"):
+            pending = {}
+            for item in items:
+                rk = int(item.ratingKey)
+                if not force and rk in self.cached_items and self.cached_items[rk][1]:
+                    continue
+                pending[rk] = item
+            if not pending:
+                return
+            batch_size = 100
+            # Grouped by type first, not just chunked - _buildDetailsKey's include/exclude set can differ by class, same reasoning _group_items_by_type already uses for batchMultiEdits.
+            for group in self._group_items_by_type(list(pending.values())):
+                details_key = group[0]._buildDetailsKey(
+                    checkFiles=False,
+                    includeAllConcerts=False,
+                    includeBandwidths=False,
+                    includeChapters=False,
+                    includeChildren=False,
+                    includeConcerts=False,
+                    includeExternalMedia=False,
+                    includeExtras=False,
+                    includeFields=False,
+                    includeGeolocation=False,
+                    includeLoudnessRamps=False,
+                    includeMarkers=False,
+                    includeOnDeck=False,
+                    includePopularLeaves=False,
+                    includeRelated=False,
+                    includeRelatedCount=0,
+                    includeReviews=False,
+                    includeStations=False,
+                )
+                query_suffix = details_key.split("?", 1)[1] if "?" in details_key else ""
+                keys = [int(i.ratingKey) for i in group]
+                for i in range(0, len(keys), batch_size):
+                    chunk = keys[i : i + batch_size]
+                    id_str = ",".join(str(k) for k in chunk)
+                    batch_key = f"/library/metadata/{id_str}" + (f"?{query_suffix}" if query_suffix else "")
+                    try:
+                        data = self.PlexServer.query(batch_key)
+                    except (BadRequest, NotFound):
+                        data = None
+                    seen = set()
+                    if data is not None:
+                        for element in data:
+                            rk = utils.cast(int, element.attrib.get("ratingKey"))
+                            if rk in pending:
+                                pending[rk]._invalidateCacheAndLoadData(element)
+                                pending[rk]._autoReload = False
+                                self.cached_items[rk] = (pending[rk], True)
+                                for fk in [k for k in self.filter_attr_cache if k[0] == rk]:
+                                    del self.filter_attr_cache[fk]
+                                seen.add(rk)
+                    # Anything the batch didn't return (dropped invalid key, whole-chunk failure) falls back to the proven single-item path - never silently skipped.
+                    for rk in chunk:
+                        if rk not in seen:
+                            self.item_reload(pending[rk])
+                            self.cached_items[rk] = (pending[rk], True)
+
     def cached_item_attr(self, item, attr):
         # Memoizes a plain item.<attr> read for the rest of the run - safe because reload() above already clears this item's entries the moment a real reload happens, so a cached value is exactly as fresh as reading the attribute directly would be.
         cache_key = (item.ratingKey, attr)

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -820,7 +820,7 @@ class Plex(Library):
         logger.secret(self.token)
         try:
             self.PlexServer = PlexServer(baseurl=self.url, token=self.token, session=self.session, timeout=self.timeout)
-            timings.registry.set_plex_hostname(urlparse(self.url).hostname)
+            timings.registry.set_plex_hostname(self.url)
             plexapi.server.TIMEOUT = self.timeout  # pyright: ignore[reportOptionalMemberAccess,reportAttributeAccessIssue]
             os.environ["PLEXAPI_PLEXAPI_TIMEOUT"] = str(self.timeout)
             logger.info(f"Connected to server {self.PlexServer.friendlyName} version {self.PlexServer.version}")
@@ -1125,26 +1125,28 @@ class Plex(Library):
         return image_url
 
     def item_reload(self, item):
-        item.reload(
-            checkFiles=False,
-            includeAllConcerts=False,
-            includeBandwidths=False,
-            includeChapters=False,
-            includeChildren=False,
-            includeConcerts=False,
-            includeExternalMedia=False,
-            includeExtras=False,
-            includeFields=False,
-            includeGeolocation=False,
-            includeLoudnessRamps=False,
-            includeMarkers=False,
-            includeOnDeck=False,
-            includePopularLeaves=False,
-            includeRelated=False,
-            includeRelatedCount=0,
-            includeReviews=False,
-            includeStations=False,
-        )
+        # Tagged so the census can isolate single-item reload GETs (the read-batching candidate) from every other kind of plex network call - see perf-results-log.md's call census entry.
+        with timings.tag_context("item_reload"):
+            item.reload(
+                checkFiles=False,
+                includeAllConcerts=False,
+                includeBandwidths=False,
+                includeChapters=False,
+                includeChildren=False,
+                includeConcerts=False,
+                includeExternalMedia=False,
+                includeExtras=False,
+                includeFields=False,
+                includeGeolocation=False,
+                includeLoudnessRamps=False,
+                includeMarkers=False,
+                includeOnDeck=False,
+                includePopularLeaves=False,
+                includeRelated=False,
+                includeRelatedCount=0,
+                includeReviews=False,
+                includeStations=False,
+            )
         item._autoReload = False
         return item
 

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1641,7 +1641,7 @@ class Plex(Library):
         logger.exorcise()
 
     def remove_smart_label_for_collection(self, collection):
-        # -dcl: Smart Label's default label is the collection's own title (see CollectionBuilder.smart_label). Custom smart_label names aren't detectable here, before config is parsed - returns 0, caller no-ops.
+        # --delete-collections-labels: Smart Label's default label is the collection's own title (see CollectionBuilder.smart_label). Custom smart_label names aren't detectable here, before config is parsed - returns 0, caller no-ops.
         if not self.smart_label_check(collection.title):
             return 0
         labeled_items = self.search(label=collection.title)

--- a/modules/radarr.py
+++ b/modules/radarr.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlparse
-
 from arrapi import RadarrAPI
 from arrapi.exceptions import ArrException
 
@@ -27,7 +25,7 @@ class Radarr:
         logger.secret(self.token)
         try:
             self.api = RadarrAPI(self.url, self.token, session=self.requests.session)
-            timings.registry.register_arr_host(urlparse(self.url).hostname, "radarr")
+            timings.registry.register_arr_host(self.url, "radarr")
             self.api.respect_list_exclusions_when_adding()
             self.api._validate_add_options(params["root_folder_path"], params["quality_profile"])  # noqa
             self.profiles = self.api.quality_profile()

--- a/modules/sonarr.py
+++ b/modules/sonarr.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlparse
-
 from arrapi import SonarrAPI
 from arrapi.exceptions import ArrException
 
@@ -36,7 +34,7 @@ class Sonarr:
         logger.secret(self.token)
         try:
             self.api = SonarrAPI(self.url, self.token, session=self.requests.session)
-            timings.registry.register_arr_host(urlparse(self.url).hostname, "sonarr")
+            timings.registry.register_arr_host(self.url, "sonarr")
             self.api.respect_list_exclusions_when_adding()
             self.api._validate_add_options(params["root_folder_path"], params["quality_profile"], params["language_profile"])  # noqa
             self.profiles = self.api.quality_profile()

--- a/modules/timings.py
+++ b/modules/timings.py
@@ -14,6 +14,7 @@ Design:
 import csv
 import json
 import os
+import threading
 import time
 from collections import defaultdict
 from contextlib import contextmanager
@@ -98,10 +99,11 @@ def _looks_like_miss(result):
 
 class TimingRegistry:
     """Accumulates elapsed seconds/call counts/bytes into buckets keyed by
-    (library, collection, phase, source). No locks: Kometa is single-threaded."""
+    (library, collection, phase, source). record() is lock-guarded for feat/threading's workers>1 runs; the rest is still single-threaded-only."""
 
     def __init__(self):
         self.enabled = ENABLED
+        self._lock = threading.Lock()
         self.buckets = defaultdict(lambda: {"seconds": 0.0, "calls": 0, "bytes": 0})
         self.cache_hits = defaultdict(int)
         self.cache_misses = defaultdict(int)
@@ -132,19 +134,21 @@ class TimingRegistry:
             return
         if overlay is None:
             overlay = self.overlay_ctx
-        bucket = self.buckets[(library, collection, phase, source, overlay)]
-        bucket["seconds"] += seconds
-        bucket["calls"] += 1
-        bucket["bytes"] += num_bytes
+        with self._lock:
+            bucket = self.buckets[(library, collection, phase, source, overlay)]
+            bucket["seconds"] += seconds
+            bucket["calls"] += 1
+            bucket["bytes"] += num_bytes
 
     def record_cache(self, name, seconds, hit):
         if not self.enabled:
             return
-        self.cache_seconds[name] += seconds
-        if hit:
-            self.cache_hits[name] += 1
-        else:
-            self.cache_misses[name] += 1
+        with self._lock:
+            self.cache_seconds[name] += seconds
+            if hit:
+                self.cache_hits[name] += 1
+            else:
+                self.cache_misses[name] += 1
         self.record("cache", seconds, source=name)
 
     def banner(self):

--- a/modules/timings.py
+++ b/modules/timings.py
@@ -14,6 +14,7 @@ Design:
 import csv
 import json
 import os
+import re
 import threading
 import time
 from collections import defaultdict
@@ -28,6 +29,15 @@ logger = util.logger
 
 # Set by kometa.py from run_args["timings"] before any import-time reader of this flag runs; defaults False so a bare `import modules.timings` stays inert.
 ENABLED = False
+
+# One-off diagnostic, not a supported CLI flag - env-gated on purpose, for the plex-call-census research pass only.
+LOG_PLEX_REQUESTS = os.environ.get("KOMETA_LOG_PLEX_REQUESTS", "").strip().lower() in ("1", "true", "t")
+_TOKEN_PARAM_RE = re.compile(r"([?&])X-Plex-Token=[^&]*")
+
+
+def _redact_token(url):
+    return _TOKEN_PARAM_RE.sub(r"\1X-Plex-Token=REDACTED", url)
+
 
 # Hostname substring -> source tag, first match wins; unknown hosts fall back to "other:<hostname>" so new traffic is still visible.
 HOST_SOURCE_MAP = [
@@ -50,20 +60,38 @@ HOST_SOURCE_MAP = [
 ]
 
 
+def _netloc_key(value):
+    """Host[:port] lowercased, used to distinguish same-host different-port local services (e.g. Plex on
+    host.docker.internal:32400 vs Radarr on host.docker.internal:7878) - a bare-hostname comparison collapses
+    both to the same key and silently mistags arr traffic as plex when they share a Docker host address (found
+    2026-07-27 via the plex-call census). Accepts either a full URL or an already-bare host[:port] string, so
+    existing bare-hostname callers keep working - only the comparison itself needs the port, not every caller."""
+    if not value:
+        return ""
+    if "://" in value:
+        try:
+            parsed = urlparse(value)
+        except ValueError:
+            return ""
+        host = (parsed.hostname or "").lower()
+        if not host:
+            return ""
+        return f"{host}:{parsed.port}" if parsed.port else host
+    return value.lower()
+
+
 def hostname_to_source(url):
     """Map a request URL to a short source tag. Plex/Radarr/Sonarr hosts are user-configured and
     can't be recognised from the hostname alone, so those are looked up in the registry, populated
     once each service connects via registry.set_plex_hostname()/register_arr_host()."""
-    try:
-        host = (urlparse(url).hostname or "").lower()
-    except ValueError:
-        host = ""
-    if not host:
+    key = _netloc_key(url)
+    if not key:
         return "other:unknown"
-    if registry.plex_hostname and host == registry.plex_hostname:
+    host = key.split(":")[0]
+    if registry.plex_netloc and key == registry.plex_netloc:
         return "plex"
-    if host in registry.arr_hosts:
-        return registry.arr_hosts[host]
+    if key in registry.arr_hosts:
+        return registry.arr_hosts[key]
     for needle, source in HOST_SOURCE_MAP:
         if needle in host:
             return source
@@ -117,9 +145,37 @@ class TimingRegistry:
         self.library_ctx = None
         # Single-threaded call-scoped tag so every bucket can be split overlay-loop vs collection-loop work - set via overlay_context(), read in record()/timed()/instrument_session().
         self.overlay_ctx = None
-        # Populated once each service connects - see set_plex_hostname()/register_arr_host().
-        self.plex_hostname = None
+        # Populated once each service connects - see set_plex_hostname()/register_arr_host(). Keyed by host[:port], not bare host - see _netloc_key().
+        self.plex_netloc = None
         self.arr_hosts = {}
+        # Only opened when KOMETA_LOG_PLEX_REQUESTS is set - the one-off call-census research pass, not normal operation.
+        self._plex_request_log = None
+        self._plex_request_csv = None
+
+    def enable_plex_request_log(self, logs_dir):
+        if not LOG_PLEX_REQUESTS:
+            return
+        os.makedirs(logs_dir, exist_ok=True)
+        stamp = time.strftime("%Y%m%d-%H%M%S")
+        path = os.path.join(logs_dir, f"plex-request-census-{stamp}.csv")
+        self._plex_request_log = open(path, "w", newline="", encoding="utf-8")
+        self._plex_request_csv = csv.writer(self._plex_request_log)
+        self._plex_request_csv.writerow(["method", "path", "elapsed_ms", "source_tag", "library", "overlay"])
+        logger.info(f"KOMETA_LOG_PLEX_REQUESTS enabled - writing {path}")
+
+    def log_plex_request(self, method, url, elapsed, source_tag):
+        if self._plex_request_csv is None:
+            return
+        # library/overlay columns added 2026-07-27 so the census can subdivide the parallelizable-not-batchable
+        # pool by loop context (overlay-loop vs collection-loop, per library) to pick a phase-2 pilot target -
+        # same context_tag/library_ctx/overlay_ctx already recorded per-call in record(), just also logged here.
+        self._plex_request_csv.writerow([method, _redact_token(url), round(elapsed * 1000, 3), source_tag, self.library_ctx, self.overlay_ctx])
+
+    def close_plex_request_log(self):
+        if self._plex_request_log is not None:
+            self._plex_request_log.close()
+            self._plex_request_log = None
+            self._plex_request_csv = None
 
     def reset(self):
         # Re-stamps start_time and clears the four accumulator dicts so a persistent scheduler process's next run starts from zero instead of adding to every run since the container started.
@@ -132,13 +188,15 @@ class TimingRegistry:
             self.meta = {}
             self._banner_logged = False
 
-    def set_plex_hostname(self, hostname):
-        if hostname:
-            self.plex_hostname = hostname.lower()
+    def set_plex_hostname(self, url_or_hostname):
+        key = _netloc_key(url_or_hostname)
+        if key:
+            self.plex_netloc = key
 
-    def register_arr_host(self, hostname, source):
-        if hostname:
-            self.arr_hosts[hostname.lower()] = source
+    def register_arr_host(self, url_or_hostname, source):
+        key = _netloc_key(url_or_hostname)
+        if key:
+            self.arr_hosts[key] = source
 
     def record(self, phase, seconds, library=None, collection=None, source=None, num_bytes=0, overlay=None):
         if not self.enabled:
@@ -419,6 +477,8 @@ def instrument_session(session):
         except (ValueError, AttributeError):
             pass
         registry.record("network", elapsed, library=registry.library_ctx, source=source, num_bytes=num_bytes, overlay=registry.overlay_ctx)
+        if LOG_PLEX_REQUESTS and source.startswith("plex"):
+            registry.log_plex_request(method, url, elapsed, source)
         return response
 
     session.request = wrapped_request

--- a/modules/timings.py
+++ b/modules/timings.py
@@ -2,7 +2,7 @@
 
 Design:
 - A single process-wide TimingRegistry accumulates (library, collection, phase, source) -> seconds/calls/bytes.
-- Kometa is single-threaded (no `threading` usage anywhere in the codebase), so no locking is needed.
+- record()/record_cache() take a lock so concurrent worker threads (settings.threading) can't lose updates.
 - When KOMETA_TIMINGS is unset/false every entry point below is a guarded early return - near-zero overhead.
 - `track()` is a context manager for scoping an arbitrary block of code.
 - `timed()` is a decorator for scoping an entire method with minimal diff noise at call sites.
@@ -166,9 +166,7 @@ class TimingRegistry:
     def log_plex_request(self, method, url, elapsed, source_tag):
         if self._plex_request_csv is None:
             return
-        # library/overlay columns added 2026-07-27 so the census can subdivide the parallelizable-not-batchable
-        # pool by loop context (overlay-loop vs collection-loop, per library) to pick a phase-2 pilot target -
-        # same context_tag/library_ctx/overlay_ctx already recorded per-call in record(), just also logged here.
+        # library/overlay columns (added 2026-07-27) let the census subdivide the parallelizable-not-batchable pool by loop context to pick a phase-2 pilot target.
         self._plex_request_csv.writerow([method, _redact_token(url), round(elapsed * 1000, 3), source_tag, self.library_ctx, self.overlay_ctx])
 
     def close_plex_request_log(self):

--- a/modules/timings.py
+++ b/modules/timings.py
@@ -121,6 +121,17 @@ class TimingRegistry:
         self.plex_hostname = None
         self.arr_hosts = {}
 
+    def reset(self):
+        # Re-stamps start_time and clears the four accumulator dicts so a persistent scheduler process's next run starts from zero instead of adding to every run since the container started.
+        with self._lock:
+            self.start_time = time.perf_counter()
+            self.buckets = defaultdict(lambda: {"seconds": 0.0, "calls": 0, "bytes": 0})
+            self.cache_hits = defaultdict(int)
+            self.cache_misses = defaultdict(int)
+            self.cache_seconds = defaultdict(float)
+            self.meta = {}
+            self._banner_logged = False
+
     def set_plex_hostname(self, hostname):
         if hostname:
             self.plex_hostname = hostname.lower()

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1362,3 +1362,126 @@ class TestDispatchTables:
         assert "serializd_trending" in all_builders
         assert "serializd_popular" in all_builders
         assert "serializd_featured" in all_builders
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# _service_lock_key (Experiment C - per-service lock bucket classification)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestServiceLockKey:
+    @pytest.mark.parametrize(
+        "method, expected",
+        [
+            ("plex_all", "plex"),
+            ("plex_search", "plex"),
+            ("tautulli_popular", "tautulli"),
+            ("tracearr_watched", "tracearr"),
+            ("anidb_id", "anidb"),
+            ("anilist_id", "anilist"),
+            ("mal_id", "mal"),
+            ("tvdb_list", "tvdb"),
+            ("imdb_list", "imdb"),
+            ("icheckmovies_list", "icheckmovies"),
+            ("letterboxd_list", "letterboxd"),
+            ("stevenlu_popular", "stevenlu"),
+            ("mojo_yearly", "mojo"),
+            ("mdblist_list", "mdblist"),
+            ("simkl_list", "simkl"),
+            ("tmdb_discover", "tmdb"),
+            ("trakt_list", "trakt"),
+            ("yamtrack_list", "yamtrack"),
+            ("serializd_list", "serializd"),
+            ("floppy_tracked", "floppy"),
+            ("radarr_taglist", "radarr"),
+            ("sonarr_taglist", "sonarr"),
+        ],
+    )
+    def test_known_prefixes_map_to_expected_bucket(self, method, expected):
+        assert builder_module._service_lock_key(method) == expected
+
+    def test_textfile_builder_maps_to_textfile_bucket(self):
+        textfile_method = next(iter(builder_module.textfile.builders))
+        assert builder_module._service_lock_key(textfile_method) == "textfile"
+
+    def test_unrecognized_method_falls_into_other_not_bypassed(self):
+        """Unknown methods must still get a lock bucket ('other'), never bypass per-service locking entirely."""
+        assert builder_module._service_lock_key("some_never_seen_method") == "other"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# _resolve_remove_item_map (prefetch_collection_children deferral)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class FakeThreadPool:
+    def __init__(self):
+        self.submitted = []
+
+    def submit(self, fn, *args, **kwargs):
+        from concurrent.futures import Future
+
+        future = Future()
+        future.set_result(fn(*args, **kwargs))
+        self.submitted.append((fn, args, kwargs))
+        return future
+
+
+class TestResolveRemoveItemMap:
+    def _make(self, playlist, thread_pool, prefetch_enabled, items):
+        library = SimpleNamespace(get_collection_items=lambda obj, smart_label: items)
+        config = SimpleNamespace(thread_pool=thread_pool, general={"threading": {"prefetch_collection_children": prefetch_enabled}})
+        return make_builder(playlist=playlist, library=library, config=config, obj=SimpleNamespace(), smart_label_collection=False)
+
+    def test_toggle_off_returns_dict_directly_not_a_future(self):
+        """prefetch_collection_children:false must behave byte-identical to the pre-toggle code: eager dict, no Future."""
+        item = SimpleNamespace(ratingKey=1)
+        builder = self._make(playlist=False, thread_pool=FakeThreadPool(), prefetch_enabled=False, items=[item])
+        result = builder._resolve_remove_item_map()
+        assert result == {1: item}
+
+    def test_thread_pool_none_returns_dict_directly_even_if_toggle_on(self):
+        item = SimpleNamespace(ratingKey=1)
+        builder = self._make(playlist=False, thread_pool=None, prefetch_enabled=True, items=[item])
+        result = builder._resolve_remove_item_map()
+        assert result == {1: item}
+
+    def test_toggle_on_submits_to_thread_pool_for_sync_collections(self):
+        from concurrent.futures import Future
+
+        item = SimpleNamespace(ratingKey=1)
+        pool = FakeThreadPool()
+        builder = self._make(playlist=False, thread_pool=pool, prefetch_enabled=True, items=[item])
+        result = builder._resolve_remove_item_map()
+        assert isinstance(result, Future)
+        assert result.result() == {1: item}
+        assert len(pool.submitted) == 1
+
+    def test_playlists_always_fetch_eagerly_regardless_of_toggle(self):
+        """Playlists need len() immediately in __init__, so they must never be deferred to the thread_pool."""
+        item = SimpleNamespace(ratingKey=1)
+        pool = FakeThreadPool()
+        builder = self._make(playlist=True, thread_pool=pool, prefetch_enabled=True, items=[item])
+        result = builder._resolve_remove_item_map()
+        assert result == {1: item}
+        assert not pool.submitted
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# _collection_child_count (None childCount on blank/separator collections)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestCollectionChildCount:
+    def test_none_childcount_treated_as_zero(self):
+        """Plex returns None for childCount on genuinely-empty separator collections - must not raise/propagate None."""
+        obj = SimpleNamespace(childCount=None)
+        assert CollectionBuilder._collection_child_count(obj) == 0
+
+    def test_real_childcount_passes_through_unchanged(self):
+        obj = SimpleNamespace(childCount=7)
+        assert CollectionBuilder._collection_child_count(obj) == 7
+
+    def test_zero_childcount_stays_zero(self):
+        obj = SimpleNamespace(childCount=0)
+        assert CollectionBuilder._collection_child_count(obj) == 0

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -7,6 +7,7 @@ filtering, deletion, and method dispatching.
 
 from __future__ import annotations
 
+import contextlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -399,7 +400,7 @@ class TestFilterAndSaveItems:
         library.fetch_item.side_effect = lambda rating_key: items[rating_key]
         builder = make_builder(
             library=library,
-            config=SimpleNamespace(Cache=None),
+            config=SimpleNamespace(Cache=None, get_service_lock=lambda key: contextlib.nullcontext()),
             value_filters=[("mdb_tomatoes_rating", "gte", 6.0)],
             check_filters=MagicMock(side_effect=[False, True]),
         )
@@ -1002,7 +1003,7 @@ class TestGatherIds:
         tracearr.get_rating_keys.return_value = [(101, "ratingKey")]
         library = SimpleNamespace(Tracearr=tracearr)
         builder = make_builder(
-            config=SimpleNamespace(Cache=None),
+            config=SimpleNamespace(Cache=None, get_service_lock=lambda key: contextlib.nullcontext()),
             library=library,
             libraries=[library],
             playlist=False,
@@ -1023,7 +1024,7 @@ class TestGatherIds:
         show_library = SimpleNamespace(Tracearr=first_connector, PlexServer=first_server)
         libraries = [movie_library, show_library]
         builder = make_builder(
-            config=SimpleNamespace(Cache=None),
+            config=SimpleNamespace(Cache=None, get_service_lock=lambda key: contextlib.nullcontext()),
             library=movie_library,
             libraries=libraries,
             playlist=True,
@@ -1046,7 +1047,7 @@ class TestGatherIds:
             SimpleNamespace(Tracearr=second_connector, PlexServer=second_server),
         ]
         builder = make_builder(
-            config=SimpleNamespace(Cache=None),
+            config=SimpleNamespace(Cache=None, get_service_lock=lambda key: contextlib.nullcontext()),
             library=libraries[0],
             libraries=libraries,
             playlist=True,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
 from datetime import datetime, timedelta
 from types import SimpleNamespace
@@ -1105,6 +1106,49 @@ class TestConnectionReuse:
 # ═══════════════════════════════════════════════════════════════════════
 # SQL identifier validation
 # ═══════════════════════════════════════════════════════════════════════
+
+
+class TestLockedConnection:
+    """Experiment A1 - the RLock wrapper around the shared connection."""
+
+    @staticmethod
+    def _other_thread_can_acquire(cache) -> bool:
+        # RLock has no public .locked() - probe from a different thread instead, since RLock is only reentrant for its owning thread.
+        def try_acquire():
+            got = cache._lock.acquire(blocking=False)
+            if got:
+                cache._lock.release()
+            return got
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(try_acquire).result()
+
+    def test_lock_is_held_for_the_duration_of_a_transaction(self, tmp_path):
+        cache = make_cache(tmp_path)
+        assert self._other_thread_can_acquire(cache) is True
+        with cache.connection:
+            assert self._other_thread_can_acquire(cache) is False
+        assert self._other_thread_can_acquire(cache) is True
+
+    def test_nested_entry_from_same_thread_does_not_deadlock(self, tmp_path):
+        """RLock, not Lock - migrate_overlay_value_cache-style nesting must re-enter cleanly from the owning thread."""
+        cache = make_cache(tmp_path)
+        with cache.connection as outer:
+            with closing(outer.cursor()) as cursor:
+                cursor.execute("SELECT 1")
+                with cache.connection as inner:
+                    with closing(inner.cursor()) as inner_cursor:
+                        inner_cursor.execute("SELECT 2")
+        # Reaching here without a hang/exception is the assertion - a plain Lock would deadlock on the inner `with`.
+        assert self._other_thread_can_acquire(cache) is True
+
+    def test_underlying_connection_object_identity_is_stable(self, tmp_path):
+        """Same real sqlite3 connection every access, not a fresh wrapper - callers like set_trace_callback need this."""
+        cache = make_cache(tmp_path)
+        first = cache.connection
+        second = cache.connection
+        assert first is second
+        assert first._connection is second._connection
 
 
 class TestSqlIdentifierValidation:

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -1239,6 +1239,49 @@ class TestBatchEditTags:
         assert called_chunks == [shows, seasons]
 
 
+class TestRemoveSmartLabelForCollection:
+    def test_no_matching_plex_label_is_noop(self):
+        plex = make_plex()
+        plex.smart_label_check = MagicMock(return_value=False)
+        plex.search = MagicMock()
+        plex.batch_edit_tags = MagicMock()
+        collection = SimpleNamespace(title="Apple TV+")
+
+        result = plex.remove_smart_label_for_collection(collection)
+
+        assert result == 0
+        plex.search.assert_not_called()
+        plex.batch_edit_tags.assert_not_called()
+
+    def test_matching_label_but_no_labeled_items_is_noop(self):
+        plex = make_plex()
+        plex.smart_label_check = MagicMock(return_value=True)
+        plex.search = MagicMock(return_value=[])
+        plex.batch_edit_tags = MagicMock()
+        collection = SimpleNamespace(title="Apple TV+")
+
+        result = plex.remove_smart_label_for_collection(collection)
+
+        assert result == 0
+        plex.search.assert_called_once_with(label="Apple TV+")
+        plex.batch_edit_tags.assert_not_called()
+
+    def test_matching_label_batch_removes_from_labeled_items_only(self):
+        plex = make_plex()
+        plex.smart_label_check = MagicMock(return_value=True)
+        items = [make_plex_item(rating_key=i) for i in range(3)]
+        plex.search = MagicMock(return_value=items)
+        plex.batch_edit_tags = MagicMock()
+        collection = SimpleNamespace(title="Apple TV+")
+
+        result = plex.remove_smart_label_for_collection(collection)
+
+        assert result == 3
+        plex.smart_label_check.assert_called_once_with("Apple TV+")
+        plex.search.assert_called_once_with(label="Apple TV+")
+        plex.batch_edit_tags.assert_called_once_with(items, "label", remove_tags=["Apple TV+"])
+
+
 class TestBatchAddLabel:
     def test_noop_when_no_items(self):
         plex = make_plex()

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -1330,6 +1330,115 @@ class TestBatchEditField:
 
 
 # ═══════════════════════════════════════════════════════════════════════
+# bulk_reload (batch-prefetch via PMS's comma-separated /library/metadata/{ids})
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def make_batch_element(rating_key: int) -> MagicMock:
+    """A fake plexapi XML element as returned by PlexServer.query() for a batch metadata fetch."""
+    element = MagicMock()
+    element.attrib = {"ratingKey": str(rating_key)}
+    return element
+
+
+class TestBulkReload:
+    def test_ids_in_same_objects_out(self):
+        item1 = make_plex_item(rating_key=1, type="movie")
+        item2 = make_plex_item(rating_key=2, type="movie")
+        for item in (item1, item2):
+            item._buildDetailsKey = MagicMock(return_value="/library/metadata/1,2")
+        plex = make_plex()
+        plex.PlexServer.query = MagicMock(return_value=[make_batch_element(1), make_batch_element(2)])
+        plex.item_reload = MagicMock()
+
+        plex.bulk_reload([item1, item2])
+
+        assert plex.cached_items[1] == (item1, True)
+        assert plex.cached_items[2] == (item2, True)
+        item1._invalidateCacheAndLoadData.assert_called_once()
+        item2._invalidateCacheAndLoadData.assert_called_once()
+        plex.item_reload.assert_not_called()
+
+    def test_missing_ratingkey_falls_back_to_single_item_reload(self):
+        """A dropped/invalid ratingKey in the batch response must still get reloaded, not silently skipped."""
+        item1 = make_plex_item(rating_key=1, type="movie")
+        item2 = make_plex_item(rating_key=2, type="movie")
+        for item in (item1, item2):
+            item._buildDetailsKey = MagicMock(return_value="/library/metadata/1,2")
+        plex = make_plex()
+        plex.PlexServer.query = MagicMock(return_value=[make_batch_element(1)])
+        plex.item_reload = MagicMock(side_effect=lambda i: i)
+
+        plex.bulk_reload([item1, item2])
+
+        plex.item_reload.assert_called_once_with(item2)
+        assert plex.cached_items[1] == (item1, True)
+        assert plex.cached_items[2] == (item2, True)
+
+    def test_whole_chunk_http_failure_falls_back_for_every_item(self):
+        item1 = make_plex_item(rating_key=1, type="movie")
+        item1._buildDetailsKey = MagicMock(return_value="/library/metadata/1")
+        plex = make_plex()
+        plex.PlexServer.query = MagicMock(side_effect=BadRequest("boom"))
+        plex.item_reload = MagicMock(side_effect=lambda i: i)
+
+        plex.bulk_reload([item1])
+
+        plex.item_reload.assert_called_once_with(item1)
+        assert plex.cached_items[1] == (item1, True)
+
+    def test_skips_items_already_fully_cached_when_not_forced(self):
+        item1 = make_plex_item(rating_key=1, type="movie")
+        plex = make_plex(cached_items={1: (item1, True)})
+        plex.PlexServer.query = MagicMock()
+
+        plex.bulk_reload([item1])
+
+        plex.PlexServer.query.assert_not_called()
+
+    def test_force_refetches_even_if_already_cached(self):
+        item1 = make_plex_item(rating_key=1, type="movie")
+        item1._buildDetailsKey = MagicMock(return_value="/library/metadata/1")
+        plex = make_plex(cached_items={1: (item1, True)})
+        plex.PlexServer.query = MagicMock(return_value=[make_batch_element(1)])
+
+        plex.bulk_reload([item1], force=True)
+
+        plex.PlexServer.query.assert_called_once()
+
+    def test_empty_items_is_a_noop(self):
+        plex = make_plex()
+        plex.PlexServer.query = MagicMock()
+
+        plex.bulk_reload([])
+
+        plex.PlexServer.query.assert_not_called()
+
+    def test_mixed_types_are_batched_in_separate_requests(self):
+        movie = make_plex_item(rating_key=1, type="movie")
+        show = make_plex_item(rating_key=2, type="show")
+        movie._buildDetailsKey = MagicMock(return_value="/library/metadata/1")
+        show._buildDetailsKey = MagicMock(return_value="/library/metadata/2")
+        plex = make_plex()
+        plex.PlexServer.query = MagicMock(side_effect=[[make_batch_element(1)], [make_batch_element(2)]])
+
+        plex.bulk_reload([movie, show])
+
+        assert plex.PlexServer.query.call_count == 2
+
+    def test_reloaded_item_clears_stale_filter_attr_cache(self):
+        item1 = make_plex_item(rating_key=1, type="movie")
+        item1._buildDetailsKey = MagicMock(return_value="/library/metadata/1")
+        plex = make_plex(filter_attr_cache={(1, "genres"): ["stale"], (2, "genres"): ["untouched"]})
+        plex.PlexServer.query = MagicMock(return_value=[make_batch_element(1)])
+
+        plex.bulk_reload([item1])
+
+        assert (1, "genres") not in plex.filter_attr_cache
+        assert (2, "genres") in plex.filter_attr_cache
+
+
+# ═══════════════════════════════════════════════════════════════════════
 # Edge cases
 # ═══════════════════════════════════════════════════════════════════════
 

--- a/tests/test_timings.py
+++ b/tests/test_timings.py
@@ -105,6 +105,32 @@ def test_timed_decorator_is_noop_when_disabled(disabled_registry):
     assert len(disabled_registry.buckets) == 0
 
 
+def test_reset_clears_accumulator_state_and_restamps_start_time(enabled_registry):
+    enabled_registry.record("gather_ids", 1.5, library="Movies", collection="Marvel", source="tmdb")
+    enabled_registry.record_cache("query_thing", 0.2, hit=True)
+    enabled_registry.set_meta(kometa_version="2.4.4-build57")
+    enabled_registry._banner_logged = True
+    old_start_time = enabled_registry.start_time
+    time.sleep(0.01)
+
+    enabled_registry.reset()
+
+    assert enabled_registry.buckets == {}
+    assert enabled_registry.cache_hits == {}
+    assert enabled_registry.cache_misses == {}
+    assert enabled_registry.cache_seconds == {}
+    assert enabled_registry.meta == {}
+    assert enabled_registry._banner_logged is False
+    assert enabled_registry.start_time > old_start_time
+
+
+def test_reset_scopes_total_wall_time_to_the_run_since_reset(enabled_registry):
+    time.sleep(0.02)
+    enabled_registry.reset()
+    elapsed = enabled_registry.total_wall_time()
+    assert elapsed < 0.02
+
+
 # ═══════════════════════════════════════════════════════════════════════
 # Cache hit/miss wrapping
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_timings.py
+++ b/tests/test_timings.py
@@ -293,10 +293,29 @@ def test_overlay_context_tags_network_calls_via_instrument_session(enabled_regis
 
 
 def test_hostname_to_source_recognises_registered_plex_and_arr_hosts(enabled_registry):
-    enabled_registry.set_plex_hostname("plex.example.com")
-    enabled_registry.register_arr_host("radarr.example.com", "radarr")
+    enabled_registry.set_plex_hostname("http://plex.example.com:32400")
+    enabled_registry.register_arr_host("http://radarr.example.com:7878", "radarr")
     assert hostname_to_source("http://plex.example.com:32400/library") == "plex"
     assert hostname_to_source("http://radarr.example.com:7878/api") == "radarr"
+
+
+def test_hostname_to_source_distinguishes_same_host_different_ports(enabled_registry):
+    """Regression test for the mistagging bug found via the 2026-07-27 plex-call census: Radarr/Sonarr sharing
+    a Docker host address with Plex (e.g. host.docker.internal on different ports) must not collapse to the
+    same source tag just because the bare hostname matches."""
+    enabled_registry.set_plex_hostname("http://host.docker.internal:32400")
+    enabled_registry.register_arr_host("http://host.docker.internal:7878", "radarr")
+    enabled_registry.register_arr_host("http://host.docker.internal:8989", "sonarr")
+    assert hostname_to_source("http://host.docker.internal:32400/library/metadata/123") == "plex"
+    assert hostname_to_source("http://host.docker.internal:7878/api/v3/qualityProfile") == "radarr"
+    assert hostname_to_source("http://host.docker.internal:8989/api/v3/qualityProfile") == "sonarr"
+
+
+def test_hostname_to_source_still_accepts_bare_hostname_registration(enabled_registry):
+    """set_plex_hostname()/register_arr_host() must keep accepting a bare host[:port] string, not just a full
+    URL, so any caller that already extracted a hostname (rather than passing self.url) still works."""
+    enabled_registry.set_plex_hostname("plex.example.com")
+    assert hostname_to_source("http://plex.example.com/library") == "plex"
 
 
 # ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Adds a shared `ThreadPoolExecutor` and a `settings.threading` config block (`workers`,
`prefetch_collection_children`, plus the experimental `tmdb_pages`/`parallel_sources`), then uses it for
the two changes that actually paid for themselves in measurement, plus three unrelated correctness bugs
found along the way via this project's own request-census tooling.

Builds on #3383 (batched Plex writes, in-run
caching), which has already merged into `nightly`. This PR is rebased directly onto current `nightly` -
the diff here is just this branch's own commits.

**What's on by default now:**
- `workers: 4` (was effectively unthreaded) and `prefetch_collection_children: true` - the cache is now
  RLock-guarded (`_LockedConnection`) so concurrent worker threads can share one SQLite connection
  safely; a collection's `sync_collection` "what to remove" lookup and PMS's comma-separated
  `/library/metadata/{ids}` batch-read are both deferred to the thread pool instead of blocking the main
  loop.
- Three independent correctness fixes: a bare `self.obj` truthy check that silently triggered a full
  Plex `items()` fetch through `Collection`/`Playlist.__len__` on any falsy-looking-but-real collection;
  a `childCount` `None` follow-on that surfaced once the above stopped masking it; and
  `get_item_display_title()` unconditionally fetching a parent's `titleSort` even when the caller didn't
  ask for sorted output.

**What's built but off by default** (measured, not stripped, in case the calculus changes on a bigger
library): concurrent `gather_ids` with per-service locks (`parallel_sources`, structurally ~0% gain -
none of the measured baseline's builder groups actually mix services within one collection). A separate
cross-collection pipelining experiment (`pipeline_depth`) was also tried and measured 1.8-4% *slower*
from GIL contention between background response parsing and main-thread Plex work - that one was
dropped from this branch entirely rather than kept behind a toggle, since it added real rebase/maintenance
surface for a change that never won.

**Why `workers: 4`/`prefetch_collection_children: true` as defaults, not just opt-in:** both only touch
work that was already safe to parallelize - a read-only Plex lookup and a shared cache connection now
guarded by an RLock - not the collection-building logic itself, so the risk profile is "more concurrent
I/O," not "different results." Zero Plex/network call-count regression across every A/B in this branch's
history (churn-loop and victory-lap alike), and the full test suite (1339 tests) passes unchanged. The
one real tradeoff is more simultaneous outbound requests, called out below.

## Gains measured

Full victory-lap run (5-pair A/B, standard test libraries, 10%-churn) put this branch's tip **41.3%
faster than stock nightly** (347.9s vs 592.5s mean) - the cumulative effect of everything above measured
together against a real feature-complete config, not summed from individual bake-offs. That number is
from the pre-rebase branch tip; this branch has since been rebased onto current `nightly` to pick up
everything merged since then (including this PR's own base, #3383), and hasn't had a fresh A/B pass
post-rebase yet. Treat 41.3% as the demonstrated order of magnitude, not a number to cite verbatim for
current `nightly` - happy to re-run the victory-lap comparison during review if that's useful.

## What users need to know

- Zero-config behavior changes: a config with no `settings.threading` block now runs with `workers: 4`
  and `prefetch_collection_children: true` instead of the old inert defaults. Anyone who already sets
  these explicitly is unaffected.
- More concurrent worker threads means more simultaneous outbound requests (Plex, TMDb, Trakt, etc.) at
  once - worth knowing if a library's Plex server or an external service is rate-limit-sensitive.
  `workers` is user-configurable if that matters for a given setup.
- `parallel_sources`/`tmdb_pages` stay off and undocumented for now - bake-off-measured as not worth it
  at steady state, kept behind their toggles rather than deleted.

## Testing

Full `pytest` suite: 1339 passed. `black`/`isort`/`flake8` clean. `pyright` baseline check passes with a
net improvement (8 -> 5 errors; two unrelated pre-existing gaps fixed along the way - see commit history
for detail). Churn-loop A/B methodology and full commit-by-commit history detail:
`threading-experiment-plan.md` in the "Kometa issues and Dev" project (not part of this repo).

## Related Issues [optional]

- Builds on [[perf: batch Plex writes and add in-run caching to reduce redundant API/network calls (part 2) #3383](https://github.com/Kometa-Team/Kometa/pull/3383)](https://github.com/Kometa-Team/Kometa/pull/3383) (merged), which itself built on [perf: add `--timings`/`KOMETA_TIMINGS` Runtime Flag for Timing Instrumentation (part 1) #3382](https://github.com/Kometa-Team/Kometa/pull/3382) (merged).
- Three of this branch's commits (`self.obj`, `childCount`, `titleSort` fixes) are independent
  correctness bugs, not threading-specific - candidates for their own small PRs if reviewers would
  rather land those separately from the threading work.

## Have you updated the Documentation to reflect changes (if necessary)?

- [x] Yes
- [ ] No
- [ ] Not Applicable

Added a `threading` attribute block to `docs/config/settings.md` (documenting `workers` and
`prefetch_collection_children`; the experimental sub-attributes are intentionally left undocumented in
prose, matching their off-by-default/unsupported status) and a commented-out example in
`config/config.yml.template`.

## Have you updated the JSON Schema files (if necessary)?

- [x] Yes
- [ ] No
- [ ] Not Applicable

`settings.threading` added to `json-schema/config-schema.json`, including the undocumented experimental
sub-attributes (typed but undescribed) so users who do set them still get valid schema validation instead
of an `additionalProperties` error.

## Have you updated the CHANGELOG.md?

- [x] Yes
- [ ] No