### PR TITLE
Fix overlay reapplication after mass poster updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `serializd` as a direct rating source for show and episode-level Ratings Defaults overlays.
 
 ### Fixed
+- Refresh an item's in-run Plex state after `mass_poster_update` removes its `Overlay` label, ensuring the following overlay pass detects the reset poster and reapplies its overlays instead of incorrectly skipping it.
 - Redact registered secrets from critical-error webhook messages before sending them to Discord, Slack, Notifiarr, or other webhook destinations. #3472
 - Make nightly Docker builds wait for, and use, the matching base image after dependency changes.
 - Accept all successful Trakt API responses so `sync_to_trakt_list` handles the `201 Created` returned when adding list items instead of marking the collection build as failed. #3453

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -2077,8 +2077,6 @@ class Plex(Library):
                     logger.info(f"{text} | Reset from {location}")
                 if poster and "Overlay" in [la.tag for la in self.item_labels(item)]:
                     logger.info(self.edit_tags("label", item, remove_tags="Overlay", do_print=False))
-                    # The Overlay label was just changed on Plex. Do not let the overlay phase reuse
-                    # this run's pre-reset item, or it will incorrectly think the overlay is still present.
                     self.cached_items.pop(item.ratingKey, None)
                     for key in [k for k in self.filter_attr_cache if k[0] == item.ratingKey]:
                         del self.filter_attr_cache[key]

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -2077,6 +2077,11 @@ class Plex(Library):
                     logger.info(f"{text} | Reset from {location}")
                 if poster and "Overlay" in [la.tag for la in self.item_labels(item)]:
                     logger.info(self.edit_tags("label", item, remove_tags="Overlay", do_print=False))
+                    # The Overlay label was just changed on Plex. Do not let the overlay phase reuse
+                    # this run's pre-reset item, or it will incorrectly think the overlay is still present.
+                    self.cached_items.pop(item.ratingKey, None)
+                    for key in [k for k in self.filter_attr_cache if k[0] == item.ratingKey]:
+                        del self.filter_attr_cache[key]
                 return "Reset", source, "Updated" if updated else "Failed"
             else:
                 logger.warning(f"{text} | No Reset Image Found")

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -122,6 +122,24 @@ class TestImageUpdate:
 
         assert result == ("Reset", "Assets", "Updated")
 
+    def test_poster_reset_removing_overlay_invalidates_item_cache(self):
+        item = make_plex_item(rating_key=42)
+        plex = make_plex(
+            mass_poster_update={"source": "tmdb", "language": None},
+            cached_items={42: (item, True)},
+            filter_attr_cache={(42, "labels"): ["Overlay"], (7, "labels"): ["Keep"]},
+        )
+        plex.upload_poster = MagicMock()
+        plex.item_labels = MagicMock(return_value=[SimpleNamespace(tag="Overlay")])
+        plex.edit_tags = MagicMock(return_value="Label | -Overlay")
+
+        result = plex.image_update(item, None, tmdb=("tmdb", "https://image.tmdb.org/poster.jpg"))
+
+        assert result == ("Reset", "TMDb", "Updated")
+        plex.edit_tags.assert_called_once_with("label", item, remove_tags="Overlay", do_print=False)
+        assert plex.cached_items == {}
+        assert plex.filter_attr_cache == {(7, "labels"): ["Keep"]}
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # validate_image_size


### PR DESCRIPTION
## Description

Fixes an issue where `mass_poster_update` could reset an overlaid poster, remove the `Overlay` label, and then cause the following overlay phase to incorrectly skip reapplying overlays.

After removing the label, Kometa now invalidates the affected item’s in-run Plex cache. The overlay phase then reloads the current Plex item state, detects the missing label, and reapplies the configured overlays in the same run.

## Changes

- Invalidate the affected in-memory item and filter-attribute cache after a poster reset removes `Overlay`.
- Add regression coverage for the cache invalidation behavior.
- Add an Unreleased changelog entry.

## Testing

- `uv run pytest tests/test_plex.py`
  - 126 passed

## Related issue

Fixes the alternating overlay/reset behavior when `mass_poster_update` runs before overlays.