### PR TITLE
Fix serializd installation failure

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
  && apt-get update \
  && apt-get upgrade -y --no-install-recommends \
  && apt-get install -y tzdata --no-install-recommends \
- && apt-get install -y gcc g++ libffi-dev libxml2-dev libxslt-dev libz-dev libjpeg62-turbo-dev zlib1g-dev wget curl nano \
+ && apt-get install -y gcc g++ git libffi-dev libxml2-dev libxslt-dev libz-dev libjpeg62-turbo-dev zlib1g-dev wget curl nano \
  && runtime_libffi="$(dpkg-query -W -f='${binary:Package}\n' 'libffi[0-9]*' | awk '!/-dev$/ { print; exit }')" \
  && if [ -n "$runtime_libffi" ]; then apt-mark manual "$runtime_libffi"; fi \
  && wget -O /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-"$(dpkg --print-architecture | awk -F- '{ print $NF }')" \


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Adds `git` to the Docker base image’s build dependencies. This allows pip to install the Git-pinned `serializd-py` requirement during the base-image build.

## Related Issues [optional]

- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [ ] Yes
- [ ] No