### PR TITLE
Fix IMDb awards year range selection for unordered ceremonies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `serializd` as a direct rating source for show and episode-level Ratings Defaults overlays.
 
 ### Fixed
+- Sort IMDb award years and multi-edition year values before resolving `starting`/`ending` ranges, so out-of-order repository entries do not cause `latest` ranges to include the wrong years.
 - Refresh an item's in-run Plex state after `mass_poster_update` removes its `Overlay` label, ensuring the following overlay pass detects the reset poster and reapplies its overlays instead of incorrectly skipping it.
 - Redact registered secrets from critical-error webhook messages before sending them to Discord, Slack, Notifiarr, or other webhook destinations. #3472
 - Make nightly Docker builds wait for, and use, the matching base image after dependency changes.

--- a/modules/meta.py
+++ b/modules/meta.py
@@ -1074,7 +1074,10 @@ class MetadataFile(DataFile):
                             if event_id not in self.config.IMDb.git_events_validation:
                                 raise Failed(f"Config Error: {map_name} data only specific Event IDs work with imdb_awards. Event Options: [{', '.join([k for k in self.config.IMDb.git_events_validation])}]")
                             _, event_years = self.config.IMDb.get_event_years(event_id)
-                            year_options = [event_years[len(event_years) - i] for i in range(1, len(event_years) + 1)]
+                            year_options = sorted(
+                                event_years,
+                                key=lambda year: tuple(int(part) for part in str(year).split("-")),
+                            )
 
                             def get_position(attr):
                                 if attr not in award_methods:


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Chore
- [ ] Other

## Description

Fix IMDb awards year-range selection when the awards repository contains
out-of-order years or multiple editions in the same year.

For example, `latest-5` now correctly selects 2026–2021 for Cannes instead of
including the non-awarded 1968 edition. Multi-edition years such as `2026-1`
and `2026-2` are sorted numerically and remain distinct.

## Related Issues [optional]

- Related Issue #
- Closes #3482 

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788617357&installation_model_id=431096&pr_number=3484&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3484&signature=b23d48a32b04d2946264e37eca5d501a0a99b93dace620b414cabcd5b70a8939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->