### PR TITLE
Fix Trakt list sync handling of successful 2xx responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Accept all successful Trakt API responses so `sync_to_trakt_list` handles the `201 Created` returned when adding list items instead of marking the collection build as failed. #3453
 - Add `pyinstrument` to `requirements.txt` (it was only in `dev-requirements.txt`), so `KOMETA_PROFILE=pyinstrument` actually works in a normal/Docker install instead of silently no-opping.
 
 ### Changed

--- a/modules/trakt.py
+++ b/modules/trakt.py
@@ -242,11 +242,13 @@ class Trakt:
                     raise Failed(f"({response.status_code}) {response.reason}")
             elif response.status_code == 404 and ignore_404:
                 return None
-            elif response.status_code != 200:
+            elif not 200 <= response.status_code < 300:
                 logger.debug(f"Trakt response issue: ({response.status_code}) {response.reason}")
                 raise Failed(f"({response.status_code}) {response.reason}")
             else:
                 reauth_count = 0
+                if response.status_code == 204 or not response.content:
+                    return output_json
                 response_json = response.json()
                 logger.trace(f"Headers: {response.headers}")
                 logger.trace(f"Response: {response_json}")

--- a/tests/test_trakt.py
+++ b/tests/test_trakt.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 import modules.builder  # noqa: F401
+import modules.trakt as trakt_module
+from modules.trakt import Trakt, base_url
 from modules.util import Failed
 
 
@@ -89,3 +92,47 @@ class TestTraktAuthorization:
 
         assert adapter._refresh() is False
         mock_trakt_logger.debug.assert_called_once_with("Trakt Error: Access Token Refresh Failed: (403) Forbidden")
+
+
+class TestTraktRequest:
+    @pytest.fixture(autouse=True)
+    def mock_trakt_logger(self, monkeypatch):
+        monkeypatch.setattr(trakt_module, "logger", MagicMock())
+
+    @staticmethod
+    def adapter(response):
+        trakt = Trakt.__new__(Trakt)
+        trakt.requests = MagicMock()
+        trakt.requests.post.return_value = response
+        trakt.authorization = {"access_token": "token"}
+        trakt.client_id = "client-id"
+        return trakt
+
+    def test_request_accepts_created_response(self):
+        payload = {"added": {"movies": 1}, "not_found": {"movies": []}}
+        response = SimpleNamespace(status_code=201, reason="Created", headers={}, content=b"{}", json=MagicMock(return_value=payload))
+        trakt = self.adapter(response)
+
+        result = trakt._request("/users/me/lists/example/items", json_data={"movies": [{"ids": {"tmdb": 1}}]})
+
+        assert result == payload
+        response.json.assert_called_once_with()
+        trakt.requests.post.assert_called_once_with(
+            f"{base_url}/users/me/lists/example/items",
+            json={"movies": [{"ids": {"tmdb": 1}}]},
+            headers={"Content-Type": "application/json", "Authorization": "Bearer token", "trakt-api-version": "2", "trakt-api-key": "client-id"},
+        )
+
+    def test_request_accepts_no_content_response(self):
+        response = SimpleNamespace(status_code=204, reason="No Content", headers={}, content=b"", json=MagicMock())
+        trakt = self.adapter(response)
+
+        assert trakt._request("/users/me/lists/example/items", json_data={}) == []
+        response.json.assert_not_called()
+
+    def test_request_rejects_non_success_response(self):
+        response = SimpleNamespace(status_code=300, reason="Multiple Choices", headers={}, content=b"", json=MagicMock())
+        trakt = self.adapter(response)
+
+        with pytest.raises(Failed, match=r"\(300\) Multiple Choices"):
+            trakt._request("/users/me/lists/example/items", json_data={})


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix
- [ ] Feature/Tweak
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Chore
- [ ] Other

## Description

Updates `Trakt._request()` to accept the full successful HTTP `2xx` range instead of accepting only `200 OK`.

Trakt returns `201 Created` when `sync_to_trakt_list` adds items. Kometa previously raised `Failed` for that successful response, marked the collection build as failed, and stopped before processing the response or completing the removal leg of the sync.

The request handler now:

- accepts every `2xx` success response, including `201 Created`
- parses successful response bodies as before, allowing `sync_list()` to report additions and `not_found` items
- returns safely for `204 No Content` and other successful empty-body responses
- continues rejecting non-success responses

Regression tests cover `201 Created`, empty `204 No Content`, and a non-success `300` response.

Validation:

- `python -m pytest -q`: **1,083 passed**
- Black, isort, and flake8: passed
- `git diff --check`: passed
- pyspelling could not start locally because the `aspell` executable is not installed

## Related Issues [optional]

- Closes #3453

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [x] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [x] Not Applicable

## Have you updated the CHANGELOG.md?

- [x] Yes
- [ ] No
