### PR TITLE
Fix secret redaction in error webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `serializd` as a direct rating source for show and episode-level Ratings Defaults overlays.
 
 ### Fixed
+- Redact registered secrets from critical-error webhook messages before sending them to Discord, Slack, Notifiarr, or other webhook destinations. #3472
 - Make nightly Docker builds wait for, and use, the matching base image after dependency changes.
 - Accept all successful Trakt API responses so `sync_to_trakt_list` handles the `201 Created` returned when adding list items instead of marking the collection build as failed. #3453
 - Add `pyinstrument` to `requirements.txt` (it was only in `dev-requirements.txt`), so `KOMETA_PROFILE=pyinstrument` actually works in a normal/Docker install instead of silently no-opping.

--- a/modules/config.py
+++ b/modules/config.py
@@ -2591,7 +2591,7 @@ class ConfigFile:
     def notify(self, text, server=None, library=None, collection=None, playlist=None, critical=True):
         for error in util.get_list(text, split=False, return_none=False) or []:
             try:
-                self.Webhooks.error_hooks(error, server=server, library=library, collection=collection, playlist=playlist, critical=critical)
+                self.Webhooks.error_hooks(logger.redact(error), server=server, library=library, collection=collection, playlist=playlist, critical=critical)
             except Failed as e:
                 logger.stacktrace()
                 logger.error(f"Webhooks Error: {e}")

--- a/modules/logs.py
+++ b/modules/logs.py
@@ -312,6 +312,17 @@ class MyLogger:
             if variant not in self.secrets:
                 self.secrets.append(variant)
 
+    def redact(self, text):
+        text = str(text)
+        for secret in self.secrets:
+            if secret in text:
+                text = text.replace(secret, "(redacted)")
+        if "HTTPConnectionPool" in text:
+            text = re.sub("HTTPConnectionPool\\((.*?)\\)", "HTTPConnectionPool(redacted)", text)
+        if "HTTPSConnectionPool" in text:
+            text = re.sub("HTTPSConnectionPool\\((.*?)\\)", "HTTPSConnectionPool(redacted)", text)
+        return text
+
     def _log(self, level, msg, args, exc_info=None, extra=None, stack_info=False, stacklevel=1):
         trace = level == TRACE
         log_only = False
@@ -328,13 +339,7 @@ class MyLogger:
                     self._formatter(log_only=True, space=True)
             log_only = True
         else:
-            for secret in self.secrets:
-                if secret in msg:
-                    msg = msg.replace(secret, "(redacted)")
-            if "HTTPConnectionPool" in msg:
-                msg = re.sub("HTTPConnectionPool\\((.*?)\\)", "HTTPConnectionPool(redacted)", msg)
-            if "HTTPSConnectionPool" in msg:
-                msg = re.sub("HTTPSConnectionPool\\((.*?)\\)", "HTTPSConnectionPool(redacted)", msg)
+            msg = self.redact(msg)
             try:
                 if not _srcfile:
                     raise ValueError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,12 @@ class FakeLogger:
         if text and str(text) not in self.secrets:
             self.secrets.append(str(text))
 
+    def redact(self, text: Any) -> str:
+        text = str(text)
+        for secret in self.secrets:
+            text = text.replace(secret, "(redacted)")
+        return text
+
     def clear_errors(self) -> None:
         self.saved_errors = []
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -484,6 +484,12 @@ class TestNotify:
         cf.notify("Something went wrong")
         cf.Webhooks.error_hooks.assert_called_once()
 
+    def test_notify_redacts_secrets_before_calling_error_webhooks(self, tmp_path):
+        cf = make_config(tmp_path)
+        config_module.logger.secret("fake-plex-token")
+        cf.notify("Upload failed: http://localhost:32400/posters?X-Plex-Token=fake-plex-token")
+        assert cf.Webhooks.error_hooks.call_args.args[0] == "Upload failed: http://localhost:32400/posters?X-Plex-Token=(redacted)"
+
     def test_notify_delete_calls_webhooks_delete_hooks(self, tmp_path):
         cf = make_config(tmp_path)
         cf.notify_delete("Collection deleted")

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -72,6 +72,11 @@ class TestSecretRedaction:
         logger.secret("abc123")
         assert logger.secrets.count("abc123") == 1
 
+    def test_redact_replaces_raw_and_url_encoded_secrets(self, logger):
+        logger.secret("my token+key")
+        text = "raw=my token+key encoded=my%20token%2Bkey query=my+token%2Bkey"
+        assert logger.redact(text) == "raw=(redacted) encoded=(redacted) query=(redacted)"
+
 
 class TestTracebackSuppression:
     def test_known_not_found_error_is_suppressed(self, capsys):


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Error notifications were sent to configured webhooks with their original exception text, bypassing the secret redaction already applied to log output. This change exposes the logger redaction logic as a reusable method and sanitizes each error before passing it to Discord, Slack, Notifiarr, or another webhook destination. Regression coverage verifies both raw and URL-encoded secrets.

Validation completed:

- `black --check modules/logs.py modules/config.py tests/conftest.py tests/test_logs.py tests/test_config.py`
- `python3 -m compileall -q modules/logs.py modules/config.py tests/conftest.py tests/test_logs.py tests/test_config.py`
- Direct redaction assertion for raw and URL-encoded values
- `git diff --check`

The focused pytest suite could not collect locally because runtime dependencies (`arrapi` and `num2words`) are not installed in this checkout.

## Related Issues [optional]

- Related Issue #3472
- Closes #3472

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [x] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [x] Not Applicable

## Have you updated the CHANGELOG.md?

- [x] Yes
- [ ] No
