### PR TITLE
fix: nightly Discord notifications silently skipped since PR #3470

### DIFF
--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -256,7 +256,11 @@ jobs:
   commit-notification:
     runs-on: ubuntu-latest
     needs: [ increment-build, verify-changes, docker-build-base, docker-build-nightly ]
-    if: ${{ success() && needs.verify-changes.outputs.build == 'true' }}
+    if: >-
+      needs.verify-changes.outputs.build == 'true' &&
+      needs.increment-build.result == 'success' &&
+      needs.docker-build-nightly.result == 'success' &&
+      (needs.docker-build-base.result == 'success' || needs.docker-build-base.result == 'skipped')
     steps:
 
       - name: Send Discord Commit Notification


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

`commit-notification` in `increment-build.yml` used `if: success()` while depending on `docker-build-base`, a job that skips on purpose whenever a PR doesn't touch `Dockerfile.base`/`requirements.txt`. `success()` treats a skipped dependency as a failure, so the notification job silently skipped on nearly every nightly merge since PR #3470 (2026-08-03), even though the build and push worked fine.

Fixed by checking each dependency's `.result` explicitly instead of `success()`, same pattern already used by `docker-build-nightly` in the same file.

Verified against the last two nightly runs (`#1117`, `#1118`), which built and pushed successfully but had `commit-notification` marked `skipped`.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [ ] Yes
- [X] No
- [ ] Not Applicable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789335789&installation_model_id=431096&pr_number=3503&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3503&signature=c60308243b00a09ddf6f094cbd9d325faad41cf9ebde6b9f07e2c8fae0e7c2a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->