### PR TITLE
fix: don't fail CI jobs when the fork-PR status comment can't be posted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,13 +209,19 @@ jobs:
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
 
-            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 });
-            const existing = comments.find(c => c.user?.type === "Bot" && c.body?.includes(marker));
+            // Fork PRs get a read-only GITHUB_TOKEN no matter what permissions: this job declares, so
+            // comment writes 403 there. Log and move on instead of failing the whole build job over a comment.
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 });
+              const existing = comments.find(c => c.user?.type === "Bot" && c.body?.includes(marker));
 
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              }
+            } catch (err) {
+              core.warning(`Could not post/update status comment (likely a fork PR with a read-only token): ${err.message}`);
             }
 
   label-status:
@@ -244,13 +250,18 @@ jobs:
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
 
-            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 });
-            const existing = comments.find(c => c.user?.type === "Bot" && c.body?.includes(marker));
+            // Same fork-token limitation as docker-build's comment step -- swallow the 403 instead of failing the job.
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 });
+              const existing = comments.find(c => c.user?.type === "Bot" && c.body?.includes(marker));
 
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              }
+            } catch (err) {
+              core.warning(`Could not post/update status comment (likely a fork PR with a read-only token): ${err.message}`);
             }
 
   notify-testers:


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

`GITHUB_TOKEN` is capped to read-only for `pull_request`-triggered workflows on fork PRs, regardless of the `permissions:` a job declares. The `label-status` job and `docker-build`'s status-comment step both try to create/update a PR comment via `github.rest.issues.createComment`/`updateComment`, which 403s on fork PRs and fails the whole job -- even though the actual build/test/pyright results were fine.

This wraps both comment-posting blocks in try/catch. On failure it logs a `core.warning` with the likely cause and lets the job continue, instead of failing CI over a comment that was never going to be postable. Confirmed against PR #3477 (fork PR from @antwanchild ), whose `label-status` job was failing with `Resource not accessible by integration` on the comment-create call.

No behaviour change for same-repo PRs, where the token already has write access and comments are posted as before.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [ ] Yes
- [X] No (backend only work)