### PR TITLE
fix: detached-HEAD push failure and shell injection risk in PR automation workflows

### DIFF
--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -80,10 +80,12 @@ jobs:
 
       - name: Update VERSION File
         id: update-version
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
-            branch_name="${{ github.event.pull_request.head.ref }}"
+            branch_name="${GITHUB_HEAD_REF}"
             branch_name=$(echo "${branch_name}" | sed 's/[^a-zA-Z0-9._-]/-/g')
-            repo_name=${{ github.event.pull_request.head.repo.full_name }}
+            repo_name="${HEAD_REPO}"
             base_name="${repo_name%/*}"
             if [[ "${branch_name}" =~ ^(master|develop|nightly)$ ]]; then
                 pr_tag="${base_name}"

--- a/.github/workflows/tag-cleanup.yml
+++ b/.github/workflows/tag-cleanup.yml
@@ -13,10 +13,12 @@ jobs:
 
       - name: Get Tag Name
         id: get-tag-name
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
-          branch_name="${{ github.event.pull_request.head.ref }}"
+          branch_name="${GITHUB_HEAD_REF}"
           branch_name=$(echo "${branch_name}" | sed 's/[^a-zA-Z0-9._-]/-/g')
-          repo_name=${{ github.event.pull_request.head.repo.full_name }}
+          repo_name="${HEAD_REPO}"
           base_name="${repo_name%/*}"
           if [[ "${branch_name}" =~ ^(master|develop|nightly)$ ]]; then
               tag_name="${base_name}"

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -16,11 +16,14 @@ jobs:
     steps:
 
       - name: Display Refs
+        env:
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
-          echo "Base Repo: ${{ github.event.pull_request.base.repo.full_name }}"
+          echo "Base Repo: ${BASE_REPO}"
           echo "Base Ref: ${{ github.base_ref }}"
-          echo "Head Repo: ${{ github.event.pull_request.head.repo.full_name }}"
-          echo "Head Ref: ${{ github.event.pull_request.head.ref }}"
+          echo "Head Repo: ${HEAD_REPO}"
+          echo "Head Ref: ${GITHUB_HEAD_REF}"
 
       - name: Check Base Branch
         if: github.base_ref == 'master' || github.base_ref == 'develop'
@@ -113,44 +116,47 @@ jobs:
 
       - name: Update VERSION File
         id: update-version
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
-            branch_name="${{ github.event.pull_request.head.ref }}"
+            branch_name="${GITHUB_HEAD_REF}"
             branch_name=$(echo "${branch_name}" | sed 's/[^a-zA-Z0-9._-]/-/g')
-            repo_name=${{ github.event.pull_request.head.repo.full_name }}
+            repo_name="${HEAD_REPO}"
             base_name="${repo_name%/*}"
-            if [[ "${branch_name}" =~ ^(master|develop|nightly)$ ]]; then 
+            if [[ "${branch_name}" =~ ^(master|develop|nightly)$ ]]; then
                 tag_name="${base_name}"
             else
                 tag_name="${branch_name}"
             fi
             echo "tag-name=${tag_name}" >> $GITHUB_OUTPUT
-          
+
             if [[ "${base_name}" == "Kometa-Team" ]]; then
                 extra=""
             else
-                extra=" from the ${{ github.event.pull_request.head.repo.full_name }} repo"
+                extra=" from the ${HEAD_REPO} repo"
             fi
             echo "extra-text=${extra}" >> $GITHUB_OUTPUT
-            
+
             value=$(cat VERSION)
             old_msg=$(git log -1 HEAD --pretty=format:%s)
             echo "commit-msg=${old_msg}" >> $GITHUB_OUTPUT
-          
+
             part=$(cat PART)
             if [ -n "$part" ]; then
                 new_value="$((${part} + 1))"
             else
                 new_value="1"
             fi
-      
+
             echo "part_value=${new_value}" >> $GITHUB_OUTPUT
-      
+
             echo "$new_value" > "PART"
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
             git add PART
             git commit -m "${tag_name} Part: ${new_value}"
-            git push
+            # HEAD is detached because checkout uses the immutable PR head SHA.
+            git push origin "HEAD:refs/heads/${GITHUB_HEAD_REF}"
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Fixes the CI failure hit when PR #3435 was promoted to internal PR #3448. `docker-build-pull` in `validate-pull.yml` checks out the PR at an exact commit SHA (detached HEAD by design, to pin the build to an immutable commit), then commits a `PART` bump and runs a bare `git push`, which requires being on a branch. Result: `fatal: You are not currently on a branch`. Fixed by pushing explicitly to the PR branch instead: `git push origin "HEAD:refs/heads/${GITHUB_HEAD_REF}"`. This keeps the SHA-pinned checkout intact and fails safely (non-fast-forward) if the branch moved during the job, rather than force-pushing over it.

While tracing that, found the same underlying pattern in two other workflows: `${{ github.event.pull_request.head.ref }}` and `${{ github.event.pull_request.head.repo.full_name }}` were interpolated directly into `run:` shell scripts instead of being passed through `env:`. This is a known GitHub Actions script injection pattern: the `${{ }}` substitution happens before the shell parses the script, so a crafted branch name (git allows characters like backticks, `$()`, quotes in ref names) can break out of the string and inject arbitrary shell commands. Fixed by mapping these values through `env:` and referencing them as quoted variables, using the built-in `GITHUB_HEAD_REF` where GitHub already provides it.

Files changed:
- `validate-pull.yml`: fixes the `git push` failure, plus the same injection pattern in `branch_name`, `repo_name`, `extra-text`, and the `Display Refs` step.
- `increment-build.yml`: same injection pattern in `branch_name`/`repo_name`. Runs on `pull_request_target` after a merge to nightly, with the GitHub App token and `PAT2` in scope at that point.
- `tag-cleanup.yml`: same pattern. Highest exposure of the three, since it runs on `pull_request_target` for `closed`/`unlabeled` on any PR including forks, with Docker Hub credentials in scope, and does not require a merge or write access to trigger.
- `promote-fork-pr.yml` needed no changes. It already passes all untrusted values through `env:`/`process.env` rather than direct interpolation.

Tested by reasoning through the fix with a maintainer (Yozora) before opening this. Could not execute the workflows locally since they depend on repo secrets and live PR events; this needs a real PR run to confirm the push path succeeds.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [ ] Yes
- [X] No