### PR TITLE
fix: OR language locale variants instead of AND-ing them in plex_search filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `audio_language`/`subtitle_language` `plex_search` filters matching zero items whenever a library has multiple Plex-reported locale variants for the requested language (e.g. `de` + `de-DE`); the variants were being AND'd together into an impossible filter instead of OR'd. Regression from #3440.
+
 ## [v2.4.8] - 2026-08-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `audio_language`/`subtitle_language` `plex_search` filters matching zero items whenever a library has multiple Plex-reported locale variants for the requested language (e.g. `de` + `de-DE`); the variants were being AND'd together into an impossible filter instead of OR'd. Regression from #3440.
+- Fix `audio_language`/`subtitle_language` `plex_search` filters matching zero items whenever a library has multiple Plex-reported locale variants for the requested language (e.g. `de` + `de-DE`); the variants were being `AND` together into an impossible filter instead of `OR`. Regression from #3440.
 
 ## [v2.4.8] - 2026-08-15
 

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -4243,9 +4243,21 @@ class CollectionBuilder:
                             results = ""
                             display_add = ""
                             for og_value, result in validation:  # type: ignore[misc]
-                                built_arg = build_url_arg(quote(str(result)) if attr in plex.string_attributes else result, arg_s=og_value)
-                                display_add += built_arg[1]
-                                results += f"{conjunction if len(results) > 0 else ''}{built_arg[0]}"
+                                if isinstance(result, list):
+                                    # Same-language locale variants: OR them (AND their negations, De Morgan style) in their own sub-block instead of the outer all/any conjunction, since an item only ever matches one variant.
+                                    sub_conjunction = "and=1&" if modifier in [".not", ".isnot"] else "or=1&"
+                                    sub_results = ""
+                                    sub_display = ""
+                                    for variant in result:
+                                        built_arg = build_url_arg(quote(str(variant)) if attr in plex.string_attributes else variant, arg_s=og_value)
+                                        sub_display += built_arg[1]
+                                        sub_results += f"{sub_conjunction if len(sub_results) > 0 else ''}{built_arg[0]}"
+                                    display_add += sub_display
+                                    results += f"{conjunction if len(results) > 0 else ''}push=1&{sub_results}pop=1&"
+                                else:
+                                    built_arg = build_url_arg(quote(str(result)) if attr in plex.string_attributes else result, arg_s=og_value)
+                                    display_add += built_arg[1]
+                                    results += f"{conjunction if len(results) > 0 else ''}{built_arg[0]}"
                         else:
                             results, display_add = build_url_arg(validation)
                     display_out += display_add
@@ -4415,7 +4427,7 @@ class CollectionBuilder:
                 if is_plex_search_language:
                     variants = self.library.get_language_search_values(attribute, str(fvalue).lower())
                     if variants:
-                        valid_list.extend((fvalue, variant) for variant in variants)
+                        valid_list.append((fvalue, variants[0] if len(variants) == 1 else variants))
                         continue
                 elif str(fvalue) in search_choices or str(fvalue).lower() in search_choices:
                     valid_value = search_choices[str(fvalue) if str(fvalue) in search_choices else str(fvalue).lower()]

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -286,7 +286,7 @@ class TestValidateAttributeLanguage:
         library = FakeLangLibrary({"audio_language": {"es": ["es-419", "es-MX", "spa"]}})
         builder = make_lang_builder(library)
         result = builder.validate_attribute("audio_language", "", "audio_language", "es", True, plex_search=True)
-        assert result == [("es", "es-419"), ("es", "es-MX"), ("es", "spa")]
+        assert result == [("es", ["es-419", "es-MX", "spa"])]
 
     def test_does_not_call_the_uncached_get_search_choices_for_plex_search_language(self):
         """The generic (uncached) listFilterChoices lookup must be skipped entirely for
@@ -301,7 +301,7 @@ class TestValidateAttributeLanguage:
         library = FakeLangLibrary({"subtitle_language": {"fr": ["fr-CA", "fre"]}})
         builder = make_lang_builder(library)
         result = builder.validate_attribute("subtitle_language", "", "subtitle_language", "fr", True, plex_search=True)
-        assert result == [("fr", "fr-CA"), ("fr", "fre")]
+        assert result == [("fr", ["fr-CA", "fre"])]
         assert library.get_tags_calls == [("subtitle_language", "fr")]
 
     def test_is_case_insensitive(self):
@@ -322,7 +322,7 @@ class TestValidateAttributeLanguage:
         library = FakeLangLibrary({"audio_language": {"es": ["es-419", "spa"], "en": ["en-US"]}})
         builder = make_lang_builder(library)
         result = builder.validate_attribute("audio_language", "", "audio_language", ["es", "en"], True, plex_search=True)
-        assert result == [("es", "es-419"), ("es", "spa"), ("en", "en-US")]
+        assert result == [("es", ["es-419", "spa"]), ("en", "en-US")]
 
     def test_raises_filter_failed_when_language_not_present_in_library(self):
         library = FakeLangLibrary({"audio_language": {}})
@@ -1085,6 +1085,56 @@ class TestBuildFilter:
                 {"all": {"folder_location": "/media/music"}},
                 default_sort="random",
             )
+
+    @staticmethod
+    def _split(value):
+        attribute = value.removesuffix(".not")
+        modifier = ".not" if value.endswith(".not") else ""
+        return attribute, modifier, value
+
+    def test_language_variants_are_ored_not_anded_under_plex_search_all(self):
+        """Regression: a base language code (e.g. "de") that expands to multiple Plex locale
+        variants (e.g. "de", "de-DE") must be OR'd together, since an item can only ever carry
+        one variant at a time. AND-ing them (the #3440 regression) produces a filter that can
+        never match, silently dropping every item from the overlay/collection."""
+        library = SimpleNamespace(
+            is_movie=True,
+            is_show=False,
+            is_music=False,
+            split=self._split,
+            get_language_search_values=lambda attribute, code: {"de": ["de", "de-DE"]}.get(code, []),
+        )
+        builder = make_builder(library=library, details={"show_options": False})
+
+        _, _details, url = builder.build_filter(
+            "smart_filter",
+            {"all": {"audio_language": "de"}},
+            default_sort="random",
+        )
+
+        assert "push=1&audioLanguage=de&or=1&audioLanguage=de-DE&pop=1" in url
+        assert "audioLanguage=de&and=1&audioLanguage=de-DE" not in url
+
+    def test_negated_language_variants_are_anded_under_plex_search_all(self):
+        """Excluding a language must exclude every one of its variants: audioLanguage!=de AND
+        audioLanguage!=de-DE (De Morgan's), not an OR of negatives which would only require an
+        item to fail to match one of the two variants."""
+        library = SimpleNamespace(
+            is_movie=True,
+            is_show=False,
+            is_music=False,
+            split=self._split,
+            get_language_search_values=lambda attribute, code: {"de": ["de", "de-DE"]}.get(code, []),
+        )
+        builder = make_builder(library=library, details={"show_options": False})
+
+        _, _details, url = builder.build_filter(
+            "smart_filter",
+            {"all": {"audio_language.not": "de"}},
+            default_sort="random",
+        )
+
+        assert "push=1&audioLanguage!=de&and=1&audioLanguage!=de-DE&pop=1" in url
 
 
 # ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

#3440 expanded a base language code (e.g. `de`) into every matching Plex locale variant (e.g. `de`, `de-DE`) for `audio_language`/`subtitle_language` plex_search filters, but those variants were joined with the surrounding `all`/`any` conjunction. Under `all`, that means `audioLanguage=de AND audioLanguage=de-DE`, which can never match since an item only ever has one variant. Result: zero items found, and with `ignore_blank_results: true` the failure is silent, so language overlays just stop appearing.

Fix: variants of the same requested value are now wrapped in their own `push=1/pop=1` sub-block and OR'd together (AND'd for `.not`/`.isnot`, De Morgan style), independent of the outer conjunction. Filters combining a language attribute with other attributes, or multiple distinct languages under `all`, are unaffected.

Added regression tests in `tests/test_builder.py` covering both the positive and negated cases, and updated existing `TestValidateAttributeLanguage` assertions for the new grouped tuple shape.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789464404&installation_model_id=431096&pr_number=3508&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3508&signature=99fbb0c915762b49bc068912c26337dbeb90ac9a6aa88da8274aad2577fb5df2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->