### PR TITLE
Add MDBList collection synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `sync_watchlist_to_serializd` show-library operation to mark the Plex server owner's watched episodes as watched in Serializd.
 - Add builders: `serializd_list`, `serializd_watchlist`, `serializd_trending`, `serializd_popular`, and `serializd_featured`
 - Add `serializd` as a direct rating source for show and episode-level Ratings Defaults overlays.
+- Add `sync_to_mdb_list` for synchronizing collections with MDBList static lists.
 
 ### Fixed
 - Sort IMDb award years and multi-edition year values before resolving `starting`/`ending` ranges, so out-of-order repository entries do not cause `latest` ranges to include the wrong years.

--- a/docs/files/builders/radarr/taglist.md
+++ b/docs/files/builders/radarr/taglist.md
@@ -27,3 +27,20 @@ collections:
   Radarr Movies Without Tags:
     radarr_taglist: 
 ```
+
+### Sync to MDBList
+
+When used with [`sync_to_mdb_list`](../../settings.md#mdblist-sync-example),
+`radarr_taglist` uses the matching movies in Radarr as the source of truth.
+The sync does not depend on the items being present in Plex or on a Plex
+collection being built. Removing a tag in Radarr also removes
+the movie from the MDBList static list. Only movies are removed, so this can
+safely share a list with [`sonarr_taglist`](../../sonarr/taglist.md) syncs.
+
+```yaml
+collections:
+  Radarr Test:
+    radarr_taglist: kometa_test
+    sync_to_mdb_list: My Kometa Test Tags
+    build_collection: false
+```

--- a/docs/files/builders/sonarr/taglist.md
+++ b/docs/files/builders/sonarr/taglist.md
@@ -28,3 +28,20 @@ collections:
   Sonarr Series Without Tags:
     sonarr_taglist: 
 ```
+
+### Sync to MDBList
+
+When used with [`sync_to_mdb_list`](../../settings.md#mdblist-sync-example),
+`sonarr_taglist` uses the matching series in Sonarr as the source of truth.
+The sync does not depend on the items being present in Plex or on a Plex
+collection being built. Removing a tag in Sonarr also removes
+the series from the MDBList static list. Only series are removed, so this can
+safely share a list with [`radarr_taglist`](../../radarr/taglist.md) syncs.
+
+```yaml
+collections:
+  Sonarr Test:
+    sonarr_taglist: kometa_test
+    sync_to_mdb_list: My Kometa Test Tags
+    build_collection: false
+```

--- a/docs/files/settings.md
+++ b/docs/files/settings.md
@@ -115,7 +115,7 @@ collections:
 If a list with the name specified exists, it will be used. If no list exists, one will be created.
 The default `mode` is `sync`, which adds missing items and removes items no
 longer present in the collection. Use `append` to add items without removing
-existing list entries. Movies, shows, seasons, and episodes are supported.
+existing list entries. Movies and shows are supported.
 
 ## Smart Label Definitions
 

--- a/docs/files/settings.md
+++ b/docs/files/settings.md
@@ -35,6 +35,7 @@ tags:
   - tmdb_birthday
   - changes_webhooks
   - sync_to_trakt_list
+  - sync_to_mdb_list
   - sync_missing_to_trakt_list
   - run_definition
   - default_percent
@@ -81,12 +82,40 @@ All the following attributes serve various functions as how the definition funct
 | `sync_missing_to_trakt_list` | **Description:** Used to also sync missing items to the Trakt List specified by `sync_to_trakt_list`.<br>**Default:** `false`<br>**Values:** `true` or `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `sync_mode`                  | **Description:** Used to change how builders sync with this definition.<br>**Default:** `sync_mode` [settings value](../config/settings.md) in the Configuration File<br>**Values:** `sync` or `append`<br>See main [settings page](../config/settings.md#sync-mode)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `sync_to_trakt_list`         | **Description:** Used to specify a trakt list you want the definition synced to.<br>**Values:** Trakt List Slug you want to sync to                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `sync_to_mdb_list`           | **Description:** Syncs a collection to an MDBList static list by exact `name`, creating it when absent. Use a name directly or an object with `name` and optional `mode` (`sync` by default, or `append`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `template`                   | **Description:** Used to specify a template and Template Variables to use for this definition. See the [Templates Page](templates.md) for more information.<br>**Values:** Dictionary :material-information-outline:{ data-tooltip data-tooltip-id="tippy-yaml-dictionaries" }                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `test`                       | **Description:** When running in Test Mode (`--run-tests` [option](../kometa/environmental.md)) only definitions with `test: true` will be run.<br>**Default:** `false`<br>**Values:** `true` or `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `tmdb_birthday`              | **Description:** Controls if the Definition is run based on `tmdb_person`'s Birthday. Has 3 possible attributes `this_month`, `before` and `after`.<br>**Values:**<table class="clearTable"><tr><td>`this_month`</td><td>Run's if Birthday is in current Month</td><td>`true`/`false`</td></tr><tr><td>`before`</td><td>Run if X Number of Days before the Birthday</td><td>Number 0 or greater</td></tr><tr><td>`after`</td><td>Run if X Number of Days after the Birthday</td><td>Number 0 or greater</td></tr></table>                                                                                                                                                                                                                                                                                          |
 | `tmdb_deathday`              | **Description:** Controls if the Definition is run based on `tmdb_person`'s Deathday. Has 3 possible attributes `this_month`, `before` and `after`.<br>**Values:**<table class="clearTable"><tr><td>`this_month`</td><td>Run's if Deathday is in current Month</td><td>`true`/`false`</td></tr><tr><td>`before`</td><td>Run if X Number of Days before the Deathday</td><td>Number 0 or greater</td></tr><tr><td>`after`</td><td>Run if X Number of Days after the Deathday</td><td>Number 0 or greater</td></tr></table>                                                                                                                                                                                                                                                                                          |
 | `tmdb_region`                | **Description:** Sets the region for `tmdb_popular`, `tmdb_now_playing`, `tmdb_top_rated`, and `tmdb_upcoming`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `validate_builders`          | **Description:** When set to false the definition will not fail if one Builder fails.<br>**Default:** `true`<br>**Values:** `true` or `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+
+### MDBList Sync Example
+
+`sync_to_mdb_list` synchronizes a collection with an MDBList static list. The
+list is found by exact name and created automatically when it does not exist.
+
+```yaml
+collections:
+  Recently Added:
+    plex_search:
+      all:
+        added: 30
+    sync_to_mdb_list: "Recently Added"
+
+  Favourites:
+    plex_search:
+      all:
+        user_rating.gte: 8.0
+    sync_to_mdb_list:
+      name: "Favourites"
+      mode: append
+```
+
+If a list with the name specified exists, it will be used. If no list exists, one will be created.
+The default `mode` is `sync`, which adds missing items and removes items no
+longer present in the collection. Use `append` to add items without removing
+existing list entries. Movies, shows, seasons, and episodes are supported.
 
 ## Smart Label Definitions
 

--- a/json-schema/collection-schema.json
+++ b/json-schema/collection-schema.json
@@ -104,6 +104,7 @@
                 "sync_missing_to_trakt_list": { "type": "boolean" },
                 "sync_mode": { "type": "string", "enum": ["sync", "append"] },
                 "sync_to_trakt_list": { "type": "string", "description": "Trakt list slug to sync this definition to." },
+                "sync_to_mdb_list": { "oneOf": [{ "type": "string" }, { "type": "object", "required": ["name"], "properties": { "name": { "type": "string" }, "mode": { "type": "string", "enum": ["sync", "append"], "default": "sync" } }, "additionalProperties": false }], "description": "MDBList list name, optionally with sync or append mode." },
                 "test": { "type": "boolean" },
                 "tmdb_birthday": {
                     "type": "object", "additionalProperties": false,

--- a/kometa.py
+++ b/kometa.py
@@ -1376,7 +1376,7 @@ def run_collection(config, library, metadata, requested_collections):
                 logger.info("")
                 logger.info(f"Plex Server Movie pre-roll video updated to {builder.server_preroll}")
 
-            if valid and run_item_details and (builder.item_details or builder.custom_sort or builder.sync_to_trakt_list):
+            if valid and run_item_details and (builder.item_details or builder.custom_sort or builder.sync_to_trakt_list or builder.sync_to_mdb_list):
                 try:
                     builder.load_collection_items()
                 except Failed:
@@ -1389,6 +1389,8 @@ def run_collection(config, library, metadata, requested_collections):
                         builder.sort_collection()
                     if builder.sync_to_trakt_list:
                         builder.sync_trakt_list()
+                    if builder.sync_to_mdb_list:
+                        builder.sync_mdb_list()
 
             builder.send_notifications()
 

--- a/kometa.py
+++ b/kometa.py
@@ -1331,7 +1331,7 @@ def run_collection(config, library, metadata, requested_collections):
                     library.stats["sonarr"] += sonarr_add
                     library.status[str(mapping_name)]["sonarr"] += sonarr_add
 
-                if not builder.found_items and not builder.ignore_blank_results and not builder.obj:
+                if not builder.found_items and not builder.ignore_blank_results and not builder.obj and not builder.sync_to_mdb_list:
                     raise NonExisting(f"{builder.Type} Warning: No items found")
 
             valid = True
@@ -1376,7 +1376,11 @@ def run_collection(config, library, metadata, requested_collections):
                 logger.info("")
                 logger.info(f"Plex Server Movie pre-roll video updated to {builder.server_preroll}")
 
-            if valid and run_item_details and (builder.item_details or builder.custom_sort or builder.sync_to_trakt_list or builder.sync_to_mdb_list):
+            arr_mdb_list_sync = builder.sync_to_mdb_list and builder.mdb_list_arr_ids is not None
+            if valid and run_item_details and arr_mdb_list_sync:
+                builder.sync_mdb_list()
+
+            if valid and run_item_details and (builder.item_details or builder.custom_sort or builder.sync_to_trakt_list or (builder.sync_to_mdb_list and not arr_mdb_list_sync)):
                 try:
                     builder.load_collection_items()
                 except Failed:
@@ -1389,7 +1393,7 @@ def run_collection(config, library, metadata, requested_collections):
                         builder.sort_collection()
                     if builder.sync_to_trakt_list:
                         builder.sync_trakt_list()
-                    if builder.sync_to_mdb_list:
+                    if builder.sync_to_mdb_list and not arr_mdb_list_sync:
                         builder.sync_mdb_list()
 
             builder.send_notifications()

--- a/kometa.py
+++ b/kometa.py
@@ -1331,7 +1331,7 @@ def run_collection(config, library, metadata, requested_collections):
                     library.stats["sonarr"] += sonarr_add
                     library.status[str(mapping_name)]["sonarr"] += sonarr_add
 
-                if not builder.found_items and not builder.ignore_blank_results and not builder.obj and not builder.sync_to_mdb_list:
+                if not builder.found_items and not builder.ignore_blank_results and not builder.obj and builder.mdb_list_arr_ids is None:
                     raise NonExisting(f"{builder.Type} Warning: No items found")
 
             valid = True

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -4926,7 +4926,7 @@ class CollectionBuilder:
             logger.separator(f"Items Found for {self.name} {self.Type}", space=False, border=False)
             logger.info("")
             self.items = self.found_items
-        if not self.items and not self.sync_to_mdb_list:
+        if not self.items and self.mdb_list_arr_ids is None:
             raise Failed(f"Plex Error: No {self.Type} items found")
 
     def _safe_tmdb_lookup(self, getter, tmdb_id, item_type):

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -19,6 +19,7 @@ from modules.util import BuilderValidationError, Deleted, Failed, FilterFailed, 
 
 logger = util.logger
 
+mdb_list_arr_types = {"radarr_taglist": "tmdb", "sonarr_taglist": "tmdb_show"}
 advance_new_agent = ["item_metadata_language", "item_use_original_title"]
 advance_show = [
     "item_episode_sorting",
@@ -1165,6 +1166,8 @@ class CollectionBuilder:
         self.file_theme = None
         self.sync_to_trakt_list = None
         self.sync_to_mdb_list = None
+        self.mdb_list_arr_ids = None
+        self.mdb_list_arr_removal_types = set()
         self.sync_missing_to_trakt_list = False
         self.collection_poster = None
         self.collection_background = None
@@ -3751,6 +3754,11 @@ class CollectionBuilder:
                 self.config.Cache.delete_list_ids(list_key)
             list_key = self.config.Cache.update_list_cache(f"{self.library.type}:{method}", str(value), expired, self.details["cache_builders"])
             self.config.Cache.update_list_ids(list_key, ids)
+        if self.sync_to_mdb_list and method in mdb_list_arr_types:
+            if self.mdb_list_arr_ids is None:
+                self.mdb_list_arr_ids = []
+            self.mdb_list_arr_ids.extend(ids)
+            self.mdb_list_arr_removal_types.add(mdb_list_arr_types[method])
         return ids
 
     def _find_plex_keys(self, input_id):
@@ -4918,7 +4926,7 @@ class CollectionBuilder:
             logger.separator(f"Items Found for {self.name} {self.Type}", space=False, border=False)
             logger.info("")
             self.items = self.found_items
-        if not self.items:
+        if not self.items and not self.sync_to_mdb_list:
             raise Failed(f"Plex Error: No {self.Type} items found")
 
     def _safe_tmdb_lookup(self, getter, tmdb_id, item_type):
@@ -5594,6 +5602,15 @@ class CollectionBuilder:
         if not self.sync_to_mdb_list:
             return
         logger.separator(f"Syncing {self.name} {self.Type} to MDBList {self.sync_to_mdb_list['name']}", space=False, border=False)
+        if self.mdb_list_arr_ids is not None:
+            logger.info("Using Radarr/Sonarr tag-list results as the MDBList sync source")
+            self.config.MDBList.sync_list(
+                self.sync_to_mdb_list["name"],
+                self._get_mdb_list_arr_ids(),
+                self.sync_to_mdb_list["mode"],
+                removal_types=self.mdb_list_arr_removal_types,
+            )
+            return
         if self.obj:
             self.library.item_reload(self.obj)
         self.load_collection_items()
@@ -5612,6 +5629,18 @@ class CollectionBuilder:
                     current_ids.append((tmdb_id, "tmdb_show"))
                     break
         self.config.MDBList.sync_list(self.sync_to_mdb_list["name"], current_ids, self.sync_to_mdb_list["mode"])
+
+    def _get_mdb_list_arr_ids(self):
+        current_ids = []
+        for item_id, item_type in self.mdb_list_arr_ids:
+            if item_type == "tmdb":
+                current_ids.append((item_id, "tmdb"))
+            elif item_type == "tvdb":
+                try:
+                    current_ids.append((self.config.Convert.tvdb_to_tmdb(item_id, fail=True), "tmdb_show"))
+                except MappingConvertError as e:
+                    logger.warning(f"MDBList Warning: Skipping TVDb ID {item_id}: {e}")
+        return list(dict.fromkeys(current_ids))
 
     def delete(self):
         title = self.obj.title if self.obj else self.name

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -3754,7 +3754,7 @@ class CollectionBuilder:
                 self.config.Cache.delete_list_ids(list_key)
             list_key = self.config.Cache.update_list_cache(f"{self.library.type}:{method}", str(value), expired, self.details["cache_builders"])
             self.config.Cache.update_list_ids(list_key, ids)
-        if self.sync_to_mdb_list and method in mdb_list_arr_types:
+        if getattr(self, "sync_to_mdb_list", None) and method in mdb_list_arr_types:
             if self.mdb_list_arr_ids is None:
                 self.mdb_list_arr_ids = []
             self.mdb_list_arr_ids.extend(ids)

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -15,7 +15,7 @@ from modules import anidb, anilist, floppy, icheckmovies, imdb, letterboxd, mal,
 from modules.overlay import Overlay, rating_sources
 from modules.poster import KometaImage
 from modules.request import quote
-from modules.util import BuilderValidationError, Deleted, Failed, FilterFailed, NonExisting, NotScheduled, NotScheduledRange, ServiceError
+from modules.util import BuilderValidationError, Deleted, Failed, FilterFailed, MappingConvertError, NonExisting, NotScheduled, NotScheduledRange, ServiceError
 
 logger = util.logger
 
@@ -5604,7 +5604,12 @@ class CollectionBuilder:
                     current_ids.append((pl_library.movie_rating_key_map[item.ratingKey], "tmdb"))
                     break
                 if isinstance(item, Show) and item.ratingKey in pl_library.show_rating_key_map:
-                    current_ids.append((self.config.Convert.tvdb_to_tmdb(pl_library.show_rating_key_map[item.ratingKey], fail=True), "tmdb_show"))
+                    try:
+                        tmdb_id = self.config.Convert.tvdb_to_tmdb(pl_library.show_rating_key_map[item.ratingKey], fail=True)
+                    except MappingConvertError as e:
+                        logger.warning(f"MDBList Warning: Skipping {item.title}: {e}")
+                        break
+                    current_ids.append((tmdb_id, "tmdb_show"))
                     break
         self.config.MDBList.sync_list(self.sync_to_mdb_list["name"], current_ids, self.sync_to_mdb_list["mode"])
 

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -640,6 +640,7 @@ parts_collection_valid = (
         "non_item_remove_label",
         "item_analyze",
         "sync_to_trakt_list",
+        "sync_to_mdb_list",
     ]
     + episode_parts_only
     + summary_details
@@ -1163,6 +1164,7 @@ class CollectionBuilder:
         self.url_theme = None
         self.file_theme = None
         self.sync_to_trakt_list = None
+        self.sync_to_mdb_list = None
         self.sync_missing_to_trakt_list = False
         self.collection_poster = None
         self.collection_background = None
@@ -1653,6 +1655,7 @@ class CollectionBuilder:
                     self._tmdb(method_name, method_data)
                 elif method_name in trakt.builders or method_name in [
                     "sync_to_trakt_list",
+                    "sync_to_mdb_list",
                     "sync_missing_to_trakt_list",
                 ]:
                     self._trakt(method_name, method_data)
@@ -3488,6 +3491,17 @@ class CollectionBuilder:
             if method_data not in self.config.Trakt.slugs:
                 raise BuilderValidationError(f"{self.Type} Error: {method_data} invalid. Options {', '.join(self.config.Trakt.slugs)}")
             self.sync_to_trakt_list = method_data
+        elif method_name == "sync_to_mdb_list":
+            if isinstance(method_data, dict):
+                name = method_data.get("name")
+                mode = str(method_data.get("mode", "sync")).lower()
+            else:
+                name, mode = method_data, "sync"
+            if not name:
+                raise BuilderValidationError(f"{self.Type} Error: sync_to_mdb_list requires a name")
+            if mode not in ("sync", "append"):
+                raise BuilderValidationError(f"{self.Type} Error: sync_to_mdb_list mode must be sync or append")
+            self.sync_to_mdb_list = {"name": str(name), "mode": mode}
         elif method_name == "sync_missing_to_trakt_list":
             self.sync_missing_to_trakt_list = util.parse(self.Type, method_name, method_data, datatype="bool", default=False)
         elif method_name in trakt.builders:
@@ -5575,6 +5589,20 @@ class CollectionBuilder:
             current_ids.extend([(mm, "tmdb") for mm in self.missing_movies])
             current_ids.extend([(ms, "tvdb") for ms in self.missing_shows])
         self.config.Trakt.sync_list(self.sync_to_trakt_list, current_ids)
+
+    def sync_mdb_list(self):
+        logger.separator(f"Syncing {self.name} {self.Type} to MDBList {self.sync_to_mdb_list['name']}", space=False, border=False)
+        if self.obj:
+            self.library.item_reload(self.obj)
+        self.load_collection_items()
+        current_ids = []
+        for item in self.items:
+            for pl_library in self.libraries:
+                if isinstance(item, Movie) and item.ratingKey in pl_library.movie_rating_key_map:
+                    current_ids.append((pl_library.movie_rating_key_map[item.ratingKey], "tmdb")); break
+                if isinstance(item, Show) and item.ratingKey in pl_library.show_rating_key_map:
+                    current_ids.append((self.config.Convert.tvdb_to_tmdb(pl_library.show_rating_key_map[item.ratingKey], fail=True), "tmdb_show")); break
+        self.config.MDBList.sync_list(self.sync_to_mdb_list["name"], current_ids, self.sync_to_mdb_list["mode"])
 
     def delete(self):
         title = self.obj.title if self.obj else self.name

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -5632,7 +5632,7 @@ class CollectionBuilder:
 
     def _get_mdb_list_arr_ids(self):
         current_ids = []
-        for item_id, item_type in self.mdb_list_arr_ids:
+        for item_id, item_type in self.mdb_list_arr_ids or []:
             if item_type == "tmdb":
                 current_ids.append((item_id, "tmdb"))
             elif item_type == "tvdb":

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -5591,6 +5591,8 @@ class CollectionBuilder:
         self.config.Trakt.sync_list(self.sync_to_trakt_list, current_ids)
 
     def sync_mdb_list(self):
+        if not self.sync_to_mdb_list:
+            return
         logger.separator(f"Syncing {self.name} {self.Type} to MDBList {self.sync_to_mdb_list['name']}", space=False, border=False)
         if self.obj:
             self.library.item_reload(self.obj)
@@ -5599,9 +5601,11 @@ class CollectionBuilder:
         for item in self.items:
             for pl_library in self.libraries:
                 if isinstance(item, Movie) and item.ratingKey in pl_library.movie_rating_key_map:
-                    current_ids.append((pl_library.movie_rating_key_map[item.ratingKey], "tmdb")); break
+                    current_ids.append((pl_library.movie_rating_key_map[item.ratingKey], "tmdb"))
+                    break
                 if isinstance(item, Show) and item.ratingKey in pl_library.show_rating_key_map:
-                    current_ids.append((self.config.Convert.tvdb_to_tmdb(pl_library.show_rating_key_map[item.ratingKey], fail=True), "tmdb_show")); break
+                    current_ids.append((self.config.Convert.tvdb_to_tmdb(pl_library.show_rating_key_map[item.ratingKey], fail=True), "tmdb_show"))
+                    break
         self.config.MDBList.sync_list(self.sync_to_mdb_list["name"], current_ids, self.sync_to_mdb_list["mode"])
 
     def delete(self):

--- a/modules/mdblist.py
+++ b/modules/mdblist.py
@@ -225,8 +225,7 @@ class MDBList:
         lists = lists if isinstance(lists, list) else lists.get("lists", [])
         matches = [item for item in lists if isinstance(item, dict) and item.get("name") == slug]
         if len(matches) > 1:
-            logger.warning(f"MDBList Warning: Multiple lists named '{slug}' found; no changes made")
-            return
+            raise Failed(f"MDBList Error: Multiple lists named '{slug}' found")
         if not matches:
             created, _ = self._request(f"{api_url}lists/user/add", json_data={"name": slug})
             if isinstance(created, dict):
@@ -248,26 +247,14 @@ class MDBList:
         payload = {"movies": [], "shows": []}
         for item_id, item_type in ids:
             key = "movies" if item_type == "tmdb" else "shows"
-            payload[key].append({"tmdb": int(str(item_id).split("_")[0])})
+            payload[key].append({"tmdb": int(item_id)})
         payload = {key: value for key, value in payload.items() if value}
 
         def update_items(action, item_payload, processed, total):
             if not item_payload:
                 return processed
             result, _ = self._request(f"{api_url}lists/{list_id}/items/{action}", json_data=item_payload)
-            result = result if isinstance(result, dict) else {}
-            counts = result.get(action + "ed", result.get("removed", {}))
-            if action == "remove":
-                counts = result.get("removed", result.get("deleted", counts))
-            existing = result.get("existing", {})
-            not_found = result.get("not_found", result.get("notfound", {}))
-            for kind in ("movies", "shows"):
-                if counts.get(kind, 0):
-                    logger.info(f"MDBList {action.capitalize()} {counts[kind]} {kind}")
-                if existing.get(kind, 0):
-                    logger.info(f"MDBList Existing {existing[kind]} {kind}")
-                if not_found.get(kind, 0):
-                    logger.warning(f"MDBList Not Found {not_found[kind]} {kind}")
+            logger.trace(f"MDBList {action.capitalize()} Response: {result}")
             processed += sum(len(value) for value in item_payload.values())
             logger.info(f"MDBList Sync Progress: {processed}/{total} items processed")
             return processed
@@ -278,7 +265,7 @@ class MDBList:
             if owner and list_slug:
                 existing = self.get_tmdb_ids("mdblist_list", {"url": f"{base_url}{owner}/{list_slug}"}, is_movie=None)
             else:
-                existing = []
+                raise Failed(f"MDBList Error: Could not determine the URL for list '{slug}'")
             wanted = set(ids)
             remove_payload = {"movies": [], "shows": []}
             for item_id, item_type in existing:

--- a/modules/mdblist.py
+++ b/modules/mdblist.py
@@ -243,8 +243,6 @@ class MDBList:
         else:
             list_id = matches[0].get("id")
 
-        selected = matches[0] if matches else {"id": list_id}
-
         payload = {"movies": [], "shows": []}
         for item_id, item_type in ids:
             key = "movies" if item_type == "tmdb" else "shows"
@@ -261,12 +259,7 @@ class MDBList:
             return processed
 
         if mode == "sync":
-            owner = selected.get("username") or selected.get("user") or selected.get("owner")
-            list_slug = selected.get("slug") or selected.get("list_slug")
-            if owner and list_slug:
-                existing = self.get_tmdb_ids("mdblist_list", {"url": f"{base_url}{owner}/{list_slug}"}, is_movie=None)
-            else:
-                raise Failed(f"MDBList Error: Could not determine the URL for list '{slug}'")
+            existing = self.get_tmdb_ids("mdblist_list", {"id": list_id}, is_movie=None)
             wanted = set(ids)
             remove_payload = {"movies": [], "shows": []}
             for item_id, item_type in existing:
@@ -310,12 +303,16 @@ class MDBList:
 
     def get_tmdb_ids(self, method, data, is_movie=None, filters=None):
 
-        list_path = data["url"].split("/lists/")[-1].strip("/")
-
-        external_id = list_path.split("/external/")[-1] if "/external/" in list_path else None
-
-        items_url = f"{api_url}external/lists/{external_id}/items/" if external_id else f"{api_url}lists/{list_path}/items/"
-        meta_url = f"{api_url}external/lists/{external_id}" if external_id else f"{api_url}lists/{list_path}"
+        list_id = data.get("id")
+        if list_id:
+            external_id = None
+            items_url = f"{api_url}lists/{list_id}/items/"
+            meta_url = f"{api_url}lists/{list_id}"
+        else:
+            list_path = data["url"].split("/lists/")[-1].strip("/")
+            external_id = list_path.split("/external/")[-1] if "/external/" in list_path else None
+            items_url = f"{api_url}external/lists/{external_id}/items/" if external_id else f"{api_url}lists/{list_path}/items/"
+            meta_url = f"{api_url}external/lists/{external_id}" if external_id else f"{api_url}lists/{list_path}"
 
         sort, direction = data["sort_by"].split(".") if "sort_by" in data else (None, None)
         results = []

--- a/modules/mdblist.py
+++ b/modules/mdblist.py
@@ -1,5 +1,6 @@
 import time
 from datetime import datetime
+from urllib.parse import urlencode
 
 from modules import util
 from modules.util import Failed, LimitReached
@@ -147,7 +148,7 @@ class MDBList:
     def has_key(self):
         return self.apikey is not None
 
-    def _request(self, url, params=None):
+    def _request(self, url, params=None, json_data=None):
         final_params = {"apikey": self.apikey}
         if params:
             final_params.update(params)
@@ -155,9 +156,14 @@ class MDBList:
         # Respect API Rate limits
         time.sleep(0.2 if self.supporter else 1.0)
 
-        response = self.requests.get(url, params=final_params)
+        if json_data is not None:
+            separator = "&" if "?" in url else "?"
+            post_url = f"{url}{separator}{urlencode(final_params)}"
+            response = self.requests.post(post_url, json=json_data)
+        else:
+            response = self.requests.get(url, params=final_params)
 
-        if response.status_code != 200:
+        if not 200 <= response.status_code < 300:
             raise Failed(f"MDBList Error: {response.status_code} - {response.text}")
 
         json_data = response.json()
@@ -205,6 +211,94 @@ class MDBList:
 
     def get_movie(self, tmdb_id):
         return self.get_item(media_provider="tmdb", media_type="movie", media_id=tmdb_id)
+
+    def sync_list(self, slug, ids, mode="sync"):
+        """Update a user-owned static list using MDBList's list item API.
+
+        ``slug`` is the exact list name. MDBList resolves it to the user's
+        numeric list id; write endpoints then require the id and a payload
+        containing ``tmdb`` identifiers grouped under movies and shows.
+        """
+        if mode not in ("sync", "append"):
+            raise Failed(f"MDBList Error: invalid sync mode: {mode}")
+        lists, _ = self._request(f"{api_url}lists/user")
+        lists = lists if isinstance(lists, list) else lists.get("lists", [])
+        matches = [item for item in lists if isinstance(item, dict) and item.get("name") == slug]
+        if len(matches) > 1:
+            logger.warning(f"MDBList Warning: Multiple lists named '{slug}' found; no changes made")
+            return
+        if not matches:
+            created, _ = self._request(f"{api_url}lists/user/add", json_data={"name": slug})
+            if isinstance(created, dict):
+                list_id = created.get("id") or (created.get("list") or {}).get("id")
+            else:
+                list_id = None
+            if not list_id:
+                lists, _ = self._request(f"{api_url}lists/user")
+                lists = lists if isinstance(lists, list) else lists.get("lists", [])
+                matches = [item for item in lists if isinstance(item, dict) and item.get("name") == slug]
+                list_id = matches[0].get("id") if len(matches) == 1 else None
+            if not list_id:
+                raise Failed(f"MDBList Error: could not create list: {slug}")
+        else:
+            list_id = matches[0].get("id")
+
+        selected = matches[0] if matches else {"id": list_id}
+
+        payload = {"movies": [], "shows": []}
+        for item_id, item_type in ids:
+            key = "movies" if item_type == "tmdb" else "shows"
+            payload[key].append({"tmdb": int(str(item_id).split("_")[0])})
+        payload = {key: value for key, value in payload.items() if value}
+
+        def update_items(action, item_payload, processed, total):
+            if not item_payload:
+                return processed
+            result, _ = self._request(f"{api_url}lists/{list_id}/items/{action}", json_data=item_payload)
+            result = result if isinstance(result, dict) else {}
+            counts = result.get(action + "ed", result.get("removed", {}))
+            if action == "remove":
+                counts = result.get("removed", result.get("deleted", counts))
+            existing = result.get("existing", {})
+            not_found = result.get("not_found", result.get("notfound", {}))
+            for kind in ("movies", "shows"):
+                if counts.get(kind, 0):
+                    logger.info(f"MDBList {action.capitalize()} {counts[kind]} {kind}")
+                if existing.get(kind, 0):
+                    logger.info(f"MDBList Existing {existing[kind]} {kind}")
+                if not_found.get(kind, 0):
+                    logger.warning(f"MDBList Not Found {not_found[kind]} {kind}")
+            processed += sum(len(value) for value in item_payload.values())
+            logger.info(f"MDBList Sync Progress: {processed}/{total} items processed")
+            return processed
+
+        if mode == "sync":
+            owner = selected.get("username") or selected.get("user") or selected.get("owner")
+            list_slug = selected.get("slug") or selected.get("list_slug")
+            if owner and list_slug:
+                existing = self.get_tmdb_ids("mdblist_list", {"url": f"{base_url}{owner}/{list_slug}"}, is_movie=None)
+            else:
+                existing = []
+            wanted = set(ids)
+            remove_payload = {"movies": [], "shows": []}
+            for item_id, item_type in existing:
+                if (item_id, item_type) not in wanted:
+                    key = "movies" if item_type == "tmdb" else "shows"
+                    remove_payload[key].append({"tmdb": int(item_id)})
+            remove_payload = {key: value for key, value in remove_payload.items() if value}
+            if remove_payload:
+                total = sum(len(value) for value in remove_payload.values())
+                processed = 0
+                for key, value in remove_payload.items():
+                    for start in range(0, len(value), 100):
+                        processed = update_items("remove", {key: value[start : start + 100]}, processed, total)
+        if payload:
+            total = sum(len(value) for value in payload.values())
+            processed = 0
+            for key, value in payload.items():
+                for start in range(0, len(value), 100):
+                    processed = update_items("add", {key: value[start : start + 100]}, processed, total)
+        logger.info(f"MDBList list {slug} updated ({mode})")
 
     def validate_mdblist_lists(self, error_type, mdb_lists):
         valid_lists = []

--- a/modules/mdblist.py
+++ b/modules/mdblist.py
@@ -212,12 +212,13 @@ class MDBList:
     def get_movie(self, tmdb_id):
         return self.get_item(media_provider="tmdb", media_type="movie", media_id=tmdb_id)
 
-    def sync_list(self, slug, ids, mode="sync"):
+    def sync_list(self, slug, ids, mode="sync", removal_types=None):
         """Update a user-owned static list using MDBList's list item API.
 
         ``slug`` is the exact list name. MDBList resolves it to the user's
         numeric list id; write endpoints then require the id and a payload
         containing ``tmdb`` identifiers grouped under movies and shows.
+        ``removal_types`` optionally limits removals to the supplied media types.
         """
         if mode not in ("sync", "append"):
             raise Failed(f"MDBList Error: invalid sync mode: {mode}")
@@ -269,7 +270,7 @@ class MDBList:
             wanted = set(ids)
             remove_payload = {"movies": [], "shows": []}
             for item_id, item_type in existing:
-                if (item_id, item_type) not in wanted:
+                if (removal_types is None or item_type in removal_types) and (item_id, item_type) not in wanted:
                     key = "movies" if item_type == "tmdb" else "shows"
                     remove_payload[key].append({"tmdb": int(item_id)})
             remove_payload = {key: value for key, value in remove_payload.items() if value}

--- a/modules/mdblist.py
+++ b/modules/mdblist.py
@@ -243,6 +243,9 @@ class MDBList:
         else:
             list_id = matches[0].get("id")
 
+        existing = []
+        if mode == "sync":
+            existing = self.get_tmdb_ids("mdblist_list", {"id": list_id}, is_movie=None)
         payload = {"movies": [], "shows": []}
         for item_id, item_type in ids:
             key = "movies" if item_type == "tmdb" else "shows"
@@ -255,15 +258,15 @@ class MDBList:
             result, _ = self._request(f"{api_url}lists/{list_id}/items/{action}", json_data=item_payload)
             logger.trace(f"MDBList {action.capitalize()} Response: {result}")
             processed += sum(len(value) for value in item_payload.values())
-            logger.info(f"MDBList Sync Progress: {processed}/{total} items processed")
+            item_type = "movies" if "movies" in item_payload else "shows"
+            action_name = "Added to" if action == "add" else "Removed from"
+            logger.info(f"{action_name} MDBList ({item_type}): {processed}/{total}")
             return processed
 
         if mode == "sync":
-            existing = self.get_tmdb_ids("mdblist_list", {"id": list_id}, is_movie=None)
-            wanted = set(ids)
             remove_payload = {"movies": [], "shows": []}
             for item_id, item_type in existing:
-                if (removal_types is None or item_type in removal_types) and (item_id, item_type) not in wanted:
+                if removal_types is None or item_type in removal_types:
                     key = "movies" if item_type == "tmdb" else "shows"
                     remove_payload[key].append({"tmdb": int(item_id)})
             remove_payload = {key: value for key, value in remove_payload.items() if value}
@@ -386,10 +389,10 @@ class MDBList:
             if total_count:
                 percent = min(int((len(results) / total_count) * 100), 100)
                 suffix = "..." if has_more else " - Complete"
-                logger.info(f"MDBList Sync Progress: {len(results)}/{total_count} ({percent}%){suffix}")
+                logger.info(f"Reading current MDBList items: {len(results)}/{total_count} ({percent}%){suffix}")
             else:
                 suffix = "..." if has_more else ""
-                logger.info(f"MDBList Sync Progress: {len(results)} items fetched{suffix}")
+                logger.info(f"Reading current MDBList items: {len(results)} found{suffix}")
 
             if len(items) == 0:  # type: ignore
                 break

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -111,6 +111,7 @@ def make_builder(**attrs) -> CollectionBuilder:
         "name": "Test Collection",
         "builders": [],
         "items": [],
+        "mdb_list_arr_ids": None,
         "item_details": {},
         "asset_directory": None,
         "radarr_details": {"add_existing": False, "upgrade_existing": False, "monitor_existing": False},
@@ -141,6 +142,21 @@ def _episode_builder(library) -> CollectionBuilder:
         libraries=[library],
         details={"show_filtered": False, "show_unfiltered": False, "only_filter_missing": False},
     )
+
+
+def test_load_collection_items_rejects_empty_standard_mdblist_sync(monkeypatch):
+    monkeypatch.setattr(builder_module, "logger", FakeLogger())
+    builder = make_builder(build_collection=False, sync_to_mdb_list={"name": "List", "mode": "sync"})
+
+    with pytest.raises(Failed, match="No Collection items found"):
+        builder.load_collection_items()
+
+
+def test_load_collection_items_allows_empty_arr_mdblist_sync(monkeypatch):
+    monkeypatch.setattr(builder_module, "logger", FakeLogger())
+    builder = make_builder(build_collection=False, sync_to_mdb_list={"name": "List", "mode": "sync"}, mdb_list_arr_ids=[])
+
+    builder.load_collection_items()
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_mdblist.py
+++ b/tests/test_mdblist.py
@@ -129,3 +129,22 @@ class TestMDBList:
         adapter._request = MagicMock(side_effect=Failed("Invalid API key"))
         with pytest.raises(Failed, match="Invalid"):
             adapter.add_key("bad-key", 30)
+
+    def test_sync_list_rejects_ambiguous_names(self, adapter):
+        adapter._request = MagicMock(return_value=([{"id": 1, "name": "Favourites"}, {"id": 2, "name": "Favourites"}], {}))
+        with pytest.raises(Failed, match="Multiple lists"):
+            adapter.sync_list("Favourites", [])
+
+    def test_sync_list_requires_list_url_in_sync_mode(self, adapter):
+        adapter._request = MagicMock(return_value=([{"id": 1, "name": "Favourites"}], {}))
+        with pytest.raises(Failed, match="Could not determine the URL"):
+            adapter.sync_list("Favourites", [])
+
+    def test_sync_list_limits_removals_to_requested_media_types(self, adapter):
+        adapter._request = MagicMock(return_value=([{"id": 1, "name": "Favourites", "username": "user", "slug": "favourites"}], {}))
+        adapter.get_tmdb_ids = MagicMock(return_value=[(1, "tmdb"), (2, "tmdb_show")])
+
+        adapter.sync_list("Favourites", [], removal_types={"tmdb"})
+
+        remove_call = next(call for call in adapter._request.call_args_list if call.args[0].endswith("/items/remove"))
+        assert remove_call.kwargs["json_data"] == {"movies": [{"tmdb": 1}]}

--- a/tests/test_mdblist.py
+++ b/tests/test_mdblist.py
@@ -140,7 +140,8 @@ class TestMDBList:
         with pytest.raises(Failed, match="Could not determine the URL"):
             adapter.sync_list("Favourites", [])
 
-    def test_sync_list_limits_removals_to_requested_media_types(self, adapter):
+    def test_sync_list_limits_removals_to_requested_media_types(self, adapter, monkeypatch):
+        monkeypatch.setattr("modules.mdblist.logger", FakeLogger())
         adapter._request = MagicMock(return_value=([{"id": 1, "name": "Favourites", "username": "user", "slug": "favourites"}], {}))
         adapter.get_tmdb_ids = MagicMock(return_value=[(1, "tmdb"), (2, "tmdb_show")])
 

--- a/tests/test_mdblist.py
+++ b/tests/test_mdblist.py
@@ -135,10 +135,14 @@ class TestMDBList:
         with pytest.raises(Failed, match="Multiple lists"):
             adapter.sync_list("Favourites", [])
 
-    def test_sync_list_requires_list_url_in_sync_mode(self, adapter):
+    def test_sync_list_uses_list_id_when_syncing(self, adapter, monkeypatch):
+        monkeypatch.setattr("modules.mdblist.logger", FakeLogger())
         adapter._request = MagicMock(return_value=([{"id": 1, "name": "Favourites"}], {}))
-        with pytest.raises(Failed, match="Could not determine the URL"):
-            adapter.sync_list("Favourites", [])
+        adapter.get_tmdb_ids = MagicMock(return_value=[])
+
+        adapter.sync_list("Favourites", [])
+
+        adapter.get_tmdb_ids.assert_called_once_with("mdblist_list", {"id": 1}, is_movie=None)
 
     def test_sync_list_limits_removals_to_requested_media_types(self, adapter, monkeypatch):
         monkeypatch.setattr("modules.mdblist.logger", FakeLogger())

--- a/tests/test_mdblist.py
+++ b/tests/test_mdblist.py
@@ -144,6 +144,19 @@ class TestMDBList:
 
         adapter.get_tmdb_ids.assert_called_once_with("mdblist_list", {"id": 1}, is_movie=None)
 
+    def test_sync_list_removes_existing_items_before_adding_in_source_order(self, adapter, monkeypatch):
+        monkeypatch.setattr("modules.mdblist.logger", FakeLogger())
+        adapter._request = MagicMock(return_value=([{"id": 1, "name": "Favourites"}], {}))
+        adapter.get_tmdb_ids = MagicMock(return_value=[(1, "tmdb")])
+
+        adapter.sync_list("Favourites", [(1, "tmdb"), (2, "tmdb")])
+
+        remove_call = next(call for call in adapter._request.call_args_list if call.args[0].endswith("/items/remove"))
+        add_call = next(call for call in adapter._request.call_args_list if call.args[0].endswith("/items/add"))
+        assert remove_call.kwargs["json_data"] == {"movies": [{"tmdb": 1}]}
+        assert add_call.kwargs["json_data"] == {"movies": [{"tmdb": 1}, {"tmdb": 2}]}
+        assert adapter._request.call_args_list.index(remove_call) < adapter._request.call_args_list.index(add_call)
+
     def test_sync_list_limits_removals_to_requested_media_types(self, adapter, monkeypatch):
         monkeypatch.setattr("modules.mdblist.logger", FakeLogger())
         adapter._request = MagicMock(return_value=([{"id": 1, "name": "Favourites", "username": "user", "slug": "favourites"}], {}))


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Adds `sync_to_mdb_list` support for synchronizing Kometa collections with MDBList static lists.

The feature:

- Finds lists by exact name through the MDBList API.
- Creates the list automatically when it does not exist.
- Warns and stops when multiple lists have the same exact name.
- Supports `sync` mode (default), which adds and removes items to match the collection.
- Supports `append` mode, which only adds items.

Examples:

```yaml
collections:
  Recently Added:
    plex_search:
      all:
        added: 30
    sync_to_mdb_list: Recently Added
```

```yaml
collections:
  Favourite Shows:
    plex_search:
      all:
        user_rating.gte: 8.0
    sync_to_mdb_list:
      name: Favourite Shows
      mode: append
```

## Related Issues [optional]

- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

- [X] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [X] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [] No

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789127154&installation_model_id=431096&pr_number=3496&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3496&signature=9fc536d35dc0dd9cdf52e45d5897d266c6f362b7e2b5ddf7aa150e3907c74622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->