### PR TITLE
fix: docker-build-pull self-trigger loop from the PAT-authenticated version-bump push

### DIFF
--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -154,7 +154,8 @@ jobs:
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
             git add PART
-            git commit -m "${tag_name} Part: ${new_value}"
+            # [skip ci] prevents this PAT-authenticated push from re-triggering this same job via synchronize.
+            git commit -m "${tag_name} Part: ${new_value} [skip ci]"
             # HEAD is detached because checkout uses the immutable PR head SHA.
             git push origin "HEAD:refs/heads/${GITHUB_HEAD_REF}"
 


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Follow-up to the detached-HEAD push fix in `validate-pull.yml`. That fix made the version-bump push succeed, but since it's authenticated with `secrets.PAT` (not the loop-guarded `GITHUB_TOKEN`), each successful push re-triggered `synchronize` on the same PR, which re-ran `docker-build-pull`, which pushed again, looping. Seen live on PR #3456: five bump commits before a maintainer broke it by removing the `docker` label. Fix: append `[skip ci]` to the version-bump commit message so its own `synchronize` event doesn't re-trigger the job.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [ ] Yes
- [X] No