### PR TITLE
Improve dependency validation and startup messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
 - Added a fallback Trakt Client ID for "public" mode if the current Trakt credentials are invalid
 - Add a Floppy connector with `floppy_list`, `floppy_list_details` and `floppy_tracked` builders, optional API-token authentication for private lists, and `sync_tags` support for applying Floppy list tags as Plex item labels.
 - Add Floppy as a movie, show, and episode mass-rating source for Plex audience, critic, or user rating fields.
@@ -32,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lock the poster, background, logo, and square art fields after resetting them from a source, and check the logo's actual Plex field name (`clearLogo`, not `logo`), so subsequent runs with `ignore_locked: true` skip re-resetting instead of looping forever. #3487
 
 ### Changed
-
 - Document Trakt's free connected-app limitation and identify which Trakt builders and account features require OAuth/VIP access versus public API access.
 - Migrate Trakt authentication documentation and shipped configuration examples from the legacy PIN/OAuth callback flow to Device Code Flow, including headless-server guidance and the optional `webhooks.trakt_pin` notification.
 - Batch Plex writes that were previously one API call per item: label/genre sync, `item_critic`/`audience`/`user_rating` updates, and title-parentheses removal now merge into shared `saveMultiEdits()`/`batchMultiEdits()` calls (respecting `plex_bulk_edit_batch_size`) instead of one `edit_tags()`/`editField()`/`editTitle()` call per item; label/genre and rating writes for the same item are further merged into a single PUT instead of one per attribute type, grouped by library and media type so mixed-library/mixed-type playlists route through the correct Plex connection. The overlay `Overlay` label add is batched the same way, flushing every `plex_bulk_edit_batch_size` items instead of only once at the very end of the run.
@@ -41,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `modules/request.py`: read-only file/URL YAML loads (that are never saved back) now use ruamel's safe loader, skipping comment/formatting-preservation bookkeeping that was pure overhead for these loads.
 - Dedupe forced Plex reloads for tag filters checked back-to-back in `check_filters`; snapshot the overlay backup folder once per run instead of calling `os.path.exists()` per item; buffer log file writes instead of flushing after every line (`WARNING` and above still flush immediately, and handler removal/close force a final flush so the file is always complete); early-exit `check_for_var`'s variable-resolution loop once a pass makes no substitutions, and skip its redundant second pass when no arithmetic `<<var+N>>` syntax is present.
 - Improve `audio_language`/`subtitle_language` `plex_search` matching (including the default `languages.yml` flag overlays) to recognize every locale- or region-tagged variant of a language that actually exists in the library (e.g. `es-419`, `en-US`, `spa`) instead of only an exact 2-letter match. A single `es`/`it`/`zh` filter now matches every variant Plex reports for that language, resolved with one lightweight, cached lookup of the library's language filter choices rather than a separate Plex query per variant.
+- Improved startup dependency validation to report missing requirements clearly and identify installed packages that do not satisfy `requirements.txt`.
 
 ## [v2.4.6] - 2026-07-30
 

--- a/kometa.py
+++ b/kometa.py
@@ -113,7 +113,7 @@ def check_requirements(logger):
             outdated.append(f"{requirement.name} {installed} (requires {requirement.specifier})")
 
     if outdated:
-        logger.info("    Requirements are out of date:")
+        logger.warning("    Requirements are out of date. Please follow the documentation for instructions on installing requirements.")
         for requirement in outdated:
             logger.info(f"      {requirement}")
 

--- a/kometa.py
+++ b/kometa.py
@@ -1,5 +1,6 @@
 import argparse
 import hashlib
+from importlib.metadata import PackageNotFoundError, version as installed_version
 import os
 import platform
 import re
@@ -11,9 +12,6 @@ from collections import Counter
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from typing import TypeAlias
-
-from packaging.requirements import InvalidRequirement, Requirement
-from packaging.version import parse
 
 from modules.logs import MyLogger
 
@@ -40,9 +38,17 @@ if sys.version_info[0] != 3 or sys.version_info[1] < 10:
     sys.exit(0)
 
 try:
+    import apprise
     import arrapi
+    import cloudscraper
     import dateutil
+    import git
+    import jsonschema
+    import langcodes
+    import letterboxdpy
     import lxml
+    import num2words
+    import packaging
     import pathvalidate
     import PIL
     import plexapi
@@ -51,12 +57,18 @@ try:
     import requests
     import ruamel.yaml
     import schedule
+    import serializd
     import setuptools
+    import tenacity
     import tmdbapis
     from dotenv import load_dotenv
     from dotenv import version as dotenv_version
     from PIL import ImageFile
+    from packaging.requirements import InvalidRequirement, Requirement
+    from packaging.version import parse
     from plexapi.exceptions import BadRequest, NotFound
+    if sys.platform == "win32":
+        import win32api
 except (ModuleNotFoundError, ImportError) as ie:
     print(f"Requirements Error: Requirements are not installed.\nPlease follow the documentation for instructions on installing requirements. ({ie})")
     sys.exit(0)
@@ -80,6 +92,30 @@ system_versions = {
     "tenacity": None,
     "tmdbapis": tmdbapis.__version__,
 }
+
+
+def check_requirements(logger):
+    requirements_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "requirements.txt")
+    try:
+        with open(requirements_path, "r") as file:
+            requirements = [Requirement(line.strip()) for line in file if line.strip() and not line.startswith("#")]
+    except FileNotFoundError:
+        logger.error("    File Error: requirements.txt not found")
+        return
+
+    outdated = []
+    for requirement in requirements:
+        try:
+            installed = parse(installed_version(requirement.name))
+        except PackageNotFoundError:
+            continue
+        if installed not in requirement.specifier:
+            outdated.append(f"{requirement.name} {installed} (requires {requirement.specifier})")
+
+    if outdated:
+        logger.info("    Requirements are out of date:")
+        for requirement in outdated:
+            logger.info(f"      {requirement}")
 
 LibraryRunStatus: TypeAlias = dict[str, dict[str, str]]
 
@@ -491,39 +527,7 @@ def start(attrs):
         logger.info(f"    Process Priority: {'low' if run_args['low-priority'] else 'normal'}")
 
         if not is_docker and not is_linuxserver:
-            try:
-                with open(os.path.abspath(os.path.join(os.path.dirname(__file__), "requirements.txt")), "r") as file:
-                    required_specs = {}
-                    required_versions = {}
-                    for line in file:
-                        line = line.strip()
-                        if not line or line.startswith("#"):
-                            continue
-                        try:
-                            requirement = Requirement(line)
-                        except InvalidRequirement:
-                            continue
-                        required_specs[requirement.name] = requirement.specifier
-                        pinned_versions = [spec.version for spec in requirement.specifier if spec.operator == "=="]
-                        if pinned_versions:
-                            required_versions[requirement.name] = pinned_versions[0]
-                required_versions_ci = {k.lower(): v for k, v in required_versions.items()}
-                required_specs_ci = {k.lower(): v for k, v in required_specs.items()}
-                for req_name, sys_ver in system_versions.items():
-                    if not sys_ver:
-                        continue
-                    key = req_name.lower()
-                    v1 = parse(sys_ver)
-                    if key in required_versions_ci:
-                        v2 = parse(required_versions_ci[key])
-                        if v1 < v2:
-                            logger.info(f"    {req_name} version: {v1} requires an update to: {v2}")
-                        elif v1 > v2:
-                            logger.info(f"    {req_name} version: {v1} does not match expected: {v2}")
-                    elif key in required_specs_ci and v1 not in required_specs_ci[key]:
-                        logger.info(f"    {req_name} version: {v1} does not satisfy expected: {required_specs_ci[key]}")
-            except FileNotFoundError:
-                logger.error("    File Error: requirements.txt not found")
+            check_requirements(logger)
         if "time" in attrs and attrs["time"]:
             start_type = f"{attrs['time']} "
         elif run_args["tests"]:


### PR DESCRIPTION
## What type of PR is this?

- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Chore
- [ ] Other

## Description

Improves dependency validation during startup.

Kometa now:

- Reports missing requirements with a clear message instead of a traceback.
- Checks all dependencies listed in `requirements.txt` for startup validation
- Compares installed package versions against the requirement specifiers.
- Produces a warning at startup when dependencies are installed but out of date.

Example when requirements are missing - note this isn't wrapped in a critical logger as it happens prior to Kometa actually starting a run.
```text
Requirements Error: Requirements are not installed.
Please follow the documentation for instructions on installing requirements. (No module named 'langcodes')
```

Example when requirements are out of date:
```text
[WARNING]     Requirements are out of date. Please follow the documentation for instructions on installing requirements.
[INFO]       requests 2.34.2 (requires ==0.0.0)
```

## Related Issues [optional]

- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789036208&installation_model_id=431096&pr_number=3494&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3494&signature=8f0661ccdc90cb538371f4b9263e66ded21070e0d7654bc01b298580e59da90c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->