### PR TITLE
Fix Trakt episode ratings when an episode is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `audio_codec` track builder
 - Include collections removed by the `delete_collections` library operation, the `--delete-collections` CLI option, dynamic collection sync, and `delete_collections_named` in the run-end notification total.
 - Fix `audio_language`/`subtitle_language` `plex_search` filters matching zero items whenever a library has multiple Plex-reported locale variants for the requested language (e.g. `de` + `de-DE`); the variants were being `AND` together into an impossible filter instead of `OR`. Regression from #3440.
+- Fix `episode_*` ratings from producing a critical error when Trakt did not have an episode in its database
 
 ## [v2.4.8] - 2026-08-15
 

--- a/modules/trakt.py
+++ b/modules/trakt.py
@@ -277,7 +277,7 @@ class Trakt:
 
     def get_episode_rating(self, show_id, season, episode):
         response = self._request(f"/shows/{show_id}/seasons/{season}/episodes/{episode}/ratings")
-        return response["rating"]
+        return response.get("rating") if isinstance(response, dict) else None
 
     def get_item_images(self, item_id, media_type, season=None, episode=None):
         if media_type not in ["movie", "show"]:

--- a/tests/test_trakt.py
+++ b/tests/test_trakt.py
@@ -52,6 +52,13 @@ class TestTrakt:
         assert adapter.slugs == ["my-list"]
 
 
+    def test_missing_episode_rating_returns_none(self, adapter):
+        adapter._request.return_value = []
+
+        assert adapter.get_episode_rating("tt0103359", 2, 15) is None
+        adapter._request.assert_called_once_with("/shows/tt0103359/seasons/2/episodes/15/ratings")
+
+
 class TestTraktAuthorization:
     @pytest.fixture
     def adapter(self):

--- a/tests/test_trakt.py
+++ b/tests/test_trakt.py
@@ -51,7 +51,6 @@ class TestTrakt:
         adapter._request.return_value = [{"ids": {"slug": "my-list"}}]
         assert adapter.slugs == ["my-list"]
 
-
     def test_missing_episode_rating_returns_none(self, adapter):
         adapter._request.return_value = []
 


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Prevents library operations from failing when Trakt has no matching episode for the configured season and episode number.

Trakt may return an empty list for episodes that do not exist in its selected ordering. `get_episode_rating` now treats that response as no rating (`None`), allowing the operation to continue normally.

## Related Issues [optional]

- Related Issue #3512
- Closes #3512

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [] No

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789632108&installation_model_id=431096&pr_number=3513&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3513&signature=4c211da70b342af198e8f90750b71a65c13404ac1b10268920137ac435d51d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->