### PR TITLE
fix: commit-notification still skipped after #3503 - missing explicit always()

### DIFF
--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -257,6 +257,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ increment-build, verify-changes, docker-build-base, docker-build-nightly ]
     if: >-
+      always() &&
       needs.verify-changes.outputs.build == 'true' &&
       needs.increment-build.result == 'success' &&
       needs.docker-build-nightly.result == 'success' &&


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Follow-up to #3503. That PR replaced `success()` with explicit `.result ==` checks on `commit-notification`'s `if:`, but the expression still contained no status-check function (`success()`/`failure()`/`cancelled()`/`always()`). GitHub Actions auto-prepends an implicit `success()` to any job `if:` that lacks one, so the same bug came right back: `commit-notification` kept getting marked `skipped` on every nightly run where `docker-build-base` legitimately skipped, which is nearly all of them.

Fixed by adding `always() &&` at the top of the condition, matching the pattern `docker-build-nightly` already uses two jobs above it in the same file.

Verified against nightly runs after #3503 merged (07:10 UTC 08-15) - `commit-notification` was still `skipped` on every run through at least run `#1125`, despite `docker-build-nightly` succeeding each time.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [ ] Yes
- [X] No
- [ ] Not Applicable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789404556&installation_model_id=431096&pr_number=3506&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3506&signature=de1ea8c32fb30ff624dfffec7a3d969216fc6c9c600ff882edefc93dbb378acb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->