### PR TITLE
Docker builds wait for matching base image

### DIFF
--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -1,11 +1,6 @@
 name: Docker Base Image Build
 
 on:
-  push:
-    branches: [ nightly ]
-    paths:
-      - requirements.txt
-      - Dockerfile.base
   schedule:
     - cron: "0 5 * * 0"  # weekly on Sunday 5am UTC
   workflow_dispatch:

--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -16,6 +16,7 @@ jobs:
     if: github.base_ref == 'nightly' && github.event.pull_request.merged
     outputs:
       build: ${{ steps.list-changes.outputs.build }}
+      base: ${{ steps.list-changes.outputs.base }}
     steps:
 
       - name: Check Out Repo
@@ -38,6 +39,10 @@ jobs:
                     echo "build=true" >> $GITHUB_OUTPUT
                 else
                     echo "$file will not trigger docker build"
+                fi
+                if [[ $file == "requirements.txt" || $file == "Dockerfile.base" ]]; then
+                    echo "$file will trigger docker base build"
+                    echo "base=true" >> $GITHUB_OUTPUT
                 fi
             done
 
@@ -133,10 +138,54 @@ jobs:
             git push origin nightly
             echo "bump-commit-hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-  docker-build-nightly:
+  docker-build-base:
     runs-on: ubuntu-latest
     needs: [ increment-build, verify-changes ]
-    if: needs.verify-changes.outputs.build == 'true'
+    if: needs.verify-changes.outputs.base == 'true'
+    steps:
+
+      - name: Check Out Repo
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.increment-build.outputs.bump-commit-hash }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4.5.2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.20.0
+
+      - name: Build and Push Base Image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./
+          file: ./Dockerfile.base
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:base
+            ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:base-${{ needs.increment-build.outputs.bump-commit-hash }}
+          cache-from: type=registry,ref=${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:buildcache-base
+          cache-to: type=registry,ref=${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:buildcache-base,mode=max
+
+  docker-build-nightly:
+    runs-on: ubuntu-latest
+    needs: [ increment-build, verify-changes, docker-build-base ]
+    if: >-
+      always() &&
+      needs.verify-changes.outputs.build == 'true' &&
+      (needs.docker-build-base.result == 'success' || needs.docker-build-base.result == 'skipped')
     steps:
 
       # Checks out the bump commit itself (has both the merged code and new VERSION/PART), not a mutable nightly ref -- closes the race with later pushes.
@@ -171,6 +220,7 @@ jobs:
           file: ./Dockerfile
           build-args: |
             "BRANCH_NAME=nightly"
+            "BASE_TAG=${{ needs.verify-changes.outputs.base == 'true' && format('base-{0}', needs.increment-build.outputs.bump-commit-hash) || 'base' }}"
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:nightly
@@ -205,7 +255,7 @@ jobs:
 
   commit-notification:
     runs-on: ubuntu-latest
-    needs: [ increment-build, verify-changes, docker-build-nightly ]
+    needs: [ increment-build, verify-changes, docker-build-base, docker-build-nightly ]
     if: ${{ success() && needs.verify-changes.outputs.build == 'true' }}
     steps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `serializd` as a direct rating source for show and episode-level Ratings Defaults overlays.
 
 ### Fixed
-
+- Make nightly Docker builds wait for, and use, the matching base image after dependency changes.
 - Accept all successful Trakt API responses so `sync_to_trakt_list` handles the `201 Created` returned when adding list items instead of marking the collection build as failed. #3453
 - Add `pyinstrument` to `requirements.txt` (it was only in `dev-requirements.txt`), so `KOMETA_PROFILE=pyinstrument` actually works in a normal/Docker install instead of silently no-opping.
 


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Ensures a nightly Docker image cannot be published before a required base-image rebuild completes.

When `requirements.txt` or `Dockerfile.base` changes, the nightly workflow now builds and publishes a commit-specific `base-<commit-sha>` image, waits for it to succeed, and builds nightly from that exact image. Source-only changes continue using the regular `base` tag without rebuilding it.

Validated the modified GitHub Actions YAML and ran `git diff --check`.

## Related Issues [optional]

- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No