### PR TITLE
Fix Tracearr documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Make nightly Docker builds wait for, and use, the matching base image after dependency changes.
-- Complete the Tracearr documentation by adding its Defaults, connector, and builder sidebar entries; restore the annotated Defaults example; place all Tracearr list controls in the file-specific template-variable table; document authentication requirements, `list_minimum`, and the v2-to-v1 history API fallback; include Tracearr in the configuration template; and validate its optional `server_id` and Public API key in the correct JSON Schema definition.
 - Accept all successful Trakt API responses so `sync_to_trakt_list` handles the `201 Created` returned when adding list items instead of marking the collection build as failed. #3453
 - Add `pyinstrument` to `requirements.txt` (it was only in `dev-requirements.txt`), so `KOMETA_PROFILE=pyinstrument` actually works in a normal/Docker install instead of silently no-opping.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Make nightly Docker builds wait for, and use, the matching base image after dependency changes.
+- Complete the Tracearr documentation by adding its Defaults, connector, and builder sidebar entries; restore the annotated Defaults example; place all Tracearr list controls in the file-specific template-variable table; document authentication requirements, `list_minimum`, and the v2-to-v1 history API fallback; and include Tracearr in the configuration template.
 - Accept all successful Trakt API responses so `sync_to_trakt_list` handles the `201 Created` returned when adding list items instead of marking the collection build as failed. #3453
 - Add `pyinstrument` to `requirements.txt` (it was only in `dev-requirements.txt`), so `KOMETA_PROFILE=pyinstrument` actually works in a normal/Docker install instead of silently no-opping.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Make nightly Docker builds wait for, and use, the matching base image after dependency changes.
-- Complete the Tracearr documentation by adding its Defaults, connector, and builder sidebar entries; restore the annotated Defaults example; place all Tracearr list controls in the file-specific template-variable table; document authentication requirements, `list_minimum`, and the v2-to-v1 history API fallback; and include Tracearr in the configuration template.
+- Complete the Tracearr documentation by adding its Defaults, connector, and builder sidebar entries; restore the annotated Defaults example; place all Tracearr list controls in the file-specific template-variable table; document authentication requirements, `list_minimum`, and the v2-to-v1 history API fallback; include Tracearr in the configuration template; and validate its optional `server_id` and Public API key in the correct JSON Schema definition.
 - Accept all successful Trakt API responses so `sync_to_trakt_list` handles the `201 Created` returned when adding list items instead of marking the collection build as failed. #3453
 - Add `pyinstrument` to `requirements.txt` (it was only in `dev-requirements.txt`), so `KOMETA_PROFILE=pyinstrument` actually works in a normal/Docker install instead of silently no-opping.
 

--- a/config/config.yml.template
+++ b/config/config.yml.template
@@ -109,6 +109,10 @@ webhooks:                          # Can be individually specified per library a
 tautulli:                          # Can be individually specified per library as well
   url: http://192.168.1.12:8181    # Enter Tautulli URL (Optional)
   apikey:                          # Enter Tautulli API Key (Optional)
+tracearr:                          # Can be individually specified per library as well
+  url: http://192.168.1.12:3019    # Enter Tracearr URL (Optional)
+  apikey:                          # Enter Tracearr Public API Key (Optional)
+  server_id:                       # Enter Tracearr Plex Server UUID when automatic matching is ambiguous (Optional)
 github:
   token:                           # Enter GitHub Personal Access Token (Optional)
 omdb:

--- a/docs/defaults/chart/tracearr.md
+++ b/docs/defaults/chart/tracearr.md
@@ -23,24 +23,33 @@ hide:
 
 {% include-markdown "./../../templates/snippets/white_style.md" replace='{"CODE_NAME": "tracearr"}' %}
 {% include-markdown "./../../templates/defaults/base/mid.md" replace='{"CODE_NAME": "tracearr"}' include-tags='all|movie|show' %}
+    ```yaml
+    libraries:
+      Movies:
+        collection_files:
+          - default: tracearr
+            template_variables:
+              use_rewatched: false #(1)!
+              list_days_popular: 7 #(2)!
+              list_size_popular: 10 #(3)!
+              visible_library_popular: true #(4)!
+              visible_home_popular: true #(5)!
+              visible_shared_popular: true #(6)!
+    ```
 
-## Template Variables
-
-Tracearr collections share the same base settings, and each collection can be customized individually by using the matching key suffix.
-
-| Variable | Description |
-|:---------|:------------|
-| `list_days_<<key>>` | Number of days to look back in Tracearr history for the matching collection key. Default: `30`; `list_days_trending` defaults to `7`. |
-| `list_size_<<key>>` | Maximum number of items to include in the matching collection. Default: `20` |
-
-The `<<key>>` suffix matches the collection key from the table above, such as `popular`, `watched`, `trending`, `rewatched`, `completed`, `binged`, or `transcoded`.
+    1. Do not create the "Tracearr Rewatched" collection
+    2. Change "Tracearr Popular" to look at items from the past 7 days
+    3. Change "Tracearr Popular" to have a maximum of 10 items
+    4. Pin the "Tracearr Popular" collection to the Recommended tab of the library
+    5. Pin the "Tracearr Popular" collection to the home screen of the server owner
+    6. Pin the "Tracearr Popular" collection to the home screen of other users of the server
 
 {% include-markdown "./../../templates/defaults/base/collection/variables_header.md" exclude-tags="separator" %}
     {%
         include-markdown "./../../templates/variable_list.md"
-        include-tags="white-style|limit|sync_mode|collection_order"
+        include-tags="tracearr|white-style|sync_mode|collection_order"
         rewrite-relative-urls=false
-        replace='{"<!--limit-extra-->": "<br>**Default:** `100`", "COLLECTION_ORDER": "`custom`"}'
+        replace='{"COLLECTION_ORDER": "`custom`"}'
     %}
 
     {% include-markdown "./../../templates/variable_list.md" include-tags="sup1" rewrite-relative-urls=false %}

--- a/docs/files/builders/tracearr/history.md
+++ b/docs/files/builders/tracearr/history.md
@@ -4,7 +4,7 @@ hide:
 ---
 # Tracearr History
 
-The Tracearr builders below all derive from the `/api/v1/public/history` endpoint and use its pagination and filtering support.
+The Tracearr builders below use the Public API history endpoints and their pagination and filtering support. Kometa prefers `/api/v2/public/history` and automatically falls back to `/api/v1/public/history` when v2 is unavailable.
 
 | Builder | Description |
 |:--------|:------------|

--- a/docs/overrides/partials/tooltips.html
+++ b/docs/overrides/partials/tooltips.html
@@ -182,6 +182,10 @@
 </div>
 
 <div id="tippy-collection-list-2" style="display:none;">
+    Requires <a href="../../../config/tracearr">Tracearr Authentication</a>
+</div>
+
+<div id="tippy-collection-list-3" style="display:none;">
     Requires <a href="../../../config/trakt">Trakt Authentication</a>
 </div>
 
@@ -193,7 +197,6 @@
 <div id="tippy-operations-2" style="display:none;">
     Kometa checks for the <code>Overlay</code> label on the item in Plex to determine if an Overlay is applied.
 </div>
-
 
 
 

--- a/docs/templates/snippets/collection_list.md
+++ b/docs/templates/snippets/collection_list.md
@@ -37,9 +37,9 @@ These collections are applied by calling the below paths into the `collection_fi
     | [Letterboxd Charts](../../chart/letterboxd)                                                                                   | `letterboxd`      | Letterboxd Top 250, Top 250 Most Fans      | `Movies`            |
     | [MyAnimeList Charts](../../chart/myanimelist)                                                                                 | `myanimelist`     | MyAnimeList Popular, MyAnimeList Top Rated | `Movies`<br>`Shows` |
     | [Tautulli Charts](../../chart/tautulli) :material-numeric-1-circle:{ data-tooltip data-tooltip-id="tippy-collection-list-1" } | `tautulli`        | Plex Popular, Plex Watched                 | `Movies`<br>`Shows` |
-    | [Tracearr Charts](../../chart/tracearr)                                                                                       | `tracearr`        | Plex History                               | `Movies`<br>`Shows` |
+    | [Tracearr Charts](../../chart/tracearr) :material-numeric-2-circle:{ data-tooltip data-tooltip-id="tippy-collection-list-2" } | `tracearr`        | Tracearr Popular, Tracearr Watched         | `Movies`<br>`Shows` |
     | [TMDb Charts](../../chart/tmdb)                                                                                               | `tmdb`            | TMDb Popular, TMDb Airing Today            | `Movies`<br>`Shows` |
-    | [Trakt Charts](../../chart/trakt) :material-numeric-2-circle:{ data-tooltip data-tooltip-id="tippy-collection-list-2" }       | `trakt`           | Trakt Popular, Trakt Trending              | `Movies`<br>`Shows` |
+    | [Trakt Charts](../../chart/trakt) :material-numeric-3-circle:{ data-tooltip data-tooltip-id="tippy-collection-list-3" }       | `trakt`           | Trakt Popular, Trakt Trending              | `Movies`<br>`Shows` |
     | [Other Charts](../../chart/other)                                                                                             | `other_chart`     | AniDB Popular, Common Sense Selection      | `Movies`<br>`Shows` |
 
 === "Content"

--- a/docs/templates/variable_list.md
+++ b/docs/templates/variable_list.md
@@ -230,6 +230,14 @@
 | `list_size`                     | **Description:** Changes the `list_size` attribute of the Builder for all collections in a Defaults File.<br>**Values:** Number greater than 0         |
 | `list_size_<<key>>` :material-numeric-1-circle:{ data-tooltip data-tooltip-id="tippy-defaults-key" } | **Description:** Changes the `list_size` attribute of the Builder of the [key's](#collection_section) collection.<br>**Values:** Number greater than 0 |
 <!--tautulli-->
+<!--tracearr-->
+| `list_days` | **Description:** Changes how many days of Tracearr history are used for all collections in the Defaults File.<br>**Default:** `30`<br>**Values:** Number greater than 0 |
+| `list_days_<<key>>` :material-numeric-1-circle:{ data-tooltip data-tooltip-id="tippy-defaults-key" } | **Description:** Changes how many days of Tracearr history are used for the [key's](#collection_section) collection.<br>**Default:** `30`; `list_days_trending` defaults to `7`<br>**Values:** Number greater than 0 |
+| `list_minimum` | **Description:** Changes the minimum activity count required for all collections in the Defaults File.<br>**Default:** `0`<br>**Values:** Number 0 or greater |
+| `list_minimum_<<key>>` :material-numeric-1-circle:{ data-tooltip data-tooltip-id="tippy-defaults-key" } | **Description:** Changes the minimum activity count required for the [key's](#collection_section) collection.<br>**Default:** `0`<br>**Values:** Number 0 or greater |
+| `list_size` | **Description:** Changes the maximum number of items in all collections in the Defaults File.<br>**Default:** `20`<br>**Values:** Number greater than 0 |
+| `list_size_<<key>>` :material-numeric-1-circle:{ data-tooltip data-tooltip-id="tippy-defaults-key" } | **Description:** Changes the maximum number of items in the [key's](#collection_section) collection.<br>**Default:** `20`<br>**Values:** Number greater than 0 |
+<!--tracearr-->
 <!--universe-->
 | `name_mapping_<<key>>` :material-numeric-1-circle:{ data-tooltip data-tooltip-id="tippy-defaults-key" }     | **Description:** Sets the name mapping value for using assets of the [key's](#collection_section) collection. <br>**Values:** Any String                                                                                        |
 | `minimum_items`                        | **Description:** Controls the minimum items that the collection must have to be created.<br>**Default:** `2`<br>**Values:** Any number                                                                                          |

--- a/json-schema/config-schema.json
+++ b/json-schema/config-schema.json
@@ -930,19 +930,7 @@
         "apikey": {
           "anyOf": [
             {
-              "type": "string",
-              "pattern": "^trr_pub_.+"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "server_id": {
-          "anyOf": [
-            {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             },
             {
               "type": "null"
@@ -972,7 +960,19 @@
         "apikey": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "string",
+              "pattern": "^trr_pub_.+"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "server_id": {
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uuid"
             },
             {
               "type": "null"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -179,6 +179,7 @@ nav:
       - TMDb: config/tmdb.md
     - OPTIONAL CONNECTIONS:
       - Tautulli: config/tautulli.md
+      - Tracearr: config/tracearr.md
       - Github: config/github.md
       - OMDb: config/omdb.md
       - MDBList: config/mdblist.md
@@ -235,6 +236,7 @@ nav:
       - Simkl Charts: defaults/chart/simkl.md
       - Tautulli Charts: defaults/chart/tautulli.md
       - TMDb Charts: defaults/chart/tmdb.md
+      - Tracearr Charts: defaults/chart/tracearr.md
       - Trakt Charts: defaults/chart/trakt.md
       - Other Charts: defaults/chart/other.md
     - Content:
@@ -386,6 +388,9 @@ nav:
         - Overview: files/builders/tautulli/overview.md
         - Popular: files/builders/tautulli/popular.md
         - Watched: files/builders/tautulli/watched.md
+      - Tracearr:
+        - Overview: files/builders/tracearr/overview.md
+        - History: files/builders/tracearr/history.md
       - Radarr:
         - Overview: files/builders/radarr/overview.md
         - All: files/builders/radarr/all.md


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [x] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Completes the Tracearr documentation and corrects its connector schema after the Tracearr integration landed on nightly.

Changes include:

- Register Tracearr in the Defaults, connector, and builder sidebars.
- Add the annotated Defaults template-variable example and authentication tooltip.
- Move Tracearr list controls into the file-specific template-variable table and document global/per-key list_days, list_minimum, and list_size values.
- Document the preferred v2 history API with automatic v1 fallback.
- Add Tracearr to the shipped configuration template and update the changelog.
- Restore the Tautulli API-key schema while validating the Tracearr trr_pub_ API-key prefix and optional UUID server_id under tracearr-api.

Validation performed:

- git diff --check passed.
- Changed YAML and JSON files parse successfully.
- Navigation targets and tooltip references were verified.
- Positive and negative Tracearr/Tautulli schema cases passed for root and per-library references.
- Full pytest collection was unavailable locally because arrapi and num2words are not installed in this environment.

## Related Issues [optional]

None.

## Have you updated the Documentation to reflect changes (if necessary)?

- [x] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [x] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the CHANGELOG.md?

- [x] Yes
- [ ] No
