### PR TITLE
fix: lock image fields after reset so ignore_locked stops the reset loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make nightly Docker builds wait for, and use, the matching base image after dependency changes.
 - Accept all successful Trakt API responses so `sync_to_trakt_list` handles the `201 Created` returned when adding list items instead of marking the collection build as failed. #3453
 - Add `pyinstrument` to `requirements.txt` (it was only in `dev-requirements.txt`), so `KOMETA_PROFILE=pyinstrument` actually works in a normal/Docker install instead of silently no-opping.
+- Lock the poster, background, logo, and square art fields after resetting them from a source, so subsequent runs with `ignore_locked: true` skip re-resetting instead of looping forever. #3487
 
 ### Changed
 - Document Trakt's free connected-app limitation and identify which Trakt builders and account features require OAuth/VIP access versus public API access.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make nightly Docker builds wait for, and use, the matching base image after dependency changes.
 - Accept all successful Trakt API responses so `sync_to_trakt_list` handles the `201 Created` returned when adding list items instead of marking the collection build as failed. #3453
 - Add `pyinstrument` to `requirements.txt` (it was only in `dev-requirements.txt`), so `KOMETA_PROFILE=pyinstrument` actually works in a normal/Docker install instead of silently no-opping.
-- Lock the poster, background, logo, and square art fields after resetting them from a source, so subsequent runs with `ignore_locked: true` skip re-resetting instead of looping forever. #3487
+- Lock the poster, background, logo, and square art fields after resetting them from a source, and check the logo's actual Plex field name (`clearLogo`, not `logo`), so subsequent runs with `ignore_locked: true` skip re-resetting instead of looping forever. #3487
 
 ### Changed
 - Document Trakt's free connected-app limitation and identify which Trakt builders and account features require OAuth/VIP access versus public API access.

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -1208,7 +1208,7 @@ class Operations:
                     if self.library.mass_logo_update:
                         source = self.library.mass_logo_update["source"]
                         ignore_locked = self.library.mass_logo_update["ignore_locked"]
-                        logo_locked = _field_locked("logo")
+                        logo_locked = _field_locked("clearLogo")  # Plex's Field name for the logo is "clearLogo", not "logo" - matches lockLogo()/unlockLogo()'s clearLogo.locked
                         resolved_source, logo_url = _get_external_image(self.library.mass_logo_update, is_poster=False, image_type="logo")
                         if (source in ["unlock", "lock"] and len(_image_sources(self.library.mass_logo_update)) == 1) or not (ignore_locked and logo_locked):
                             result = self.library.logo_update(item, new_logo, tmdb=(resolved_source, logo_url))

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -2075,6 +2075,9 @@ class Plex(Library):
                         updated = False
                 if updated:
                     logger.info(f"{text} | Reset from {location}")
+                    lock_method = {"poster": "lockPoster", "background": "lockArt", "logo": "lockLogo", "square_art": "lockSquareArt"}[image_type]  # lock the field so it isn't reset again next run
+                    if hasattr(item, lock_method):
+                        self.query(getattr(item, lock_method))
                 if poster and "Overlay" in [la.tag for la in self.item_labels(item)]:
                     logger.info(self.edit_tags("label", item, remove_tags="Overlay", do_print=False))
                     self.cached_items.pop(item.ratingKey, None)


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

`mass_metadata_update`'s poster, background, logo, and square art resets never locked the field afterward, so `ignore_locked: true` never saw anything as locked and kept re-resetting the same items every run.

Two fixes:
- `plex.py`: lock the field right after a successful reset, reusing the existing `lockPoster`/`lockArt`/`lockLogo`/`lockSquareArt` mapping.
- `operations.py`: the logo lock check read the wrong Plex field name (`logo` instead of `clearLogo`), so even with the lock call in place, `ignore_locked` still never detected it for logo specifically.

Tested with an A/B script against a live Plex library: two consecutive runs per side, counting reset log lines. Stock `nightly` reset all 825 test items on both run 1 and run 2 (the loop). The fix reset all 825 on run 1, then 0 on run 2.

## Related Issues [optional]

- Closes #3487

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [X] No
- [ ] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788770496&installation_model_id=431096&pr_number=3488&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3488&signature=bd7478b7a82868738d3386bcaa26c15e9b39631e4ae1ff4e491dde7bcbe49ee9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->